### PR TITLE
Refine how IP pool ranges are handled

### DIFF
--- a/docs/resources/oxide_ip_pool.md
+++ b/docs/resources/oxide_ip_pool.md
@@ -6,7 +6,7 @@ page_title: "oxide_ip_pool Resource - terraform-provider-oxide"
 
 This resource manages IP pools.
 
-!> This resource currently only provides create and read actions. Once remaining endpoints have been added to the API, that functionality will be added here as well.
+!> This resource currently only provides create, read and delete actions.
 
 ## Example Usage
 
@@ -15,7 +15,6 @@ resource "oxide_ip_pool" "example" {
   description       = "a test ippool"
   name              = "myippool"
   ranges {
-    ip_version    = "ipv4"
     first_address = "172.20.15.227"
     last_address  = "172.20.15.239"
   }
@@ -31,9 +30,9 @@ resource "oxide_ip_pool" "example" {
 
 ### Optional
 
-- `ranges` (List of Object, Optional) Adds IP ranges to the created IP pool. (see [below for nested schema](#nestedblock--ranges))
 - `organization_name` (String, Optional) Name of the organization.
 - `project_name` (String, Optional) Name of the project.
+- `ranges` (List of Object, Optional) Adds IP ranges to the created IP pool. Can be IPv4 or IPv6. (see [below for nested schema](#nestedblock--ranges))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -49,7 +48,6 @@ resource "oxide_ip_pool" "example" {
 
 Required:
 
-- `ip_version` (String) IP version of the range. Accepted values are `ipv4` or `ipv6`.
 - `first_address` (String) First address in the range.
 - `last_address` (String) Last address in the range.
 

--- a/examples/ip_pool_resource/ip_pool.tf
+++ b/examples/ip_pool_resource/ip_pool.tf
@@ -15,7 +15,6 @@ resource "oxide_ip_pool" "example" {
   description = "a test IP pool"
   name        = "myippool"
   ranges {
-    ip_version    = "ipv4"
     first_address = "172.20.15.227"
     last_address  = "172.20.15.239"
   }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oxidecomputer/terraform-provider-oxide
 go 1.18
 
 require (
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
 	github.com/oxidecomputer/oxide.go v0.0.22
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/oxide/resource_ip_pool_test.go
+++ b/oxide/resource_ip_pool_test.go
@@ -77,6 +77,10 @@ resource "oxide_ip_pool" "test2" {
 	project_name      = "test"
 	description       = "a test ip_pool"
 	name              = "terraform-acc-myippool2"
+	ranges {
+		first_address = "172.20.15.227"
+		last_address  = "172.20.15.239"
+	}
   }
 `
 
@@ -90,6 +94,10 @@ func checkResourceIpPoolOrgProject(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.227"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.239"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.id"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.time_created"),
 	}...)
 }
 


### PR DESCRIPTION
Removes the use of the `ip_version` attribute within the `ranges` block for a more refined solution.

```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccResourceIpPool
=== PAUSE TestAccResourceIpPool
=== CONT  TestAccResourceIpPool
--- PASS: TestAccResourceIpPool (3.03s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/oxide	4.068s
```