### PR TITLE
Refine external IPs model

### DIFF
--- a/docs/resources/oxide_instance.md
+++ b/docs/resources/oxide_instance.md
@@ -48,7 +48,12 @@ resource "oxide_instance" "example" {
   memory          = 1073741824
   ncpus           = 1
   start_on_create = false
-  external_ips    = ["myippool"]
+  external_ips = [
+    {
+      ip_pool_name = "default"
+      type         = "ephemeral"
+    }
+  ]
 }
 ```
 
@@ -76,13 +81,13 @@ resource "oxide_instance" "example" {
 - `name` (String) Name of the instance.
 - `ncpus` (Number) Number of CPUs allocated for this instance.
 - `project_id` (String) ID of the project that will contain the instance.
-- `start_on_create` (Boolean, Default `true`) Starts the instance on creation when set to true.
 
 ### Optional
 
 - `disk_attachments` (Set of String, Optional) IDs of the disks to be attached to the instance.
-- `external_ips` (List of String, Optional) External IP addresses provided to this instance. List of IP pools from which to draw addresses.
+- `external_ips` (Set of Object, Optional) External IP addresses provided to this instance. List of IP pools from which to draw addresses. (see [below for nested schema](#nestedatt--ips))
 - `network_interfaces` (Set of Object, Optional) Virtual network interface devices attached to an instance. (see [below for nested schema](#nestedatt--nics))
+- `start_on_create` (Boolean, Default `true`) Starts the instance on creation when set to true.
 - `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
 - `user_data` (String) User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in [RFC 4648 § 4](https://datatracker.ietf.org/doc/html/rfc4648#section-4) (+ and / characters with padding). Maximum 32 KiB unencoded data.
 
@@ -91,6 +96,15 @@ resource "oxide_instance" "example" {
 - `id` (String) Unique, immutable, system-controlled identifier of the instance.
 - `time_created` (String) Timestamp of when this instance was created.
 - `time_modified` (String) Timestamp of when this instance last modified.
+
+<a id="nestedatt--ips"></a>
+
+### Nested Schema for `external_ips`
+
+### Optional
+
+- `ip_pool_name` (String, Default `"default"`) Name of the IP pool to retrieve addresses from..
+- `type` (String, Default `"ephemeral"`) Type of external IP. Currently, only `ephemeral` is supported.
 
 <a id="nestedatt--nics"></a>
 

--- a/examples/instance_resource_ips/instance.tf
+++ b/examples/instance_resource_ips/instance.tf
@@ -20,5 +20,9 @@ resource "oxide_instance" "example" {
   host_name         = "myhost"
   memory            = 1073741824
   ncpus             = 1
-  external_ips      = ["mypool"]
+  external_ips      = [
+    {
+      ip_pool_name = "default"
+    }
+  ]
 }

--- a/internal/provider/data_source_instance_external_ips.go
+++ b/internal/provider/data_source_instance_external_ips.go
@@ -31,14 +31,14 @@ type instanceExternalIPsDataSource struct {
 	client *oxide.Client
 }
 
-type instanceExternalIPsModel struct {
-	ID          types.String      `tfsdk:"id"`
-	InstanceID  types.String      `tfsdk:"instance_id"`
-	Timeouts    timeouts.Value    `tfsdk:"timeouts"`
-	ExternalIPs []externalIPModel `tfsdk:"external_ips"`
+type instanceExternalIPsDatasourceModel struct {
+	ID          types.String                `tfsdk:"id"`
+	InstanceID  types.String                `tfsdk:"instance_id"`
+	Timeouts    timeouts.Value              `tfsdk:"timeouts"`
+	ExternalIPs []externalIPDatasourceModel `tfsdk:"external_ips"`
 }
 
-type externalIPModel struct {
+type externalIPDatasourceModel struct {
 	IP   types.String `tfsdk:"ip"`
 	Kind types.String `tfsdk:"kind"`
 }
@@ -87,7 +87,7 @@ func (d *instanceExternalIPsDataSource) Schema(ctx context.Context, req datasour
 }
 
 func (d *instanceExternalIPsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var state instanceExternalIPsModel
+	var state instanceExternalIPsDatasourceModel
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
@@ -123,7 +123,7 @@ func (d *instanceExternalIPsDataSource) Read(ctx context.Context, req datasource
 
 	// Map response body to model
 	for _, ip := range ips.Items {
-		externalIPState := externalIPModel{
+		externalIPState := externalIPDatasourceModel{
 			IP:   types.StringValue(ip.Ip),
 			Kind: types.StringValue(string(ip.Kind)),
 		}

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -130,7 +130,7 @@ resource "oxide_instance" "{{.BlockName}}" {
   memory          = 1073741824
   ncpus           = 1
   start_on_create = false
-  external_ips    = ["default"]
+  external_ips    = [{}]
 }
 `
 


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/159

This commit future proofs the instance resource so that when static IPs are available, they will be able to be defined without making breaking changes to the schema.