### PR TITLE
New organization resource

### DIFF
--- a/docs/resources/oxide_organization.md
+++ b/docs/resources/oxide_organization.md
@@ -1,0 +1,41 @@
+---
+page_title: "oxide_organization Resource - terraform-provider-oxide"
+---
+
+# oxide_organization (Resource)
+
+This resource manages organizations.
+
+## Example Usage
+
+```hcl
+resource "oxide_organization" "example" {
+  description       = "a test org"
+  name              = "myorg"
+}
+```
+
+## Schema
+
+### Required
+
+- `description` (String) Description for the organization.
+- `name` (String) Name of the organization.
+
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the organization.
+- `time_created` (String) Timestamp of when this organization was created.
+- `time_modified` (String) Timestamp of when this organization was last modified.
+
+<a id="nestedblock--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `default` (String)

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -1,0 +1,18 @@
+# Organizations
+
+This example Terraform configuration file performs the following:
+
+1. Creates an organization.
+
+To try it out make sure you have the following:
+
+- Previously set `OXIDE_HOST` and `OXIDE_TOKEN` environment variables
+
+Although not recommended, if you do not wish to set the environment variables, you can use the `host` and `token` fields in the `oxide` provider block:
+
+```hcl
+provider "oxide" {
+  host = "<your-host>"
+  token = "<your-token>"
+}
+```

--- a/examples/organization/org.tf
+++ b/examples/organization/org.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    oxide = {
+      source  = "oxidecomputer/oxide"
+      version = "0.1.0-dev"
+    }
+  }
+}
+
+provider "oxide" {}
+
+resource "oxide_organization" "example" {
+  description       = "a test org"
+  name              = "anorg"
+}

--- a/oxide/provider.go
+++ b/oxide/provider.go
@@ -40,10 +40,11 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"oxide_disk":     diskResource(),
-			"oxide_instance": instanceResource(),
-			"oxide_vpc":      vpcResource(),
-			"oxide_ip_pool":  ipPoolResource(),
+			"oxide_disk":         diskResource(),
+			"oxide_instance":     instanceResource(),
+			"oxide_ip_pool":      ipPoolResource(),
+			"oxide_organization": organizationResource(),
+			"oxide_vpc":          vpcResource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"oxide_organizations": organizationsDataSource(),

--- a/oxide/resource_ip_pool.go
+++ b/oxide/resource_ip_pool.go
@@ -57,12 +57,12 @@ func newIpPoolSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "Name of the disk.",
+			Description: "Name of the IP pool.",
 			Required:    true,
 		},
 		"description": {
 			Type:        schema.TypeString,
-			Description: "Description for the disk.",
+			Description: "Description for the IP pool.",
 			Required:    true,
 		},
 		"organization_name": {
@@ -82,12 +82,12 @@ func newIpPoolSchema() map[string]*schema.Schema {
 		},
 		"time_created": {
 			Type:        schema.TypeString,
-			Description: "Timestamp of when this disk was created.",
+			Description: "Timestamp of when this IP pool was created.",
 			Computed:    true,
 		},
 		"time_modified": {
 			Type:        schema.TypeString,
-			Description: "Timestamp of when this disk was last modified.",
+			Description: "Timestamp of when this IP pool was last modified.",
 			Computed:    true,
 		},
 	}

--- a/oxide/resource_organization.go
+++ b/oxide/resource_organization.go
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
+)
+
+func organizationResource() *schema.Resource {
+	return &schema.Resource{
+		Description:   "",
+		Schema:        newOrganizationSchema(),
+		CreateContext: createOrganization,
+		ReadContext:   readOrganization,
+		UpdateContext: updateOrganization,
+		DeleteContext: deleteOrganization,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(5 * time.Minute),
+		},
+		CustomizeDiff: customdiff.All(
+			// TODO: When there is an API to update organizations by ID remove this check to allow name changes
+			customdiff.ValidateChange("name", func(ctx context.Context, old, new, meta any) error {
+				if old.(string) != "" && new.(string) != old.(string) {
+					return fmt.Errorf("name of organization cannot be updated via Terraform; please revert to: \"%s\"", old.(string))
+				}
+				return nil
+			}),
+		),
+	}
+}
+
+func newOrganizationSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Description: "Name of the organization.",
+			Required:    true,
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "Description for the organization.",
+			Required:    true,
+		},
+		"time_created": {
+			Type:        schema.TypeString,
+			Description: "Timestamp of when this organization was created.",
+			Computed:    true,
+		},
+		"time_modified": {
+			Type:        schema.TypeString,
+			Description: "Timestamp of when this organization was last modified.",
+			Computed:    true,
+		},
+	}
+}
+
+func createOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	description := d.Get("description").(string)
+	name := d.Get("name").(string)
+
+	body := oxideSDK.OrganizationCreate{
+		Description: description,
+		Name:        oxideSDK.Name(name),
+	}
+
+	resp, err := client.OrganizationCreate(&body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.Id)
+
+	return readOrganization(ctx, d, meta)
+}
+
+func readOrganization(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	orgName := d.Get("name").(string)
+
+	resp, err := client.OrganizationView(oxideSDK.Name(orgName))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("name", resp.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", resp.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("time_created", resp.TimeCreated.String()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("time_modified", resp.TimeModified.String()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func updateOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+
+	description := d.Get("description").(string)
+	name := d.Get("name").(string)
+
+	body := oxideSDK.OrganizationUpdate{
+		Description: description,
+		// We cannot change the name of the organization as it is used as an identifier for
+		// the update in the Put method. Changing it would make it impossible for
+		// terraform to know which organization to update.
+		// Name:        name,
+	}
+
+	resp, err := client.OrganizationUpdate(oxideSDK.Name(name), &body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.Id)
+
+	return readOrganization(ctx, d, meta)
+}
+
+func deleteOrganization(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*oxideSDK.Client)
+	orgName := d.Get("name").(string)
+
+	if err := client.OrganizationDelete(oxideSDK.Name(orgName)); err != nil {
+		if is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/oxide/resource_organization_test.go
+++ b/oxide/resource_organization_test.go
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceOrganization(t *testing.T) {
+	resourceName := "oxide_organization.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccOrganizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceOrganizationConfig,
+				Check:  checkResourceOrganization(resourceName),
+			},
+			{
+				Config: testResourceOrganizationUpdateConfig,
+				Check:  checkResourceOrganizationUpdate(resourceName),
+			},
+		},
+	})
+}
+
+var testResourceOrganizationConfig = `
+resource "oxide_organization" "test" {
+	description       = "a test organization"
+	name              = "terraform-acc-myorg"
+  }
+`
+
+func checkResourceOrganization(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test organization"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myorg"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+var testResourceOrganizationUpdateConfig = `
+resource "oxide_organization" "test" {
+	description       = "a new description for organization"
+	name              = "terraform-acc-myorg"
+  }
+`
+
+func checkResourceOrganizationUpdate(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a new description for organization"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myorg"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccOrganizationDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_organization" {
+			continue
+		}
+
+		res, err := client.OrganizationView("terraform-acc-myorg")
+		if err != nil && is404(err) {
+			continue
+		}
+		return fmt.Errorf("organization (%v) still exists", &res.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a resource for an organization:

```console
$ terraform apply
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_organization.example will be created
  + resource "oxide_organization" "example" {
      + description   = "a test org"
      + id            = (known after apply)
      + name          = "anorg"
      + time_created  = (known after apply)
      + time_modified = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_organization.example: Creating...
oxide_organization.example: Creation complete after 1s [id=fba199e8-7cc6-4008-99e4-83ecfc077b20]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

