### PR TITLE
New VPC resource

### DIFF
--- a/docs/resources/oxide_vpc.md
+++ b/docs/resources/oxide_vpc.md
@@ -1,0 +1,50 @@
+---
+page_title: "oxide_vpc Resource - terraform-provider-oxide"
+---
+
+# oxide_vpc (Resource)
+
+This resource manages VPCs.
+
+## Example Usage
+
+```hcl
+resource "oxide_vpc" "example" {
+  organization_name = "staff"
+  project_name      = "test"
+  description       = "a test vpc"
+  name              = "myvpc"
+  dns_name          = "my-vpc-dns"
+}
+```
+
+## Schema
+
+### Required
+
+- `description` (String) Description for the VPC.
+- `dns_name` (String) DNS name of the VPC.
+- `name` (String) Name of the VPC.
+- `organization_name` (String) Name of the organization.
+- `project_name` (String) Name of the project.
+
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the VPC.
+- `ipv6_prefix` (String) All IPv6 subnets created from this VPC must be taken from this range, which should be a unique local address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix.
+- `project_id` (String) Unique, immutable, system-controlled identifier of the project.
+- `system_router_id` (String) ID for the system router where subnet default routes are registered.
+- `time_created` (String) Timestamp of when this VPC was created.
+- `time_modified` (String) Timestamp of when this VPC was last modified.
+
+<a id="nestedblock--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `default` (String)

--- a/examples/vpc_resource/vpc.tf
+++ b/examples/vpc_resource/vpc.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    oxide = {
+      source  = "oxidecomputer/oxide"
+      version = "0.1.0-dev"
+    }
+  }
+}
+
+provider "oxide" {}
+
+resource "oxide_vpc" "example" {
+  organization_name = "corp"
+  project_name      = "test"
+  description       = "a test vpc"
+  name              = "myvpc"
+  dns_name          = "my-vpc-dns"
+}

--- a/oxide/provider.go
+++ b/oxide/provider.go
@@ -42,6 +42,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"oxide_disk":     diskResource(),
 			"oxide_instance": instanceResource(),
+			"oxide_vpc":      vpcResource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"oxide_organizations": organizationsDataSource(),

--- a/oxide/resource_vpc.go
+++ b/oxide/resource_vpc.go
@@ -1,0 +1,214 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	oxideSDK "github.com/oxidecomputer/oxide.go"
+)
+
+func vpcResource() *schema.Resource {
+	return &schema.Resource{
+		Description:   "",
+		Schema:        newVPCSchema(),
+		CreateContext: createVPC,
+		ReadContext:   readVPC,
+		UpdateContext: updateVPC,
+		DeleteContext: deleteVPC,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(5 * time.Minute),
+		},
+	}
+}
+
+func newVPCSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"organization_name": {
+			Type:        schema.TypeString,
+			Description: "Name of the organization.",
+			Required:    true,
+		},
+		"project_name": {
+			Type:        schema.TypeString,
+			Description: "Name of the project.",
+			Required:    true,
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "Name of the VPC.",
+			Required:    true,
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "Description for the VPC.",
+			Required:    true,
+		},
+		"dns_name": {
+			Type:        schema.TypeString,
+			Description: "DNS name of the VPC.",
+			Required:    true,
+		},
+		"ipv6_prefix": {
+			Type:        schema.TypeString,
+			Description: "All IPv6 subnets created from this VPC must be taken from this range, which should be a unique local address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix.",
+			// TODO: For demo purposes this range will be generated only. When we move forward from demo stage
+			// this value should be optional/computed
+			Computed: true,
+		},
+		"id": {
+			Type:        schema.TypeString,
+			Description: "Unique, immutable, system-controlled identifier.",
+			Computed:    true,
+		},
+		"project_id": {
+			Type:        schema.TypeString,
+			Description: "Unique, immutable, system-controlled identifier.",
+			Computed:    true,
+		},
+		"system_router_id": {
+			Type:        schema.TypeString,
+			Description: "SystemRouterID is the ID for the system router where subnet default routes are registered.",
+			Computed:    true,
+		},
+		"time_created": {
+			Type:        schema.TypeString,
+			Description: "Timestamp of when this VPC was created.",
+			Computed:    true,
+		},
+		"time_modified": {
+			Type:        schema.TypeString,
+			Description: "Timestamp of when this VPC was last modified.",
+			Computed:    true,
+		},
+	}
+}
+
+func createVPC(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+	description := d.Get("description").(string)
+	name := d.Get("name").(string)
+	dnsName := d.Get("dns_name").(string)
+
+	body := oxideSDK.VPCCreate{
+		Description: description,
+		Name:        name,
+		DnsName:     dnsName,
+	}
+
+	resp, err := client.VPCs.Create(orgName, projectName, &body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+
+	return readVPC(ctx, d, meta)
+}
+
+func readVPC(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	vpcName := d.Get("name").(string)
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+
+	resp, err := client.VPCs.Get(orgName, projectName, vpcName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := vpcToState(d, resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func updateVPC(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+	description := d.Get("description").(string)
+	name := d.Get("name").(string)
+	dnsName := d.Get("dns_name").(string)
+
+	body := oxideSDK.VPCUpdate{
+		Description: description,
+		// We cannot change the name of the VPC as it is used as an identifier for
+		// the update in the Put method. Changing it would make it impossible for
+		// terraform to know which VPC to update.
+		// Name:        name,
+		DnsName: dnsName,
+	}
+
+	resp, err := client.VPCs.Put(orgName, projectName, name, &body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+
+	return readVPC(ctx, d, meta)
+}
+
+func deleteVPC(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	vpcName := d.Get("name").(string)
+	orgName := d.Get("organization_name").(string)
+	projectName := d.Get("project_name").(string)
+
+	if err := client.VPCs.Delete(orgName, projectName, vpcName); err != nil {
+		if is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func vpcToState(d *schema.ResourceData, vpc *oxideSDK.VPC) error {
+	if err := d.Set("description", vpc.Description); err != nil {
+		return err
+	}
+	if err := d.Set("dns_name", vpc.DnsName); err != nil {
+		return err
+	}
+	if err := d.Set("id", vpc.ID); err != nil {
+		return err
+	}
+	if err := d.Set("ipv6_prefix", vpc.IPv6Prefix); err != nil {
+		return err
+	}
+	if err := d.Set("name", vpc.Name); err != nil {
+		return err
+	}
+	if err := d.Set("project_id", vpc.ProjectID); err != nil {
+		return err
+	}
+	if err := d.Set("system_router_id", vpc.SystemRouterID); err != nil {
+		return err
+	}
+	if err := d.Set("time_created", vpc.TimeCreated.String()); err != nil {
+		return err
+	}
+	if err := d.Set("time_modified", vpc.TimeModified.String()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/oxide/resource_vpc_test.go
+++ b/oxide/resource_vpc_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceVPC(t *testing.T) {
+	resourceName := "oxide_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceVPCConfig,
+				Check:  checkResourceVPC(resourceName),
+			},
+		},
+	})
+}
+
+var testResourceVPCConfig = `
+resource "oxide_vpc" "test" {
+	organization_name = "corp"
+	project_name      = "test"
+	description       = "a test vpc"
+	name              = "terraform-acc-myvpc"
+	dns_name          = "my-vpc-dns"
+  }
+`
+
+func checkResourceVPC(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "organization_name", "corp"),
+		resource.TestCheckResourceAttr(resourceName, "project_name", "test"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test vpc"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myvpc"),
+		resource.TestCheckResourceAttr(resourceName, "dns_name", "my-vpc-dns"),
+		resource.TestCheckResourceAttrSet(resourceName, "ipv6_prefix"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "system_router_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccVPCDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_vpc" {
+			continue
+		}
+
+		res, err := client.VPCs.Get("corp", "test", "terraform-acc-myvpc")
+		if err != nil && is404(err) {
+			continue
+		}
+
+		return fmt.Errorf("vpc (%v) still exists", &res.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a resource for a VPC:

```console
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_vpc.example will be created
  + resource "oxide_vpc" "example" {
      + description       = "a test vpc"
      + dns_name          = "my-vpc-dns"
      + id                = (known after apply)
      + ipv6_prefix       = (known after apply)
      + name              = "myvpc"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + system_router_id  = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_vpc.example: Creating...
oxide_vpc.example: Creation complete after 0s [id=4dad4c7d-b239-4917-98e5-5f57a8320b88]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

With its corresponding .tfstate file

```hcl
{
  "version": 4,
  "terraform_version": "1.2.2",
  "serial": 3,
  "lineage": "8ead9279-25cc-084d-35de-a122fd13b3b7",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "oxide_vpc",
      "name": "example",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "description": "a test vpc",
            "dns_name": "my-vpc-dns",
            "id": "4dad4c7d-b239-4917-98e5-5f57a8320b88",
            "ipv6_prefix": "fd78:65a9:fe8e::/48",
            "name": "myvpc",
            "organization_name": "corp",
            "project_id": "70ab6412-3355-4b85-bc6f-0df425030ba6",
            "project_name": "test",
            "system_router_id": "40f07fbe-6fa9-4ce7-9dec-b7bd5ed2a35f",
            "time_created": "2022-06-22 04:07:07.930355 +0000 UTC",
            "time_modified": "2022-06-22 04:07:07.930355 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED"
        }
      ]
    }
  ]
}
```

Acceptance tests:

```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccDataSourceGlobalImages
=== PAUSE TestAccDataSourceGlobalImages
=== RUN   TestAccDataSourceOrganizations
=== PAUSE TestAccDataSourceOrganizations
=== RUN   TestAccDataSourceProjects
=== PAUSE TestAccDataSourceProjects
=== RUN   TestAccResourceDisk
=== PAUSE TestAccResourceDisk
=== RUN   TestAccResourceInstance
=== PAUSE TestAccResourceInstance
=== RUN   TestAccResourceVPC
=== PAUSE TestAccResourceVPC
=== CONT  TestAccDataSourceGlobalImages
=== CONT  TestAccResourceDisk
=== CONT  TestAccDataSourceProjects
=== CONT  TestAccResourceVPC
=== CONT  TestAccDataSourceOrganizations
=== CONT  TestAccResourceInstance
--- PASS: TestAccDataSourceGlobalImages (1.66s)
--- PASS: TestAccDataSourceOrganizations (1.70s)
--- PASS: TestAccDataSourceProjects (1.93s)
--- PASS: TestAccResourceVPC (2.65s)
--- PASS: TestAccResourceDisk (3.99s)
--- PASS: TestAccResourceInstance (10.08s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide-demo/oxide	10.667s
```

Closes: https://github.com/oxidecomputer/terraform-provider-oxide-demo/issues/18