### PR TITLE
Update project resource to v1 API

### DIFF
--- a/oxide/resource_project_test.go
+++ b/oxide/resource_project_test.go
@@ -54,7 +54,7 @@ func checkResourceProject(resourceName string) resource.TestCheckFunc {
 var testResourceProjectUpdateConfig = `
 resource "oxide_project" "test" {
 	description       = "a new description for project"
-	name              = "terraform-acc-myproject"
+	name              = "terraform-acc-myproject2"
 	organization_name = "corp"
   }
 `
@@ -63,7 +63,7 @@ func checkResourceProjectUpdate(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttr(resourceName, "description", "a new description for project"),
-		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myproject"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myproject2"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
 	}...)
@@ -80,7 +80,7 @@ func testAccProjectDestroy(s *terraform.State) error {
 			continue
 		}
 
-		res, err := client.ProjectView(oxide.Name("corp"), oxide.Name("terraform-acc-myproject"))
+		res, err := client.ProjectView(oxide.Name("corp"), oxide.Name("terraform-acc-myproject2"))
 		if err != nil && is404(err) {
 			continue
 		}


### PR DESCRIPTION
$ make testacc
-> Running terraform acceptance tests...
=== RUN   TestAccResourceProject
=== PAUSE TestAccResourceProject
=== CONT  TestAccResourceProject
http://127.0.0.1:12220/v1/projects?organization=corp
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054
http://127.0.0.1:12220/v1/projects/c81a9505-9896-40f6-916b-e74436cba054        
--- PASS: TestAccResourceProject (1.42s)

Related https://github.com/oxidecomputer/terraform-provider-oxide/issues/61