### PR TITLE
Adapt disk resource to v1 API

### DIFF
--- a/docs/resources/oxide_disk.md
+++ b/docs/resources/oxide_disk.md
@@ -12,8 +12,7 @@ This resource manages disks.
 
 ```hcl
 resource "oxide_disk" "example" {
-  organization_name = "staff"
-  project_name      = "test"
+  project_id        = "c1dee930-a8e4-11ed-afa1-0242ac120002"
   description       = "a test disk"
   name              = "mydisk"
   size              = 1073741824
@@ -21,8 +20,7 @@ resource "oxide_disk" "example" {
 }
 
 resource "oxide_disk" "example2" {
-  organization_name = "staff"
-  project_name      = "test"
+  project_id        = "c1dee930-a8e4-11ed-afa1-0242ac120002"
   description       = "a test disk"
   name              = "mydisk2"
   size              = 1073741824
@@ -34,15 +32,14 @@ resource "oxide_disk" "example2" {
 
 ### Required
 
-- `description` (String) Description for the disk.
 - `disk_source` (Map of String) Source of a disk. Can be one of `blank = block_size`, `image = "image_id"`, `global_image = "image_id"`, or `snapshot = "snapshot_id"`.
 - `name` (String) Name of the disk.
-- `organization_name` (String) Name of the organization.
-- `project_name` (String) Name of the project.
+- `project_id` (String) ID of the project that will contain the disk.
 - `size` (Number) Size of the disk in bytes.
 
 ### Optional
 
+- `description` (String) Description for the disk.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/demo/demo.tf
+++ b/examples/demo/demo.tf
@@ -20,8 +20,7 @@ data "oxide_projects" "project_list" {
 data "oxide_global_images" "image_list" {}
 
 resource "oxide_disk" "web_disk_1" {
-  organization_name = data.oxide_organizations.org_list.organizations.0.name
-  project_name      = data.oxide_projects.project_list.projects.0.name
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "Disk for a web instance"
   name              = "web-disk-1"
   size              = var.ten_gib
@@ -29,8 +28,7 @@ resource "oxide_disk" "web_disk_1" {
 }
 
 resource "oxide_disk" "web_disk_2" {
-  organization_name = data.oxide_organizations.org_list.organizations.0.name
-  project_name      = data.oxide_projects.project_list.projects.0.name
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "Disk for a web instance"
   name              = "web-disk-2"
   size              = var.ten_gib
@@ -38,8 +36,7 @@ resource "oxide_disk" "web_disk_2" {
 }
 
 resource "oxide_disk" "web_disk_3" {
-  organization_name = data.oxide_organizations.org_list.organizations.0.name
-  project_name      = data.oxide_projects.project_list.projects.0.name
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "Disk for a web instance"
   name              = "web-disk-3"
   size              = var.ten_gib
@@ -47,8 +44,7 @@ resource "oxide_disk" "web_disk_3" {
 }
 
 resource "oxide_disk" "db_disk_1" {
-  organization_name = data.oxide_organizations.org_list.organizations.0.name
-  project_name      = data.oxide_projects.project_list.projects.0.name
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "Disk for a DB instance"
   name              = "db-disk-1"
   size              = var.twenty_gib
@@ -56,8 +52,7 @@ resource "oxide_disk" "db_disk_1" {
 }
 
 resource "oxide_disk" "db_disk_2" {
-  organization_name = data.oxide_organizations.org_list.organizations.0.name
-  project_name      = data.oxide_projects.project_list.projects.0.name
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "Disk for a DB instance"
   name              = "db-disk-2"
   size              = var.twenty_gib

--- a/examples/disk_resource/README.md
+++ b/examples/disk_resource/README.md
@@ -8,11 +8,10 @@ This example Terraform configuration file performs the following:
 To try it out make sure you have the following:
 
 - Verify that the `global_image` ID within `disk_source` matches the global image you want to use.
-- An organization named `corp`.
-- A project within the `corp` organization called `test`.
-- Previously set `OXIDE_HOST` and `OXIDE_TOKEN` environment variables
+- A project already created.
+- Previously set `OXIDE_HOST` and `OXIDE_TOKEN` environment variables.
 
-Alternatively, you can modify the configuration file with your own `organization_name` and `project_name`. Although not recommended, if you do not wish to set the environment variables, you can use the `host` and `token` fields in the `oxide` provider block:
+Alternatively, you can modify the configuration file with your own `project_id`. Although not recommended, if you do not wish to set the environment variables, you can use the `host` and `token` fields in the `oxide` provider block:
 
 ```hcl
 provider "oxide" {

--- a/examples/disk_resource/disk.tf
+++ b/examples/disk_resource/disk.tf
@@ -13,9 +13,14 @@ provider "oxide" {}
 
 data "oxide_global_images" "image_example" {}
 
+data "oxide_organizations" "org_list" {}
+
+data "oxide_projects" "project_list" {
+  organization_name = data.oxide_organizations.org_list.organizations.0.name
+}
+
 resource "oxide_disk" "example" {
-  organization_name = "corp"
-  project_name      = "test"
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "a test disk"
   name              = "mydisk"
   size              = 1073741824
@@ -23,8 +28,7 @@ resource "oxide_disk" "example" {
 }
 
 resource "oxide_disk" "example2" {
-  organization_name = "corp"
-  project_name      = "test"
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "a test disk"
   name              = "mydisk2"
   size              = 1073741824

--- a/oxide/resource_disk_test.go
+++ b/oxide/resource_disk_test.go
@@ -29,9 +29,14 @@ func TestAccResourceDisk(t *testing.T) {
 }
 
 var testResourceDiskConfig = `
+data "oxide_organizations" "org_list" {}
+
+data "oxide_projects" "project_list" {
+  organization_name = data.oxide_organizations.org_list.organizations.0.name
+}
+
 resource "oxide_disk" "test" {
-  organization_name = "corp"
-  project_name      = "test"
+  project_id        = data.oxide_projects.project_list.projects.0.id
   description       = "a test disk"
   name              = "terraform-acc-mydisk"
   size              = 1073741824
@@ -42,8 +47,6 @@ resource "oxide_disk" "test" {
 func checkResourceDisk(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-		resource.TestCheckResourceAttr(resourceName, "organization_name", "corp"),
-		resource.TestCheckResourceAttr(resourceName, "project_name", "test"),
 		resource.TestCheckResourceAttr(resourceName, "description", "a test disk"),
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-mydisk"),
 		resource.TestCheckResourceAttr(resourceName, "size", "1073741824"),


### PR DESCRIPTION
Updates the disk resource to use the new endpoints

```console
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccResourceDisk
=== PAUSE TestAccResourceDisk
=== CONT  TestAccResourceDisk
http://127.0.0.1:12220/organizations?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations/corp/projects?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations/corp/projects?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/v1/disks?project=87520b59-af59-4ef2-bcc5-0b439be620bc
http://127.0.0.1:12220/v1/disks/12aeb847-692f-439e-94de-dcf92047202d
http://127.0.0.1:12220/organizations?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations/corp/projects?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations/corp/projects?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/v1/disks/12aeb847-692f-439e-94de-dcf92047202d
http://127.0.0.1:12220/organizations?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/organizations/corp/projects?limit=1000000&sort_by=id_ascending
http://127.0.0.1:12220/v1/disks/12aeb847-692f-439e-94de-dcf92047202d
http://127.0.0.1:12220/v1/disks/12aeb847-692f-439e-94de-dcf92047202d
http://127.0.0.1:12220/organizations/corp/projects/test/disks/terraform-acc-mydisk
--- PASS: TestAccResourceDisk (1.74s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/oxide	2.264s
```

Related: #61 