### PR TITLE
Tiny fixes to main.go and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ When trying out the same example with a provider you've recently built with chan
 
 ## Running the linters
 
-Before getting started make sure you've set the `$GOBIN` environment variable to where your go binaries are stored and add it to `$PATH`.
-
-Example:
-
-```console
-export GOBIN=/Users/username/go/bin
-export PATH=${PATH}:/Users/username/go/bin
-```
-
 There is a make target to run the linters. All that's needed is `make lint`.
 
 ## Running acceptance tests

--- a/main.go
+++ b/main.go
@@ -21,16 +21,14 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	err := providerserver.Serve(
+	if err := providerserver.Serve(
 		context.Background(),
 		func() provider.Provider { return oxide.New(oxide.Version) },
 		providerserver.ServeOpts{
 			Address: "registry.terraform.io/oxidecomputer/oxide",
 			Debug:   debug,
 		},
-	)
-
-	if err != nil {
+	); err != nil {
 		log.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
No more need to set $GOBIN since https://github.com/oxidecomputer/terraform-provider-oxide/pull/95/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R6