### PR TITLE
Implement logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.1
 	github.com/hashicorp/terraform-plugin-go v0.15.0
+	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-testing v1.2.0
 	github.com/oxidecomputer/oxide.go v0.0.22-0.20230411045251-335c1187c3bd
 	github.com/stretchr/testify v1.8.2
@@ -33,7 +34,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.16.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.8.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.1 // indirect

--- a/oxide/data_source_images.go
+++ b/oxide/data_source_images.go
@@ -6,12 +6,14 @@ package oxide
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -179,6 +181,8 @@ func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		)
 		return
 	}
+
+	tflog.Trace(ctx, fmt.Sprintf("read all images from project: %v", state.ProjectID.ValueString()), map[string]any{"success": true})
 
 	// Set a unique ID for the datasource payload
 	state.ID = types.StringValue(uuid.New().String())

--- a/oxide/data_source_projects.go
+++ b/oxide/data_source_projects.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -126,6 +127,8 @@ func (d *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		)
 		return
 	}
+
+	tflog.Trace(ctx, "read all projects", map[string]any{"success": true})
 
 	// Set a unique ID for the datasource payload
 	state.ID = types.StringValue(uuid.New().String())

--- a/oxide/provider.go
+++ b/oxide/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -59,6 +60,8 @@ func (p *oxideProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp
 
 // Configure prepares the Oxide client for data sources and resources.
 func (p *oxideProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	tflog.Info(ctx, "Configuring Oxide client")
+
 	host := os.Getenv("OXIDE_HOST")
 	token := os.Getenv("OXIDE_TOKEN")
 
@@ -98,6 +101,11 @@ func (p *oxideProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "host", host)
+	ctx = tflog.SetField(ctx, "token", token)
+	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "token")
+	tflog.Debug(ctx, "Creating Oxide client")
+
 	// TODO: Add provider version to the user agent?
 	client, err := oxideSDK.NewClient(token, "terraform-provider-oxide", host)
 	if err != nil {
@@ -107,6 +115,8 @@ func (p *oxideProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		)
 		return
 	}
+
+	tflog.Info(ctx, "Configured Oxide client", map[string]any{"success": true})
 
 	resp.DataSourceData = client
 	resp.ResourceData = client

--- a/oxide/resource_disk.go
+++ b/oxide/resource_disk.go
@@ -7,6 +7,7 @@ package oxide
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -199,6 +201,8 @@ func (r *diskResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	tflog.Trace(ctx, fmt.Sprintf("created disk with ID: %v", disk.Id), map[string]any{"success": true})
+
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(disk.Id)
 	plan.DevicePath = types.StringValue(disk.DevicePath)
@@ -259,6 +263,7 @@ func (r *diskResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read disk with ID: %v", disk.Id), map[string]any{"success": true})
 
 	state.BlockSize = types.Int64Value(int64(disk.BlockSize))
 	state.Description = types.StringValue(disk.Description)
@@ -339,6 +344,8 @@ func (r *diskResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 			return
 		}
 	}
+
+	tflog.Trace(ctx, fmt.Sprintf("deleted disk with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 }
 
 func newDiskSource(p diskResourceModel) (oxideSDK.DiskSource, error) {

--- a/oxide/resource_image.go
+++ b/oxide/resource_image.go
@@ -7,6 +7,7 @@ package oxide
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -199,6 +201,8 @@ func (r *imageResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	tflog.Trace(ctx, fmt.Sprintf("created image with ID: %v", image.Id), map[string]any{"success": true})
+
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(image.Id)
 	plan.Size = types.Int64Value(int64(image.Size))
@@ -258,6 +262,8 @@ func (r *imageResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		)
 		return
 	}
+
+	tflog.Trace(ctx, fmt.Sprintf("read image with ID: %v", image.Id), map[string]any{"success": true})
 
 	state.BlockSize = types.Int64Value(int64(image.BlockSize))
 	state.Description = types.StringValue(image.Description)

--- a/oxide/resource_ip_pool.go
+++ b/oxide/resource_ip_pool.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -159,6 +160,7 @@ func (r *ipPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("created IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(ipPool.Id)
@@ -219,6 +221,7 @@ func (r *ipPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 			)
 			return
 		}
+		tflog.Trace(ctx, fmt.Sprintf("added IP Pool range with ID: %v", ipR.Id), map[string]any{"success": true})
 
 		ipPoolRange.ID = types.StringValue(ipR.Id)
 		ipPoolRange.TimeCreated = types.StringValue(ipR.TimeCreated.String())
@@ -261,6 +264,7 @@ func (r *ipPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
 
 	state.Description = types.StringValue(ipPool.Description)
 	state.ID = types.StringValue(ipPool.Id)
@@ -281,6 +285,7 @@ func (r *ipPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read all IP pool ranges from IP pool with ID: %v", ipPool.Id), map[string]any{"success": true})
 
 	// Set the size of the slice to avoid a panic when importing
 	if len(state.Ranges) == 0 && len(ipPoolRanges.Items) != 0 {
@@ -367,7 +372,6 @@ func (r *ipPoolResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	ipPool, err := r.client.IpPoolUpdate(params)
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating IP Pool",
@@ -375,6 +379,7 @@ func (r *ipPoolResource) Update(ctx context.Context, req resource.UpdateRequest,
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("updated IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(ipPool.Id)
@@ -423,6 +428,7 @@ func (r *ipPoolResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			return
 		}
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read all IP pool ranges from IP pool with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 
 	for _, item := range ranges.Items {
 		var ipRange oxideSDK.IpRange
@@ -464,6 +470,12 @@ func (r *ipPoolResource) Delete(ctx context.Context, req resource.DeleteRequest,
 				return
 			}
 		}
+		tflog.Trace(ctx, fmt.Sprintf(
+			"removed IP pool range %v - %v from IP pool with ID: %v",
+			rs["first"].(string),
+			rs["last"].(string),
+			state.ID.ValueString(),
+		), map[string]any{"success": true})
 	}
 
 	if err := r.client.IpPoolDelete(oxideSDK.IpPoolDeleteParams{
@@ -477,4 +489,5 @@ func (r *ipPoolResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			return
 		}
 	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted IP pool with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 }

--- a/oxide/resource_project.go
+++ b/oxide/resource_project.go
@@ -6,12 +6,14 @@ package oxide
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -125,6 +127,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("created project with ID: %v", project.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(project.Id)
@@ -166,6 +169,7 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read project with ID: %v", project.Id), map[string]any{"success": true})
 
 	state.Description = types.StringValue(project.Description)
 	state.ID = types.StringValue(project.Id)
@@ -221,6 +225,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("updated project with ID: %v", project.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(project.Id)
@@ -263,4 +268,5 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 			return
 		}
 	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted project with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 }

--- a/oxide/resource_vpc.go
+++ b/oxide/resource_vpc.go
@@ -6,12 +6,14 @@ package oxide
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
 )
@@ -149,6 +151,7 @@ func (r *vpcResource) Create(ctx context.Context, req resource.CreateRequest, re
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("created VPC with ID: %v", vpc.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(vpc.Id)
@@ -193,6 +196,7 @@ func (r *vpcResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read VPC with ID: %v", vpc.Id), map[string]any{"success": true})
 
 	state.Description = types.StringValue(vpc.Description)
 	state.DNSName = types.StringValue(string(vpc.DnsName))
@@ -276,6 +280,7 @@ func (r *vpcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		)
 		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("updated VPC with ID: %v", vpc.Id), map[string]any{"success": true})
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(vpc.Id)
@@ -309,6 +314,8 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	_, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
+	// TODO: Remove all associated Subnets automatically
+
 	if err := r.client.VpcDelete(oxideSDK.VpcDeleteParams{
 		Vpc: oxideSDK.NameOrId(state.ID.ValueString()),
 	}); err != nil {
@@ -320,4 +327,5 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 			return
 		}
 	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted VPC with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 }


### PR DESCRIPTION
Implements structured logs to all datasources/resources

Example:
```shell
$ TF_LOG=TRACE terraform plan
#...
2023-05-01T20:51:29.244+1200 [INFO]  provider.terraform-provider-oxide_0.1.0-dev: Configuring Oxide client: @module=oxide tf_provider_addr=registry.terraform.io/oxidecomputer/oxide tf_req_id=01175400-751b-11ad-f838-d845294dbdc7 tf_rpc=ConfigureProvider @caller=/Users/karcafv/src/oxide/terraform-provider-oxide/oxide/provider.go:63 timestamp=2023-05-01T20:51:29.244+1200
2023-05-01T20:51:29.244+1200 [DEBUG] provider.terraform-provider-oxide_0.1.0-dev: Creating Oxide client: tf_provider_addr=registry.terraform.io/oxidecomputer/oxide tf_req_id=01175400-751b-11ad-f838-d845294dbdc7 tf_rpc=ConfigureProvider token=*** @module=oxide @caller=/Users/karcafv/src/oxide/terraform-provider-oxide/oxide/provider.go:107 host=http://127.0.0.1:12220 timestamp=2023-05-01T20:51:29.244+1200
2023-05-01T20:51:29.244+1200 [INFO]  provider.terraform-provider-oxide_0.1.0-dev: Configured Oxide client: @caller=/Users/karcafv/src/oxide/terraform-provider-oxide/oxide/provider.go:119 @module=oxide host=http://127.0.0.1:12220 success=true tf_provider_addr=registry.terraform.io/oxidecomputer/oxide tf_req_id=01175400-751b-11ad-f838-d845294dbdc7 tf_rpc=ConfigureProvider token=*** timestamp=2023-05-01T20:51:29.244+1200
#...
2023-05-01T20:51:29.317+1200 [TRACE] provider.terraform-provider-oxide_0.1.0-dev: read all projects: success=true tf_data_source_type=oxide_projects tf_provider_addr=registry.terraform.io/oxidecomputer/oxide @caller=/Users/karcafv/src/oxide/terraform-provider-oxide/oxide/data_source_projects.go:131 @module=oxide tf_req_id=448593b5-5b25-bad5-fc7b-82c63f655b1f tf_rpc=ReadDataSource timestamp=2023-05-01T20:51:29.317+1200
#...
```

Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/96