### PR TITLE
Set all fields on read to avoid drift

### DIFF
--- a/oxide/resource_disk.go
+++ b/oxide/resource_disk.go
@@ -216,6 +216,12 @@ func deleteDisk(_ context.Context, d *schema.ResourceData, meta interface{}) dia
 }
 
 func diskToState(d *schema.ResourceData, disk *oxideSDK.Disk) error {
+	if err := d.Set("name", disk.Name); err != nil {
+		return err
+	}
+	if err := d.Set("description", disk.Description); err != nil {
+		return err
+	}
 	if err := d.Set("block_size", disk.BlockSize); err != nil {
 		return err
 	}

--- a/oxide/resource_instance.go
+++ b/oxide/resource_instance.go
@@ -260,6 +260,21 @@ func deleteInstance(_ context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func instanceToState(d *schema.ResourceData, instance *oxideSDK.Instance) error {
+	if err := d.Set("name", instance.Name); err != nil {
+		return err
+	}
+	if err := d.Set("description", instance.Description); err != nil {
+		return err
+	}
+	if err := d.Set("host_name", instance.Hostname); err != nil {
+		return err
+	}
+	if err := d.Set("memory", instance.Memory); err != nil {
+		return err
+	}
+	if err := d.Set("ncpus", instance.NCPUs); err != nil {
+		return err
+	}
 	if err := d.Set("id", instance.ID); err != nil {
 		return err
 	}


### PR DESCRIPTION
Test results:

```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccDataSourceGlobalImages
=== PAUSE TestAccDataSourceGlobalImages
=== RUN   TestAccDataSourceOrganizations
=== PAUSE TestAccDataSourceOrganizations
=== RUN   TestAccDataSourceProjects
=== PAUSE TestAccDataSourceProjects
=== RUN   TestAccResourceDisk
=== PAUSE TestAccResourceDisk
=== RUN   TestAccResourceInstance
=== PAUSE TestAccResourceInstance
=== RUN   TestAccResourceVPC
=== PAUSE TestAccResourceVPC
=== CONT  TestAccDataSourceGlobalImages
=== CONT  TestAccResourceDisk
=== CONT  TestAccResourceVPC
=== CONT  TestAccResourceInstance
=== CONT  TestAccDataSourceProjects
=== CONT  TestAccDataSourceOrganizations
--- PASS: TestAccDataSourceGlobalImages (2.02s)
--- PASS: TestAccDataSourceOrganizations (2.05s)
--- PASS: TestAccDataSourceProjects (2.31s)
--- PASS: TestAccResourceVPC (2.79s)
--- PASS: TestAccResourceDisk (4.22s)
--- PASS: TestAccResourceInstance (14.86s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide-demo/oxide	15.425s
```