### PR TITLE
Create smaller disks for demo

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -7,7 +7,7 @@ This Terraform configuration file provisions 5 instances as per the demo script:
 This configuration file does the following:
 
 1. Retrieves data about the organization, project and global image. This configuration file assumes there will only be one of each and those are the ones we'll be using for the demo.
-2. Using the data retrieved from the previous step, 5 disks are created; 3 100GiB disks for the web instances and 2 500GiB disks for the DB instances.
-3. Finally, using data from the first and second steps, the 5 instances are created using the default VPC and subnet; 3 web instances with 2 CPUs and 8GiB of memory, and 2 DB instances with 8 CPUs and 32GiB of memory.
+2. Using the data retrieved from the previous step, 5 disks are created; 3 10GiB disks for the web instances and 2 20GiB disks for the DB instances.
+3. Finally, using data from the first and second steps, the 5 instances are created using the default VPC and subnet; 3 web instances with 2 CPUs and 1GiB of memory, and 2 DB instances with 4 CPUs and 2GiB of memory.
 
 To try out this configuration file follow the [instructions](https://github.com/oxidecomputer/terraform-provider-oxide-demo/#using-the-provider) from the README.

--- a/examples/demo/demo.tf
+++ b/examples/demo/demo.tf
@@ -24,7 +24,7 @@ resource "oxide_disk" "web_disk_1" {
   project_name      = data.oxide_projects.project_list.projects.0.name
   description       = "Disk for a web instance"
   name              = "web-disk-1"
-  size              = 107374182400
+  size              = 10737418240
   disk_source       = { global_image = data.oxide_global_images.image_list.global_images.0.id }
 }
 
@@ -33,7 +33,7 @@ resource "oxide_disk" "web_disk_2" {
   project_name      = data.oxide_projects.project_list.projects.0.name
   description       = "Disk for a web instance"
   name              = "web-disk-2"
-  size              = 107374182400
+  size              = 10737418240
   disk_source       = { global_image = data.oxide_global_images.image_list.global_images.0.id }
 }
 
@@ -42,7 +42,7 @@ resource "oxide_disk" "web_disk_3" {
   project_name      = data.oxide_projects.project_list.projects.0.name
   description       = "Disk for a web instance"
   name              = "web-disk-3"
-  size              = 107374182400
+  size              = 10737418240
   disk_source       = { global_image = data.oxide_global_images.image_list.global_images.0.id }
 }
 
@@ -51,7 +51,7 @@ resource "oxide_disk" "db_disk_1" {
   project_name      = data.oxide_projects.project_list.projects.0.name
   description       = "Disk for a DB instance"
   name              = "db-disk-1"
-  size              = 536870912000
+  size              = 21474836480
   disk_source       = { global_image = data.oxide_global_images.image_list.global_images.0.id }
 }
 
@@ -60,7 +60,7 @@ resource "oxide_disk" "db_disk_2" {
   project_name      = data.oxide_projects.project_list.projects.0.name
   description       = "Disk for a DB instance"
   name              = "db-disk-2"
-  size              = 536870912000
+  size              = 21474836480
   disk_source       = { global_image = data.oxide_global_images.image_list.global_images.0.id }
 }
 
@@ -70,7 +70,7 @@ resource "oxide_instance" "web_instance_1" {
   description       = "Web instance"
   name              = "web-instance-1"
   host_name         = "web-instance-1"
-  memory            = 8589934592
+  memory            = 1073741824
   ncpus             = 2
   attach_to_disks   = [oxide_disk.web_disk_1.name]
   network_interface {
@@ -87,7 +87,7 @@ resource "oxide_instance" "web_instance_2" {
   description       = "Web instance"
   name              = "web-instance-2"
   host_name         = "web-instance-2"
-  memory            = 8589934592
+  memory            = 1073741824
   ncpus             = 2
   attach_to_disks   = [oxide_disk.web_disk_2.name]
   network_interface {
@@ -104,7 +104,7 @@ resource "oxide_instance" "web_instance_3" {
   description       = "Web instance"
   name              = "web-instance-3"
   host_name         = "web-instance-3"
-  memory            = 8589934592
+  memory            = 1073741824
   ncpus             = 2
   attach_to_disks   = [oxide_disk.web_disk_3.name]
   network_interface {
@@ -121,8 +121,8 @@ resource "oxide_instance" "db_instance_1" {
   description       = "Web instance"
   name              = "db-instance-1"
   host_name         = "db-instance-1"
-  memory            = 34359738368
-  ncpus             = 8
+  memory            = 2147483648
+  ncpus             = 4
   attach_to_disks   = [oxide_disk.db_disk_1.name]
   network_interface {
     description = "Network interface for DB instance"
@@ -138,8 +138,8 @@ resource "oxide_instance" "db_instance_2" {
   description       = "Web instance"
   name              = "db-instance-2"
   host_name         = "db-instance-2"
-  memory            = 34359738368
-  ncpus             = 8
+  memory            = 2147483648
+  ncpus             = 4
   attach_to_disks   = [oxide_disk.db_disk_2.name]
   network_interface {
     description = "Network interface for DB instance"


### PR DESCRIPTION
This commit reduces the disk size and memory of the demo tf config file. It will now use:

- 3 10GiB disks for the web instances and 2 20GiB disks for the DB instances.
- 3 web instances with 2 CPUs and 1GiB of memory, and 2 DB instances with 4 CPUs and 2GiB of memory.

```console
$ terraform apply
data.oxide_organizations.org_list: Reading...
data.oxide_global_images.image_list: Reading...
data.oxide_global_images.image_list: Read complete after 0s [id=1527188288]
data.oxide_organizations.org_list: Read complete after 0s [id=3840547326]
data.oxide_projects.project_list: Reading...
data.oxide_projects.project_list: Read complete after 0s [id=3189205250]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_disk.db_disk_1 will be created
  + resource "oxide_disk" "db_disk_1" {
      + block_size        = (known after apply)
      + description       = "Disk for a DB instance"
      + device_path       = (known after apply)
      + disk_source       = {
          + "global_image" = "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
        }
      + id                = (known after apply)
      + image_id          = (known after apply)
      + name              = "db-disk-1"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + size              = 21474836480
      + snapshot_id       = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

  # oxide_disk.db_disk_2 will be created
  + resource "oxide_disk" "db_disk_2" {
      + block_size        = (known after apply)
      + description       = "Disk for a DB instance"
      + device_path       = (known after apply)
      + disk_source       = {
          + "global_image" = "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
        }
      + id                = (known after apply)
      + image_id          = (known after apply)
      + name              = "db-disk-2"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + size              = 21474836480
      + snapshot_id       = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

  # oxide_disk.web_disk_1 will be created
  + resource "oxide_disk" "web_disk_1" {
      + block_size        = (known after apply)
      + description       = "Disk for a web instance"
      + device_path       = (known after apply)
      + disk_source       = {
          + "global_image" = "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
        }
      + id                = (known after apply)
      + image_id          = (known after apply)
      + name              = "web-disk-1"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + size              = 10737418240
      + snapshot_id       = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

  # oxide_disk.web_disk_2 will be created
  + resource "oxide_disk" "web_disk_2" {
      + block_size        = (known after apply)
      + description       = "Disk for a web instance"
      + device_path       = (known after apply)
      + disk_source       = {
          + "global_image" = "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
        }
      + id                = (known after apply)
      + image_id          = (known after apply)
      + name              = "web-disk-2"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + size              = 10737418240
      + snapshot_id       = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

  # oxide_disk.web_disk_3 will be created
  + resource "oxide_disk" "web_disk_3" {
      + block_size        = (known after apply)
      + description       = "Disk for a web instance"
      + device_path       = (known after apply)
      + disk_source       = {
          + "global_image" = "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
        }
      + id                = (known after apply)
      + image_id          = (known after apply)
      + name              = "web-disk-3"
      + organization_name = "corp"
      + project_id        = (known after apply)
      + project_name      = "test"
      + size              = 10737418240
      + snapshot_id       = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

  # oxide_instance.db_instance_1 will be created
  + resource "oxide_instance" "db_instance_1" {
      + attach_to_disks        = [
          + "db-disk-1",
        ]
      + description            = "Web instance"
      + host_name              = "db-instance-1"
      + id                     = (known after apply)
      + memory                 = 2147483648
      + name                   = "db-instance-1"
      + ncpus                  = 4
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)

      + network_interface {
          + description = "Network interface for DB instance"
          + ip          = (known after apply)
          + name        = "db-interface-1"
          + subnet_id   = (known after apply)
          + subnet_name = "default"
          + vpc_id      = (known after apply)
          + vpc_name    = "default"
        }
    }

  # oxide_instance.db_instance_2 will be created
  + resource "oxide_instance" "db_instance_2" {
      + attach_to_disks        = [
          + "db-disk-2",
        ]
      + description            = "Web instance"
      + host_name              = "db-instance-2"
      + id                     = (known after apply)
      + memory                 = 2147483648
      + name                   = "db-instance-2"
      + ncpus                  = 4
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)

      + network_interface {
          + description = "Network interface for DB instance"
          + ip          = (known after apply)
          + name        = "db-interface-2"
          + subnet_id   = (known after apply)
          + subnet_name = "default"
          + vpc_id      = (known after apply)
          + vpc_name    = "default"
        }
    }

  # oxide_instance.web_instance_1 will be created
  + resource "oxide_instance" "web_instance_1" {
      + attach_to_disks        = [
          + "web-disk-1",
        ]
      + description            = "Web instance"
      + host_name              = "web-instance-1"
      + id                     = (known after apply)
      + memory                 = 1073741824
      + name                   = "web-instance-1"
      + ncpus                  = 2
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)

      + network_interface {
          + description = "Network interface for web instance"
          + ip          = (known after apply)
          + name        = "web-interface-1"
          + subnet_id   = (known after apply)
          + subnet_name = "default"
          + vpc_id      = (known after apply)
          + vpc_name    = "default"
        }
    }

  # oxide_instance.web_instance_2 will be created
  + resource "oxide_instance" "web_instance_2" {
      + attach_to_disks        = [
          + "web-disk-2",
        ]
      + description            = "Web instance"
      + host_name              = "web-instance-2"
      + id                     = (known after apply)
      + memory                 = 1073741824
      + name                   = "web-instance-2"
      + ncpus                  = 2
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)

      + network_interface {
          + description = "Network interface for web instance"
          + ip          = (known after apply)
          + name        = "web-interface-2"
          + subnet_id   = (known after apply)
          + subnet_name = "default"
          + vpc_id      = (known after apply)
          + vpc_name    = "default"
        }
    }

  # oxide_instance.web_instance_3 will be created
  + resource "oxide_instance" "web_instance_3" {
      + attach_to_disks        = [
          + "web-disk-3",
        ]
      + description            = "Web instance"
      + host_name              = "web-instance-3"
      + id                     = (known after apply)
      + memory                 = 1073741824
      + name                   = "web-instance-3"
      + ncpus                  = 2
      + organization_name      = "corp"
      + project_id             = (known after apply)
      + project_name           = "test"
      + run_state              = (known after apply)
      + time_created           = (known after apply)
      + time_modified          = (known after apply)
      + time_run_state_updated = (known after apply)

      + network_interface {
          + description = "Network interface for web instance"
          + ip          = (known after apply)
          + name        = "web-interface-3"
          + subnet_id   = (known after apply)
          + subnet_name = "default"
          + vpc_id      = (known after apply)
          + vpc_name    = "default"
        }
    }

Plan: 10 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_disk.web_disk_3: Creating...
oxide_disk.web_disk_1: Creating...
oxide_disk.db_disk_1: Creating...
oxide_disk.db_disk_2: Creating...
oxide_disk.web_disk_2: Creating...
oxide_disk.db_disk_1: Creation complete after 2s [id=1e3fb1b1-b9af-4254-830a-5b46534ffdd8]
oxide_instance.db_instance_1: Creating...
oxide_disk.db_disk_2: Creation complete after 2s [id=344d8ee1-db38-4739-97c2-1a7fee7a695c]
oxide_instance.db_instance_2: Creating...
oxide_disk.web_disk_1: Creation complete after 2s [id=ff7f662e-e53f-48f8-8988-87e529d6f376]
oxide_disk.web_disk_2: Creation complete after 2s [id=9f9a6267-c628-42c2-b278-f163bf432efb]
oxide_instance.web_instance_1: Creating...
oxide_disk.web_disk_3: Creation complete after 2s [id=e867d0c1-7c6b-497d-8d6e-3d9aac723ad7]
oxide_instance.web_instance_3: Creating...
oxide_instance.web_instance_2: Creating...
oxide_instance.db_instance_1: Creation complete after 4s [id=6ea11ccf-dcd7-4f5a-8162-52bcc30623f2]
oxide_instance.db_instance_2: Creation complete after 4s [id=26fc29c3-ecc9-49af-8ee7-a1e69a4591a9]
oxide_instance.web_instance_1: Creation complete after 4s [id=adc53dcb-4198-425a-8189-53e036bd9eee]
oxide_instance.web_instance_3: Creation complete after 4s [id=9d305226-3eda-407a-9adc-c8b19bbdbe43]
oxide_instance.web_instance_2: Creation complete after 4s [id=50df19db-2cb8-4826-b6e3-be7a2381322a]

Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
```

Corresponding tfstate file

```hcl
{
  "version": 4,
  "terraform_version": "1.2.2",
  "serial": 11,
  "lineage": "77592ffa-cade-0ade-091e-e9664453f91d",
  "outputs": {},
  "resources": [
    {
      "mode": "data",
      "type": "oxide_global_images",
      "name": "image_list",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "global_images": [
              {
                "block_size": 512,
                "description": "boot from propolis zone blob!",
                "digest": {},
                "distribution": "alpine",
                "id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
                "name": "alpine",
                "size": 104857600,
                "time_created": "2022-06-28 07:23:16.70366 +0000 UTC",
                "time_modified": "2022-06-28 07:23:16.70366 +0000 UTC",
                "url": "",
                "version": "propolis-blob"
              }
            ],
            "id": "1527188288",
            "timeouts": null
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "data",
      "type": "oxide_organizations",
      "name": "org_list",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "3840547326",
            "organizations": [
              {
                "description": "sdfg",
                "id": "9d0fe63e-0871-4e9b-bc22-c8740e964dad",
                "name": "corp",
                "time_created": "2022-06-30 02:15:15.978327 +0000 UTC",
                "time_modified": "2022-06-30 02:15:15.978327 +0000 UTC"
              }
            ],
            "timeouts": null
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "data",
      "type": "oxide_projects",
      "name": "project_list",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "3189205250",
            "organization_name": "corp",
            "projects": [
              {
                "description": "sdfhgdf",
                "id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
                "name": "test",
                "organization_id": "9d0fe63e-0871-4e9b-bc22-c8740e964dad",
                "time_created": "2022-06-30 02:15:38.643754 +0000 UTC",
                "time_modified": "2022-06-30 02:15:38.643754 +0000 UTC"
              }
            ],
            "timeouts": null
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_disk",
      "name": "db_disk_1",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "Disk for a DB instance",
            "device_path": "/mnt/db-disk-1",
            "disk_source": {
              "global_image": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
            },
            "id": "1e3fb1b1-b9af-4254-830a-5b46534ffdd8",
            "image_id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
            "name": "db-disk-1",
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "size": 21474836480,
            "snapshot_id": "",
            "state": [
              {
                "instance": "",
                "state": "detached"
              }
            ],
            "time_created": "2022-06-30 02:16:53.497742 +0000 UTC",
            "time_modified": "2022-06-30 02:16:53.497742 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_disk",
      "name": "db_disk_2",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "Disk for a DB instance",
            "device_path": "/mnt/db-disk-2",
            "disk_source": {
              "global_image": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
            },
            "id": "344d8ee1-db38-4739-97c2-1a7fee7a695c",
            "image_id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
            "name": "db-disk-2",
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "size": 21474836480,
            "snapshot_id": "",
            "state": [
              {
                "instance": "",
                "state": "detached"
              }
            ],
            "time_created": "2022-06-30 02:16:53.511439 +0000 UTC",
            "time_modified": "2022-06-30 02:16:53.511439 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_disk",
      "name": "web_disk_1",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "Disk for a web instance",
            "device_path": "/mnt/web-disk-1",
            "disk_source": {
              "global_image": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
            },
            "id": "ff7f662e-e53f-48f8-8988-87e529d6f376",
            "image_id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
            "name": "web-disk-1",
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "size": 10737418240,
            "snapshot_id": "",
            "state": [
              {
                "instance": "",
                "state": "detached"
              }
            ],
            "time_created": "2022-06-30 02:16:53.511103 +0000 UTC",
            "time_modified": "2022-06-30 02:16:53.511103 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_disk",
      "name": "web_disk_2",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "Disk for a web instance",
            "device_path": "/mnt/web-disk-2",
            "disk_source": {
              "global_image": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
            },
            "id": "9f9a6267-c628-42c2-b278-f163bf432efb",
            "image_id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
            "name": "web-disk-2",
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "size": 10737418240,
            "snapshot_id": "",
            "state": [
              {
                "instance": "",
                "state": "detached"
              }
            ],
            "time_created": "2022-06-30 02:16:53.541376 +0000 UTC",
            "time_modified": "2022-06-30 02:16:53.541376 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_disk",
      "name": "web_disk_3",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "Disk for a web instance",
            "device_path": "/mnt/web-disk-3",
            "disk_source": {
              "global_image": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f"
            },
            "id": "e867d0c1-7c6b-497d-8d6e-3d9aac723ad7",
            "image_id": "85b8a5cd-c496-4c2b-a17b-a3e745e5342f",
            "name": "web-disk-3",
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "size": 10737418240,
            "snapshot_id": "",
            "state": [
              {
                "instance": "",
                "state": "detached"
              }
            ],
            "time_created": "2022-06-30 02:16:53.514172 +0000 UTC",
            "time_modified": "2022-06-30 02:16:53.514172 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "db_instance_1",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_to_disks": [
              "db-disk-1"
            ],
            "description": "Web instance",
            "host_name": "db-instance-1",
            "id": "6ea11ccf-dcd7-4f5a-8162-52bcc30623f2",
            "memory": 2147483648,
            "name": "db-instance-1",
            "ncpus": 4,
            "network_interface": [
              {
                "description": "Network interface for DB instance",
                "ip": "172.30.0.6",
                "name": "db-interface-1",
                "subnet_id": "cda21951-20af-42e3-8975-0118d175eb18",
                "subnet_name": "",
                "vpc_id": "6e71fce5-5cc9-47f0-99f1-1316e1cfcc5d",
                "vpc_name": ""
              }
            ],
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-30 02:16:55.429828 +0000 UTC",
            "time_modified": "2022-06-30 02:16:55.429828 +0000 UTC",
            "time_run_state_updated": "2022-06-30 02:16:58.220056 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list",
            "oxide_disk.db_disk_1"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "db_instance_2",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_to_disks": [
              "db-disk-2"
            ],
            "description": "Web instance",
            "host_name": "db-instance-2",
            "id": "26fc29c3-ecc9-49af-8ee7-a1e69a4591a9",
            "memory": 2147483648,
            "name": "db-instance-2",
            "ncpus": 4,
            "network_interface": [
              {
                "description": "Network interface for DB instance",
                "ip": "172.30.0.7",
                "name": "db-interface-2",
                "subnet_id": "cda21951-20af-42e3-8975-0118d175eb18",
                "subnet_name": "",
                "vpc_id": "6e71fce5-5cc9-47f0-99f1-1316e1cfcc5d",
                "vpc_name": ""
              }
            ],
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-30 02:16:55.557147 +0000 UTC",
            "time_modified": "2022-06-30 02:16:55.557147 +0000 UTC",
            "time_run_state_updated": "2022-06-30 02:16:58.335604 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list",
            "oxide_disk.db_disk_2"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "web_instance_1",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_to_disks": [
              "web-disk-1"
            ],
            "description": "Web instance",
            "host_name": "web-instance-1",
            "id": "adc53dcb-4198-425a-8189-53e036bd9eee",
            "memory": 1073741824,
            "name": "web-instance-1",
            "ncpus": 2,
            "network_interface": [
              {
                "description": "Network interface for web instance",
                "ip": "172.30.0.8",
                "name": "web-interface-1",
                "subnet_id": "cda21951-20af-42e3-8975-0118d175eb18",
                "subnet_name": "",
                "vpc_id": "6e71fce5-5cc9-47f0-99f1-1316e1cfcc5d",
                "vpc_name": ""
              }
            ],
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-30 02:16:55.702039 +0000 UTC",
            "time_modified": "2022-06-30 02:16:55.702039 +0000 UTC",
            "time_run_state_updated": "2022-06-30 02:16:58.450879 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list",
            "oxide_disk.web_disk_1"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "web_instance_2",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_to_disks": [
              "web-disk-2"
            ],
            "description": "Web instance",
            "host_name": "web-instance-2",
            "id": "50df19db-2cb8-4826-b6e3-be7a2381322a",
            "memory": 1073741824,
            "name": "web-instance-2",
            "ncpus": 2,
            "network_interface": [
              {
                "description": "Network interface for web instance",
                "ip": "172.30.0.10",
                "name": "web-interface-2",
                "subnet_id": "cda21951-20af-42e3-8975-0118d175eb18",
                "subnet_name": "",
                "vpc_id": "6e71fce5-5cc9-47f0-99f1-1316e1cfcc5d",
                "vpc_name": ""
              }
            ],
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-30 02:16:55.828857 +0000 UTC",
            "time_modified": "2022-06-30 02:16:55.828857 +0000 UTC",
            "time_run_state_updated": "2022-06-30 02:16:58.550409 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list",
            "oxide_disk.web_disk_2"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_instance",
      "name": "web_instance_3",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_to_disks": [
              "web-disk-3"
            ],
            "description": "Web instance",
            "host_name": "web-instance-3",
            "id": "9d305226-3eda-407a-9adc-c8b19bbdbe43",
            "memory": 1073741824,
            "name": "web-instance-3",
            "ncpus": 2,
            "network_interface": [
              {
                "description": "Network interface for web instance",
                "ip": "172.30.0.9",
                "name": "web-interface-3",
                "subnet_id": "cda21951-20af-42e3-8975-0118d175eb18",
                "subnet_name": "",
                "vpc_id": "6e71fce5-5cc9-47f0-99f1-1316e1cfcc5d",
                "vpc_name": ""
              }
            ],
            "organization_name": "corp",
            "project_id": "557201d2-bd86-4ce2-ae32-e55b842eae5c",
            "project_name": "test",
            "run_state": "starting",
            "time_created": "2022-06-30 02:16:55.737955 +0000 UTC",
            "time_modified": "2022-06-30 02:16:55.737955 +0000 UTC",
            "time_run_state_updated": "2022-06-30 02:16:58.518031 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "data.oxide_global_images.image_list",
            "data.oxide_organizations.org_list",
            "data.oxide_projects.project_list",
            "oxide_disk.web_disk_3"
          ]
        }
      ]
    }
  ]
}

```