### PR TITLE
Remove any "under the hood" handling of resources

### DIFF
--- a/oxide/data_source_instance_external_ips_test.go
+++ b/oxide/data_source_instance_external_ips_test.go
@@ -29,6 +29,7 @@ resource "oxide_instance" "{{.InstanceBlockName}}" {
   host_name       = "terraform-acc-myhost"
   memory          = 1073741824
   ncpus           = 1
+  start_on_create = false
   external_ips    = ["default"]
 }
 

--- a/oxide/resource_instance.go
+++ b/oxide/resource_instance.go
@@ -234,9 +234,9 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 		}
 		ds := oxideSDK.InstanceDiskAttachment{
 			Name: oxideSDK.Name(diskName),
-			// TODO: For now we are only attaching. Verify if it makes sense to create
-			// as well. Probably not, there would be no way to delete that disk via
-			// TF
+			// We will only be attaching through terraform
+			// any disk creation should be done through
+			// the `oxide_disk` resource
 			Type: oxideSDK.InstanceDiskAttachmentTypeAttach,
 		}
 
@@ -397,19 +397,19 @@ func (r *instanceResource) Delete(ctx context.Context, req resource.DeleteReques
 		tflog.Trace(ctx, fmt.Sprintf("detached disk with ID: %v", disk.Id), map[string]any{"success": true})
 	}
 
-	// TODO: Double check if this is necessary
-	_, err = r.client.InstanceStop(oxideSDK.InstanceStopParams{
-		Instance: oxideSDK.NameOrId(state.ID.ValueString()),
-	})
-	if err != nil {
-		if !is404(err) {
-			resp.Diagnostics.AddError(
-				"Unable to stop instance:",
-				"API error: "+err.Error(),
-			)
-			return
-		}
-	}
+	// TODO: Double check if this is necessary, could be an optional feature?
+	//_, err = r.client.InstanceStop(oxideSDK.InstanceStopParams{
+	//	Instance: oxideSDK.NameOrId(state.ID.ValueString()),
+	//})
+	//if err != nil {
+	//	if !is404(err) {
+	//		resp.Diagnostics.AddError(
+	//			"Unable to stop instance:",
+	//			"API error: "+err.Error(),
+	//		)
+	//		return
+	//	}
+	//}
 
 	// TODO: Double check if this is necessary
 	// instance appears to stay in "stopping" state indefinitely
@@ -423,7 +423,7 @@ func (r *instanceResource) Delete(ctx context.Context, req resource.DeleteReques
 	//		)
 	//		return
 	//	}
-	tflog.Trace(ctx, fmt.Sprintf("stopped instance with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+	// tflog.Trace(ctx, fmt.Sprintf("stopped instance with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
 
 	if err := r.client.InstanceDelete(oxideSDK.InstanceDeleteParams{
 		Instance: oxideSDK.NameOrId(state.ID.ValueString()),

--- a/oxide/resource_instance_test.go
+++ b/oxide/resource_instance_test.go
@@ -69,6 +69,7 @@ resource "oxide_instance" "{{.BlockName}}" {
   host_name       = "terraform-acc-myhost"
   memory          = 1073741824
   ncpus           = 1
+  start_on_create = false
   external_ips    = ["default"]
   attach_to_disks = ["{{.DiskName}}", "{{.DiskName2}}"]
 }
@@ -172,7 +173,7 @@ func checkResourceInstanceFull(resourceName, instanceName, diskName, diskName2 s
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.0", diskName),
 		resource.TestCheckResourceAttr(resourceName, "attach_to_disks.1", diskName2),
 		resource.TestCheckResourceAttr(resourceName, "external_ips.0", "default"),
-		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "false"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),


### PR DESCRIPTION
Users will need to import all resources before deleting, no "magic" in the background should happen