### PR TITLE
Improve handling of updates

### DIFF
--- a/docs/resources/oxide_vpc.md
+++ b/docs/resources/oxide_vpc.md
@@ -15,6 +15,7 @@ resource "oxide_vpc" "example" {
   description       = "a test vpc"
   name              = "myvpc"
   dns_name          = "my-vpc-dns"
+  ipv6_prefix       = "fd1e:4947:d4a1::/48"
 }
 ```
 
@@ -30,12 +31,12 @@ resource "oxide_vpc" "example" {
 
 ### Optional
 
+- `ipv6_prefix` (String, Optional) All IPv6 subnets created from this VPC must be taken from this range, which should be a unique local address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix. If no `ipv6_prefix` is defined, a default one will be set.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) Unique, immutable, system-controlled identifier of the VPC.
-- `ipv6_prefix` (String) All IPv6 subnets created from this VPC must be taken from this range, which should be a unique local address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix.
 - `project_id` (String) Unique, immutable, system-controlled identifier of the project.
 - `system_router_id` (String) ID for the system router where subnet default routes are registered.
 - `time_created` (String) Timestamp of when this VPC was created.

--- a/examples/disk_resource/disk.tf
+++ b/examples/disk_resource/disk.tf
@@ -11,6 +11,8 @@ terraform {
 
 provider "oxide" {}
 
+data "oxide_global_images" "image_example" {}
+
 resource "oxide_disk" "example" {
   organization_name = "corp"
   project_name      = "test"
@@ -26,5 +28,5 @@ resource "oxide_disk" "example2" {
   description       = "a test disk"
   name              = "mydisk2"
   size              = 1073741824
-  disk_source       = { global_image = "2f62fa1c-f50c-4657-a331-fa81ddb41ade" }
+  disk_source       = { global_image = data.oxide_global_images.image_example.global_images.0.id }
 }

--- a/examples/vpc_resource/vpc.tf
+++ b/examples/vpc_resource/vpc.tf
@@ -16,5 +16,6 @@ resource "oxide_vpc" "example" {
   project_name      = "test"
   description       = "a test vpc"
   name              = "myvpc"
-  dns_name          = "my-vpc-dns"
+  dns_name          = "my-vpc-dnssd"
+  ipv6_prefix       = "fd1e:4947:d4a1::/48"
 }

--- a/oxide/resource_disk.go
+++ b/oxide/resource_disk.go
@@ -176,9 +176,8 @@ func readDisk(_ context.Context, d *schema.ResourceData, meta interface{}) diag.
 }
 
 func updateDisk(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// TODO: Currently there is no endpoint to update a disk. This function will remain
-	// as readonly until such endpoint exists.
-	return readDisk(ctx, d, meta)
+	// TODO: Currently there is no endpoint to update a disk. Update this function when such endpoint exists
+	return diag.FromErr(errors.New("the oxide_disk resource currently does not support updates"))
 }
 
 func deleteDisk(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/oxide/resource_instance.go
+++ b/oxide/resource_instance.go
@@ -6,6 +6,7 @@ package oxide
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -236,9 +237,8 @@ func readInstance(_ context.Context, d *schema.ResourceData, meta interface{}) d
 }
 
 func updateInstance(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// TODO: Currently there is no endpoint to update an instance. This function will remain
-	// as readonly until such endpoint exists.
-	return readInstance(ctx, d, meta)
+	// TODO: Currently there is no endpoint to update an instance. Update this function when such endpoint exists
+	return diag.FromErr(errors.New("the oxide_instance resource currently does not support updates"))
 }
 
 func deleteInstance(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/oxide/resource_vpc_test.go
+++ b/oxide/resource_vpc_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccResourceVPC(t *testing.T) {
 	resourceName := "oxide_vpc.test"
+	resourceName2 := "oxide_vpc.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -23,6 +24,14 @@ func TestAccResourceVPC(t *testing.T) {
 			{
 				Config: testResourceVPCConfig,
 				Check:  checkResourceVPC(resourceName),
+			},
+			{
+				Config: testResourceVPCUpdateConfig,
+				Check:  checkResourceVPCUpdate(resourceName),
+			},
+			{
+				Config: testResourceVPCIPv6Config,
+				Check:  checkResourceVPCIPv6(resourceName2),
 			},
 		},
 	})
@@ -47,6 +56,59 @@ func checkResourceVPC(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myvpc"),
 		resource.TestCheckResourceAttr(resourceName, "dns_name", "my-vpc-dns"),
 		resource.TestCheckResourceAttrSet(resourceName, "ipv6_prefix"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "system_router_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+var testResourceVPCUpdateConfig = `
+resource "oxide_vpc" "test" {
+	organization_name = "corp"
+	project_name      = "test"
+	description       = "a test vopac"
+	name              = "terraform-acc-myvpc"
+	dns_name          = "my-vpc-donas"
+  }
+`
+
+func checkResourceVPCUpdate(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "organization_name", "corp"),
+		resource.TestCheckResourceAttr(resourceName, "project_name", "test"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test vopac"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myvpc"),
+		resource.TestCheckResourceAttr(resourceName, "dns_name", "my-vpc-donas"),
+		resource.TestCheckResourceAttrSet(resourceName, "ipv6_prefix"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "system_router_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+var testResourceVPCIPv6Config = `
+resource "oxide_vpc" "test2" {
+	organization_name = "corp"
+	project_name      = "test"
+	description       = "a test vpc"
+	name              = "terraform-acc-myvpc2"
+	dns_name          = "my-vpc-dns"
+	ipv6_prefix       = "fd1e:4947:d4a1::/48"
+  }
+`
+
+func checkResourceVPCIPv6(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "organization_name", "corp"),
+		resource.TestCheckResourceAttr(resourceName, "project_name", "test"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test vpc"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myvpc2"),
+		resource.TestCheckResourceAttr(resourceName, "dns_name", "my-vpc-dns"),
+		resource.TestCheckResourceAttr(resourceName, "ipv6_prefix", "fd1e:4947:d4a1::/48"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "system_router_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),


### PR DESCRIPTION
This commit improves how updates are handled, by returning comprehensible errors when it is not possible.

Additionally, the `ipv6_prefix` field for the `oxide_vpc` resource is now both computed and optional