### PR TITLE
Remove instance attributes that are not necessary

### DIFF
--- a/docs/resources/oxide_instance.md
+++ b/docs/resources/oxide_instance.md
@@ -80,10 +80,8 @@ resource "oxide_instance" "example" {
 ### Read-Only
 
 - `id` (String) Unique, immutable, system-controlled identifier of the instance.
-- `run_state` (String) Running state of an Instance (primarily: booted or stopped). This typically reflects whether it's starting, running, stopping, or stopped, but also includes states related to the instance's lifecycle.
 - `time_created` (String) Timestamp of when this instance was created.
 - `time_modified` (String) Timestamp of when this instance last modified.
-- `time_run_state_updated` (String) Timestamp of when the run state of this instance was last modified.
 
 <a id="nestedatt--timeouts"></a>
 

--- a/oxide/resource_instance.go
+++ b/oxide/resource_instance.go
@@ -38,22 +38,20 @@ type instanceResource struct {
 }
 
 type instanceResourceModel struct {
-	AttachToDisks       types.List     `tfsdk:"attach_to_disks"`
-	Description         types.String   `tfsdk:"description"`
-	ExternalIPs         types.List     `tfsdk:"external_ips"`
-	HostName            types.String   `tfsdk:"host_name"`
-	ID                  types.String   `tfsdk:"id"`
-	Memory              types.Int64    `tfsdk:"memory"`
-	Name                types.String   `tfsdk:"name"`
-	NCPUs               types.Int64    `tfsdk:"ncpus"`
-	ProjectID           types.String   `tfsdk:"project_id"`
-	RunState            types.String   `tfsdk:"run_state"`
-	StartOnCreate       types.Bool     `tfsdk:"start_on_create"`
-	TimeCreated         types.String   `tfsdk:"time_created"`
-	TimeModified        types.String   `tfsdk:"time_modified"`
-	TimeRunStateUpdated types.String   `tfsdk:"time_run_state_updated"`
-	Timeouts            timeouts.Value `tfsdk:"timeouts"`
-	UserData            types.String   `tfsdk:"user_data"`
+	AttachToDisks types.List     `tfsdk:"attach_to_disks"`
+	Description   types.String   `tfsdk:"description"`
+	ExternalIPs   types.List     `tfsdk:"external_ips"`
+	HostName      types.String   `tfsdk:"host_name"`
+	ID            types.String   `tfsdk:"id"`
+	Memory        types.Int64    `tfsdk:"memory"`
+	Name          types.String   `tfsdk:"name"`
+	NCPUs         types.Int64    `tfsdk:"ncpus"`
+	ProjectID     types.String   `tfsdk:"project_id"`
+	StartOnCreate types.Bool     `tfsdk:"start_on_create"`
+	TimeCreated   types.String   `tfsdk:"time_created"`
+	TimeModified  types.String   `tfsdk:"time_modified"`
+	Timeouts      timeouts.Value `tfsdk:"timeouts"`
+	UserData      types.String   `tfsdk:"user_data"`
 }
 
 // Metadata returns the resource type name.
@@ -135,12 +133,6 @@ func (r *instanceResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the instance.",
 			},
-			"run_state": schema.StringAttribute{
-				Computed: true,
-				Description: "Running state of an Instance (primarily: booted or stopped)." +
-					" This typically reflects whether it's starting, running, stopping, or stopped," +
-					" but also includes states related to the instance's lifecycle.",
-			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,
 				Description: "Timestamp of when this instance was created.",
@@ -148,10 +140,6 @@ func (r *instanceResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 			"time_modified": schema.StringAttribute{
 				Computed:    true,
 				Description: "Timestamp of when this instance was last modified.",
-			},
-			"time_run_state_updated": schema.StringAttribute{
-				Computed:    true,
-				Description: "Timestamp of when the run state of this instance was last modified.",
 			},
 		},
 	}
@@ -254,12 +242,8 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(instance.Id)
-	plan.RunState = types.StringValue(string(instance.RunState))
 	plan.TimeCreated = types.StringValue(instance.TimeCreated.String())
 	plan.TimeModified = types.StringValue(instance.TimeCreated.String())
-	// TODO: Would it be problematic to have this reported? Likely changes randomly,
-	// could make for a flaky resource
-	plan.TimeRunStateUpdated = types.StringValue(instance.TimeRunStateUpdated.String())
 
 	// Save plan into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -306,11 +290,8 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 	state.Name = types.StringValue(string(instance.Name))
 	state.NCPUs = types.Int64Value(int64(instance.Ncpus))
 	state.ProjectID = types.StringValue(instance.ProjectId)
-	// Should this be something we have as part of the schema? likely to make for a buggy provider
-	state.RunState = types.StringValue(string(instance.RunState))
 	state.TimeCreated = types.StringValue(instance.TimeCreated.String())
 	state.TimeModified = types.StringValue(instance.TimeCreated.String())
-	state.TimeRunStateUpdated = types.StringValue(instance.TimeRunStateUpdated.String())
 
 	//state.AttachToDisks = TODO
 	//state.ExternalIPs = TODO

--- a/oxide/resource_instance_test.go
+++ b/oxide/resource_instance_test.go
@@ -81,11 +81,9 @@ func checkResourceInstance(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
 		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
-		resource.TestCheckResourceAttrSet(resourceName, "run_state"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-		resource.TestCheckResourceAttrSet(resourceName, "time_run_state_updated"),
 		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "1m"),
 		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
 		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
@@ -132,11 +130,9 @@ func checkResourceInstanceDisk(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.0", "terraform-acc-mydisk1"),
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.1", "terraform-acc-mydisk2"),
-		resource.TestCheckResourceAttrSet(resourceName, "run_state"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-		resource.TestCheckResourceAttrSet(resourceName, "time_run_state_updated"),
 	}...)
 }
 
@@ -163,11 +159,9 @@ func checkResourceInstanceExternalIps(resourceName string) resource.TestCheckFun
 		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttr(resourceName, "external_ips.0", "default"),
-		resource.TestCheckResourceAttrSet(resourceName, "run_state"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-		resource.TestCheckResourceAttrSet(resourceName, "time_run_state_updated"),
 	}...)
 }
 


### PR DESCRIPTION
Instance running state should not be part of provider as it may not reflect the reality.

Related: https://github.com/oxidecomputer/terraform-provider-oxide/issues/99