### PR TITLE
Config example to setup rack

### DIFF
--- a/examples/rack_setup/README.md
+++ b/examples/rack_setup/README.md
@@ -10,3 +10,9 @@ This Terraform configuration file sets up the basic elements on a rack to be abl
 _IMPORTANT: Currently there is no way to delete a global image. This means that you cannot run `terraform destroy` on this configuration file._
 
 To try out this configuration file follow the [instructions](https://github.com/oxidecomputer/terraform-provider-oxide/#using-the-provider) from the README.
+
+If you have not set up the catacomb tunnel, use the Terraform CLI to change the value of the `catacomb` variable while applying the plan by running:
+
+```console
+$ terraform apply -var="catacomb=catacomb.eng.oxide.computer"
+```

--- a/examples/rack_setup/rack_setup.tf
+++ b/examples/rack_setup/rack_setup.tf
@@ -34,7 +34,7 @@ resource "oxide_ip_pool" "ip_pool_ranges" {
 resource "oxide_global_image" "debian" {
   description          = "a debian image"
   name                 = "debian"
-  image_source         = { url = "http://${var.catacomb_tunnel}/media/cloud/debian-11-genericcloud-amd64.raw" }
+  image_source         = { url = "http://${var.catacomb}/media/cloud/debian-11-genericcloud-amd64.raw" }
   block_size           = 512
   distribution         = "debian"
   distribution_version = "11"
@@ -43,7 +43,7 @@ resource "oxide_global_image" "debian" {
 resource "oxide_global_image" "ubuntu" {
   description          = "an ubuntu image"
   name                 = "ubuntu"
-  image_source         = { url = "http://${var.catacomb_tunnel}/media/cloud/focal-server-cloudimg-amd64.raw" }
+  image_source         = { url = "http://${var.catacomb}/media/cloud/focal-server-cloudimg-amd64.raw" }
   block_size           = 512
   distribution         = "ubuntu"
   distribution_version = "22.04"
@@ -52,7 +52,7 @@ resource "oxide_global_image" "ubuntu" {
 resource "oxide_global_image" "fedora" {
   description          = "a fedora image"
   name                 = "fedora"
-  image_source         = { url = "http://${var.catacomb_tunnel}/media/cloud/Fedora-Cloud-Base-35-1.2.x86_64.raw" }
+  image_source         = { url = "http://${var.catacomb}/media/cloud/Fedora-Cloud-Base-35-1.2.x86_64.raw" }
   block_size           = 512
   distribution         = "fedora"
   distribution_version = "35-1.2"
@@ -61,7 +61,7 @@ resource "oxide_global_image" "fedora" {
 resource "oxide_global_image" "debian-nocloud" {
   description          = "a debian-nocloud image"
   name                 = "debian-nocloud"
-  image_source         = { url = "http://${var.catacomb_tunnel}/media/debian/debian-11-nocloud-amd64-20220503-998.raw" }
+  image_source         = { url = "http://${var.catacomb}/media/debian/debian-11-nocloud-amd64-20220503-998.raw" }
   block_size           = 512
   distribution         = "debian-nocloud"
   distribution_version = "nocloud 11"
@@ -70,7 +70,7 @@ resource "oxide_global_image" "debian-nocloud" {
 resource "oxide_global_image" "ubuntu-nocloud-iso" {
   description          = "an ubuntu nocloud iso image"
   name                 = "ubuntu-nocloud-iso"
-  image_source         = { url = "http://${var.catacomb_tunnel}/media/ubuntu/ubuntu-22.04-live-server-amd64.iso" }
+  image_source         = { url = "http://${var.catacomb}/media/ubuntu/ubuntu-22.04-live-server-amd64.iso" }
   block_size           = 512
   distribution         = "ubuntu-iso"
   distribution_version = "iso 22.04"

--- a/examples/rack_setup/variables.tf
+++ b/examples/rack_setup/variables.tf
@@ -1,4 +1,4 @@
-variable "catacomb_tunnel" {
+variable "catacomb" {
   type    = string
   default = "[fd00:1122:3344:101::1]:54321"
 }


### PR DESCRIPTION
Adds a Terraform configuration file to set up the basic elements on a rack to be able to run the [demo configuration file](https://github.com/oxidecomputer/terraform-provider-oxide/tree/main/examples/demo).

```console
$ terraform init
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_global_image.dummy_image will be created
  + resource "oxide_global_image" "dummy_image" {
      + block_size           = 512
      + description          = "a test global_image"
      + digest               = (known after apply)
      + distribution         = "alpine"
      + distribution_version = "propolis_blob"
      + id                   = (known after apply)
      + image_source         = {
          + "you_can_boot_anything_as_long_as_its_alpine" = "noop"
        }
      + name                 = "alpine"
      + size                 = (known after apply)
      + time_created         = (known after apply)
      + time_modified        = (known after apply)
      + url                  = (known after apply)
    }

  # oxide_ip_pool.ip_pool_ranges will be created
  + resource "oxide_ip_pool" "ip_pool_ranges" {
      + description   = "a test IP pool"
      + id            = (known after apply)
      + name          = "mypool"
      + project_id    = (known after apply)
      + time_created  = (known after apply)
      + time_modified = (known after apply)

      + ranges {
          + first_address = "172.20.15.227"
          + id            = (known after apply)
          + last_address  = "172.20.15.239"
          + time_created  = (known after apply)
        }
    }

  # oxide_organization.setup_org will be created
  + resource "oxide_organization" "setup_org" {
      + description   = "a test org"
      + id            = (known after apply)
      + name          = "myorg"
      + time_created  = (known after apply)
      + time_modified = (known after apply)
    }

  # oxide_project.setup_project will be created
  + resource "oxide_project" "setup_project" {
      + description       = "a test project"
      + id                = (known after apply)
      + name              = "myproj"
      + organization_id   = (known after apply)
      + organization_name = "myorg"
      + time_created      = (known after apply)
      + time_modified     = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_organization.setup_org: Creating...
oxide_global_image.dummy_image: Creating...
oxide_ip_pool.ip_pool_ranges: Creating...
oxide_global_image.dummy_image: Creation complete after 0s [id=4f30a8f6-342f-4311-ae3e-baa3e9983883]
oxide_organization.setup_org: Creation complete after 0s [id=f52538b1-db72-467f-8cd6-f4494c8bdd01]
oxide_project.setup_project: Creating...
oxide_ip_pool.ip_pool_ranges: Creation complete after 1s [id=730279b9-c097-41c3-ba73-dbd22706b18f]
oxide_project.setup_project: Creation complete after 1s [id=8c48ce6b-b256-48c4-a840-668460d77829]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

tfstate file
```hcl
{
  "version": 4,
  "terraform_version": "1.2.2",
  "serial": 5,
  "lineage": "2fb31de4-906b-a60c-0658-ee483d12af10",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "oxide_global_image",
      "name": "dummy_image",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_size": 512,
            "description": "a test global_image",
            "digest": "",
            "distribution": "alpine",
            "distribution_version": "propolis-blob",
            "id": "4f30a8f6-342f-4311-ae3e-baa3e9983883",
            "image_source": {
              "you_can_boot_anything_as_long_as_its_alpine": "noop"
            },
            "name": "alpine",
            "size": 104857600,
            "time_created": "2022-10-05 03:04:35.28783 +0000 UTC",
            "time_modified": "2022-10-05 03:04:35.28783 +0000 UTC",
            "timeouts": null,
            "url": ""
          },
          "sensitive_attributes": [],
          "private": "REDACTED"
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_ip_pool",
      "name": "ip_pool_ranges",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "description": "a test IP pool",
            "id": "730279b9-c097-41c3-ba73-dbd22706b18f",
            "name": "mypool",
            "organization_name": null,
            "project_id": null,
            "project_name": null,
            "ranges": [
              {
                "first_address": "172.20.15.227",
                "id": "83cf6b0e-f4cf-4002-8560-e87baa687dc7",
                "last_address": "172.20.15.239",
                "time_created": "2022-10-05 03:04:35.429773 +0000 UTC"
              }
            ],
            "time_created": "2022-10-05 03:04:35.283865 +0000 UTC",
            "time_modified": "2022-10-05 03:04:35.283865 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED"
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_organization",
      "name": "setup_org",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "description": "a test org",
            "id": "f52538b1-db72-467f-8cd6-f4494c8bdd01",
            "name": "myorg",
            "time_created": "2022-10-05 03:04:35.264693 +0000 UTC",
            "time_modified": "2022-10-05 03:04:35.264693 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED"
        }
      ]
    },
    {
      "mode": "managed",
      "type": "oxide_project",
      "name": "setup_project",
      "provider": "provider[\"registry.terraform.io/oxidecomputer/oxide\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "description": "a test project",
            "id": "8c48ce6b-b256-48c4-a840-668460d77829",
            "name": "myproj",
            "organization_id": "f52538b1-db72-467f-8cd6-f4494c8bdd01",
            "organization_name": "myorg",
            "time_created": "2022-10-05 03:04:35.539437 +0000 UTC",
            "time_modified": "2022-10-05 03:04:35.539437 +0000 UTC",
            "timeouts": null
          },
          "sensitive_attributes": [],
          "private": "REDACTED",
          "dependencies": [
            "oxide_organization.setup_org"
          ]
        }
      ]
    }
  ]
}

```