### PR TITLE
Implement basic instance resource

### DIFF
--- a/examples/instance_resource/disk.tf
+++ b/examples/instance_resource/disk.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    oxide = {
+      source  = "oxidecomputer/oxide"
+      version = "0.1.0-dev"
+    }
+  }
+}
+
+provider "oxide" {
+  host = "http://127.0.0.1:12220"
+  token = "oxide-spoof-001de000-05e4-4000-8000-000000004007"
+}
+
+resource "oxide_instance" "example" {
+  organization_name = "corp"
+  project_name = "test"
+  description = "a test instance"
+  name = "myinstance"
+  host_name = "myhost"
+  memory = 512
+  ncpus = 1
+}

--- a/oxide/provider.go
+++ b/oxide/provider.go
@@ -40,7 +40,8 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"oxide_disk": diskResource(),
+			"oxide_disk":     diskResource(),
+			"oxide_instance": instanceResource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"oxide_organizations": organizationsDataSource(),

--- a/oxide/resource_disk.go
+++ b/oxide/resource_disk.go
@@ -64,7 +64,7 @@ func newDiskSchema() map[string]*schema.Schema {
 		},
 		"size": {
 			Type:        schema.TypeInt,
-			Description: "Size of the disk",
+			Description: "Size of the disk in bytes",
 			Required:    true,
 		},
 		"block_size": {

--- a/oxide/resource_instance.go
+++ b/oxide/resource_instance.go
@@ -1,0 +1,219 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	oxideSDK "github.com/oxidecomputer/oxide.go"
+)
+
+func instanceResource() *schema.Resource {
+	return &schema.Resource{
+		Description:   "",
+		Schema:        newInstanceSchema(),
+		CreateContext: createInstance,
+		ReadContext:   readInstance,
+		UpdateContext: updateInstance,
+		DeleteContext: deleteInstance,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func newInstanceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"organization_name": {
+			Type:        schema.TypeString,
+			Description: "Name of the organization",
+			Required:    true,
+		},
+		"project_name": {
+			Type:        schema.TypeString,
+			Description: "Name of the project",
+			Required:    true,
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "Name of the instance",
+			Required:    true,
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "Description for the instance",
+			Required:    true,
+		},
+		"host_name": {
+			Type:        schema.TypeString,
+			Description: "Host name of the instance",
+			Required:    true,
+		},
+		"memory": {
+			Type:        schema.TypeInt,
+			Description: "Instance memory in bytes",
+			Required:    true,
+		},
+		"ncpus": {
+			Type:        schema.TypeInt,
+			Description: "Number of CPUs in the Instance",
+			Required:    true,
+		},
+		"id": {
+			Type:        schema.TypeString,
+			Description: "Immutable instance ID",
+			Computed:    true,
+		},
+		"project_id": {
+			Type:        schema.TypeString,
+			Description: "Immutable project ID",
+			Computed:    true,
+		},
+		"run_state": {
+			Type:        schema.TypeString,
+			Description: "Immutable project ID",
+			Computed:    true,
+		},
+		"time_created": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"time_modified": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"time_run_state_updated": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func createInstance(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+	description := d.Get("description").(string)
+	name := d.Get("name").(string)
+	hostName := d.Get("host_name").(string)
+	memory := d.Get("memory").(int)
+	ncpus := d.Get("ncpus").(int)
+
+	body := oxideSDK.InstanceCreate{
+		Description: description,
+		Name:        name,
+		Hostname:    hostName,
+		Memory:      oxideSDK.ByteCount(memory),
+		NCPUs:       oxideSDK.InstanceCPUCount(ncpus),
+		// Due to a small bug in the oxide.go SDK where the request does not
+		// omit the NetworkInterfaces struct if not set, I will set the type
+		// as "none" until this feature is implemented.
+		NetworkInterfaces: oxideSDK.InstanceNetworkInterfaceAttachment{
+			Type: "none",
+		},
+	}
+
+	resp, err := client.Instances.Create(orgName, projectName, &body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+
+	return readInstance(ctx, d, meta)
+}
+
+func readInstance(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	instanceName := d.Get("name").(string)
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+
+	resp, err := client.Instances.Get(instanceName, orgName, projectName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := instanceToState(d, resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func updateInstance(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// TODO: Currently there is no endpoint to update an instance. This function will remain
+	// as readonly until such endpoint exists.
+	return readInstance(ctx, d, meta)
+}
+
+func deleteInstance(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	instanceName := d.Get("name").(string)
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+
+	_, err := client.Instances.Stop(instanceName, orgName, projectName)
+	if err != nil {
+		if is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	// Wait for instance to be stopped before attempting to destroy
+	for {
+		resp, err := client.Instances.Get(instanceName, orgName, projectName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if resp.RunState == "stopped" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err := client.Instances.Delete(instanceName, orgName, projectName); err != nil {
+		if is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func instanceToState(d *schema.ResourceData, instance *oxideSDK.Instance) error {
+	if err := d.Set("id", instance.ID); err != nil {
+		return err
+	}
+	if err := d.Set("project_id", instance.ProjectID); err != nil {
+		return err
+	}
+	if err := d.Set("run_state", instance.RunState); err != nil {
+		return err
+	}
+	if err := d.Set("time_created", instance.TimeCreated.String()); err != nil {
+		return err
+	}
+	if err := d.Set("time_modified", instance.TimeModified.String()); err != nil {
+		return err
+	}
+	if err := d.Set("time_run_state_updated", instance.TimeRunStateUpdated.String()); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a basic resource for a disk. Other features like attaching a disk will be added in a follow up PR.

Instance create output:
```console
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # oxide_instance.example will be created
  + resource "oxide_instance" "example" {
      + description            = "a test instance"
      + host_name              = "myhost"
      + id                     = (known after apply)
      + memory                 = 512
      + name                   = "myinstance"
      + ncpus                  = 1
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_instance.example: Creating...
oxide_instance.example: Creation complete after 2s [id=87858b32-de0f-4c15-931a-e848c0ae696f]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

corresponding .tfstate file
```hcl
{
  "version": 4,
  "terraform_version": "1.2.2",
  "serial": 1,
  "lineage": "280f288c-6e39-1f3a-b794-9e7fef87f64b",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "example",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "description": "a test instance",
            "host_name": "myhost",
            "id": "87858b32-de0f-4c15-931a-e848c0ae696f",
            "memory": 512,
            "name": "myinstance",
            "ncpus": 1,
            "organization_name": "corp",
            "project_id": "ae5ddd4e-30db-44bd-a8a4-c12855fd818c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-15 06:25:31.51764 +0000 UTC",
            "time_modified": "2022-06-15 06:25:31.51764 +0000 UTC",
            "time_run_state_updated": "2022-06-15 06:25:32.84903 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED"
        }
      ]
    }
  ]
}

```

Destroy instance output:
```console
$ terraform destroy
oxide_instance.example: Refreshing state... [id=87858b32-de0f-4c15-931a-e848c0ae696f]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  - destroy

Terraform will perform the following actions:

  # oxide_instance.example will be destroyed
  - resource "oxide_instance" "example" {
      - description            = "a test instance" -> null
      - host_name              = "myhost" -> null
      - id                     = "87858b32-de0f-4c15-931a-e848c0ae696f" -> null
      - memory                 = 512 -> null
      - name                   = "myinstance" -> null
      - ncpus                  = 1 -> null
      - organization_name      = "corp" -> null
      - project_id             = "ae5ddd4e-30db-44bd-a8a4-c12855fd818c" -> null
      - project_name           = "test" -> null
      - run_state              = "running" -> null
      - time_created           = "2022-06-15 06:25:31.51764 +0000 UTC" -> null
      - time_modified          = "2022-06-15 06:25:31.51764 +0000 UTC" -> null
      - time_run_state_updated = "2022-06-15 06:25:34.355632 +0000 UTC" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

oxide_instance.example: Destroying... [id=87858b32-de0f-4c15-931a-e848c0ae696f]
oxide_instance.example: Destruction complete after 2s

Destroy complete! Resources: 1 destroyed.
```

corresponding .tfstate file:
```hcl
{
  "version": 4,
  "terraform_version": "1.2.2",
  "serial": 3,
  "lineage": "280f288c-6e39-1f3a-b794-9e7fef87f64b",
  "outputs": {},
  "resources": []
}

```

Closes: https://github.com/oxidecomputer/terraform-provider-oxide-demo/issues/3