### PR TITLE
Add codeowners file and edit release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @karencfv @augustuswm @inickles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Adding a new CODEOWNERS file to increase our release GPG key security. I'm also adding @augustuswm and @inickles so that I am not the sole "codeowner"