### PR TITLE
Update oxide.go to v.0.0.18

### DIFF
--- a/docs/resources/oxide_disk.md
+++ b/docs/resources/oxide_disk.md
@@ -14,7 +14,7 @@ resource "oxide_disk" "example" {
   project_name      = "test"
   description       = "a test disk"
   name              = "mydisk"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -23,7 +23,7 @@ resource "oxide_disk" "example2" {
   project_name      = "test"
   description       = "a test disk"
   name              = "mydisk2"
-  size              = 104857600
+  size              = 1073741824
   disk_source       = { global_image = "611bb17d-6883-45be-b3aa-8a186fdeafe8" }
 }
 ```

--- a/docs/resources/oxide_instance.md
+++ b/docs/resources/oxide_instance.md
@@ -17,7 +17,7 @@ resource "oxide_instance" "example" {
   description       = "a test instance"
   name              = "myinstance"
   host_name         = "<host value>"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
 }
 ```
@@ -31,7 +31,7 @@ resource "oxide_instance" "example" {
   description       = "a test instance"
   name              = "myinstance"
   host_name         = "<host value>"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
   attach_to_disks   = ["disk1", "disk2"]
 }

--- a/examples/attached_instance_resource/attached_instance.tf
+++ b/examples/attached_instance_resource/attached_instance.tf
@@ -16,7 +16,7 @@ resource "oxide_disk" "example" {
   project_name      = "test"
   description       = "a test disk"
   name              = "myattacheddisk1"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -25,7 +25,7 @@ resource "oxide_disk" "example2" {
   project_name      = "test"
   description       = "a test disk"
   name              = "myattacheddisk2"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -35,7 +35,7 @@ resource "oxide_instance" "example3" {
   description       = "a test instance"
   name              = "myinstance2"
   host_name         = "myhost"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
   attach_to_disks   = ["myattacheddisk1", "myattacheddisk2"]
 }

--- a/examples/disk_resource/disk.tf
+++ b/examples/disk_resource/disk.tf
@@ -16,7 +16,7 @@ resource "oxide_disk" "example" {
   project_name      = "test"
   description       = "a test disk"
   name              = "mydisk"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -25,6 +25,6 @@ resource "oxide_disk" "example2" {
   project_name      = "test"
   description       = "a test disk"
   name              = "mydisk2"
-  size              = 104857600
+  size              = 1073741824
   disk_source       = { global_image = "611bb17d-6883-45be-b3aa-8a186fdeafe8" }
 }

--- a/examples/instance_resource/instance.tf
+++ b/examples/instance_resource/instance.tf
@@ -17,6 +17,6 @@ resource "oxide_instance" "example" {
   description       = "a test instance"
   name              = "myinstance"
   host_name         = "myhost"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/oxidecomputer/oxide.go v0.0.17
+	github.com/oxidecomputer/oxide.go v0.0.18
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.0.17 h1:BAuPgDjaJeu1xLuSGUK+LSW98/nFqoF31jIRMTxDPrw=
-github.com/oxidecomputer/oxide.go v0.0.17/go.mod h1:8RWxUFRzdPoFsnFlBSBJr4zHyXqjDACCLjP9n/x3nVI=
+github.com/oxidecomputer/oxide.go v0.0.18 h1:NmUiauRQEOylcEHGbPbU037sKXenbEI2eJJgNE86UgA=
+github.com/oxidecomputer/oxide.go v0.0.18/go.mod h1:8RWxUFRzdPoFsnFlBSBJr4zHyXqjDACCLjP9n/x3nVI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/oxide/resource_disk_test.go
+++ b/oxide/resource_disk_test.go
@@ -34,7 +34,7 @@ resource "oxide_disk" "test" {
   project_name      = "test"
   description       = "a test disk"
   name              = "terraform-acc-mydisk"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 `
@@ -46,7 +46,7 @@ func checkResourceDisk(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "project_name", "test"),
 		resource.TestCheckResourceAttr(resourceName, "description", "a test disk"),
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-mydisk"),
-		resource.TestCheckResourceAttr(resourceName, "size", "1024"),
+		resource.TestCheckResourceAttr(resourceName, "size", "1073741824"),
 		resource.TestCheckResourceAttr(resourceName, "device_path", "/mnt/terraform-acc-mydisk"),
 		resource.TestCheckResourceAttr(resourceName, "block_size", "512"),
 		resource.TestCheckResourceAttr(resourceName, "disk_source.blank", "512"),

--- a/oxide/resource_instance_test.go
+++ b/oxide/resource_instance_test.go
@@ -40,7 +40,7 @@ resource "oxide_instance" "test" {
   description       = "a test instance"
   name              = "terraform-acc-myinstance"
   host_name         = "terraform-acc-myhost"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
 }
 `
@@ -53,7 +53,7 @@ func checkResourceInstance(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myinstance"),
 		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
-		resource.TestCheckResourceAttr(resourceName, "memory", "512"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttrSet(resourceName, "run_state"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -69,7 +69,7 @@ resource "oxide_disk" "test-instance" {
   project_name      = "test"
   description       = "a test disk"
   name              = "terraform-acc-mydisk1"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -78,7 +78,7 @@ resource "oxide_disk" "test-instance2" {
   project_name      = "test"
   description       = "a test disk"
   name              = "terraform-acc-mydisk2"
-  size              = 1024
+  size              = 1073741824
   disk_source       = { blank = 512 }
 }
 
@@ -88,7 +88,7 @@ resource "oxide_instance" "test2" {
   description       = "a test instance"
   name              = "terraform-acc-myinstance2"
   host_name         = "terraform-acc-myhost"
-  memory            = 512
+  memory            = 1073741824
   ncpus             = 1
   attach_to_disks   = ["terraform-acc-mydisk1", "terraform-acc-mydisk2"]
 }
@@ -102,7 +102,7 @@ func checkResourceInstanceDisk(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myinstance2"),
 		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
-		resource.TestCheckResourceAttr(resourceName, "memory", "512"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.0", "terraform-acc-mydisk1"),
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.1", "terraform-acc-mydisk2"),


### PR DESCRIPTION
```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccDataSourceGlobalImages
=== PAUSE TestAccDataSourceGlobalImages
=== RUN   TestAccDataSourceOrganizations
=== PAUSE TestAccDataSourceOrganizations
=== RUN   TestAccDataSourceProjects
=== PAUSE TestAccDataSourceProjects
=== RUN   TestAccResourceDisk
=== PAUSE TestAccResourceDisk
=== RUN   TestAccResourceInstance
=== PAUSE TestAccResourceInstance
=== CONT  TestAccDataSourceGlobalImages
=== CONT  TestAccResourceDisk
=== CONT  TestAccResourceInstance
=== CONT  TestAccDataSourceProjects
=== CONT  TestAccDataSourceOrganizations
--- PASS: TestAccDataSourceGlobalImages (1.71s)
--- PASS: TestAccDataSourceOrganizations (1.73s)
--- PASS: TestAccDataSourceProjects (2.00s)
--- PASS: TestAccResourceDisk (3.70s)
--- PASS: TestAccResourceInstance (9.82s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide-demo/oxide	10.309s
```