### PR TITLE
update to v0.0.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/oxidecomputer/oxide.go v0.0.18
+	github.com/oxidecomputer/oxide.go v0.0.19
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.0.18 h1:NmUiauRQEOylcEHGbPbU037sKXenbEI2eJJgNE86UgA=
-github.com/oxidecomputer/oxide.go v0.0.18/go.mod h1:8RWxUFRzdPoFsnFlBSBJr4zHyXqjDACCLjP9n/x3nVI=
+github.com/oxidecomputer/oxide.go v0.0.19 h1:xQhUUptblCx62KQPaQqxRxB2SkKRoAXW8EvJPJxnW34=
+github.com/oxidecomputer/oxide.go v0.0.19/go.mod h1:8RWxUFRzdPoFsnFlBSBJr4zHyXqjDACCLjP9n/x3nVI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccDataSourceGlobalImages
=== PAUSE TestAccDataSourceGlobalImages
=== RUN   TestAccDataSourceOrganizations
=== PAUSE TestAccDataSourceOrganizations
=== RUN   TestAccDataSourceProjects
=== PAUSE TestAccDataSourceProjects
=== RUN   TestAccResourceDisk
=== PAUSE TestAccResourceDisk
=== RUN   TestAccResourceInstance
=== PAUSE TestAccResourceInstance
=== RUN   TestAccResourceVPC
=== PAUSE TestAccResourceVPC
=== CONT  TestAccDataSourceGlobalImages
=== CONT  TestAccResourceDisk
=== CONT  TestAccDataSourceProjects
=== CONT  TestAccDataSourceOrganizations
=== CONT  TestAccResourceVPC
=== CONT  TestAccResourceInstance
--- PASS: TestAccDataSourceGlobalImages (1.67s)
--- PASS: TestAccDataSourceOrganizations (1.80s)
--- PASS: TestAccDataSourceProjects (2.20s)
--- PASS: TestAccResourceVPC (2.89s)
--- PASS: TestAccResourceDisk (4.48s)
--- PASS: TestAccResourceInstance (16.06s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide-demo/oxide	16.296s
```