### PR TITLE
Implement `oxide_ssh_key` resource and data source

### DIFF
--- a/docs/data-sources/oxide_ssh_key.md
+++ b/docs/data-sources/oxide_ssh_key.md
@@ -1,0 +1,45 @@
+---
+page_title: "oxide_ssh_key Data Source - terraform-provider-oxide"
+---
+
+# oxide_ssh_key (Data Source)
+
+Retrieve information about a specified SSH key.
+
+## Example Usage
+
+```hcl
+data "oxide_ssh_key" "example" {
+  name = "example"
+  timeouts = {
+    read = "1m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the SSH key.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the SSH key.
+- `description` (String) Description for the SSH key.
+- `public_key` (String) The SSH public key (e.g., `ssh-ed25519 AAAAC3NzaC...`).
+- `silo_user_id` (String) The ID of the user to whom this SSH key belongs.
+- `time_created` (String) Timestamp of when this SSH key was created.
+- `time_modified` (String) Timestamp of when this SSH key was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `read` (String, Default `10m`)

--- a/docs/resources/oxide_ssh_key.md
+++ b/docs/resources/oxide_ssh_key.md
@@ -1,0 +1,50 @@
+---
+page_title: "oxide_ssh_key Resource - terraform-provider-oxide"
+---
+
+# oxide_ssh_key (Resource)
+
+This resource manages SSH keys.
+
+## Example Usage
+
+```hcl
+resource "oxide_ssh_key" "example" {
+  name        = "example"
+  description = "Example SSH key."
+  public_key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1clIQrzlQNqxgvpCCUFFOcTTFDOaqV+aocfsDZvxqB"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the SSH key. Names must begin with a lower case ASCII
+  letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers,
+  and `-`, and may not end with a `-`. Names cannot be a UUID though they may
+  contain a UUID.
+- `description` (String) Description for the SSH key.
+- `public_key` (String) The SSH public key (e.g., `ssh-ed25519 AAAAC3NzaC...`).
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the SSH key.
+- `silo_user_id` (String) The ID of the user to whom this SSH key belongs.
+- `time_created` (String) Timestamp of when this SSH key was created.
+- `time_modified` (String) Timestamp of when this SSH key was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String, Default `10m`)
+- `delete` (String, Default `10m`)
+- `read` (String, Default `10m`)
+- `update` (String, Default `10m`)

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var (
+	_ datasource.DataSource              = (*sshKeyDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*sshKeyDataSource)(nil)
+)
+
+// NewSSHKeyDataSource is a helper function to simplify the provider implementation.
+func NewSSHKeyDataSource() datasource.DataSource {
+	return &sshKeyDataSource{}
+}
+
+// sshKeyDataSource is the data source implementation.
+type sshKeyDataSource struct {
+	client *oxide.Client
+}
+
+// sshKeyDataSourceModel are the attributes that are supported on this data source.
+type sshKeyDataSourceModel struct {
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	Description  types.String   `tfsdk:"description"`
+	PublicKey    types.String   `tfsdk:"public_key"`
+	SiloUserID   types.String   `tfsdk:"silo_user_id"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Metadata sets the resource type name.
+func (d *sshKeyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "oxide_ssh_key"
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *sshKeyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.client = req.ProviderData.(*oxide.Client)
+}
+
+// Schema defines the schema for the data source.
+func (d *sshKeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the SSH key.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the SSH key.",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Description for the SSH key.",
+			},
+			"public_key": schema.StringAttribute{
+				Computed:    true,
+				Description: "Public SSH key.",
+			},
+			"silo_user_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "User ID that owns this SSH key.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SSH key was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SSH key was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx),
+		},
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *sshKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state sshKeyDataSourceModel
+
+	// Read Terraform configuration data into the model.
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	sshKey, err := d.client.CurrentUserSshKeyView(oxide.CurrentUserSshKeyViewParams{
+		SshKey: oxide.NameOrId(state.Name.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read SSH key:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read SSH key with ID: %v", sshKey.Id), map[string]any{"success": true})
+
+	state.ID = types.StringValue(sshKey.Id)
+	state.Name = types.StringValue(string(sshKey.Name))
+	state.Description = types.StringValue(sshKey.Description)
+	state.PublicKey = types.StringValue(string(sshKey.PublicKey))
+	state.SiloUserID = types.StringValue(string(sshKey.SiloUserId))
+	state.TimeCreated = types.StringValue(sshKey.TimeCreated.String())
+	state.TimeModified = types.StringValue(sshKey.TimeModified.String())
+
+	// Save retrieved state into Terraform state.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/data_source_ssh_key_test.go
+++ b/internal/provider/data_source_ssh_key_test.go
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type dataSourceSSHKeyConfig struct {
+	BlockName string
+	Name      string
+}
+
+var dataSourceSSHKeyConfigTpl = `
+data "oxide_ssh_key" "{{.BlockName}}" {
+  name = "{{.Name}}"
+  timeouts = {
+    read = "1m"
+  }
+}
+`
+
+func TestAccDataSourceSSHKey_full(t *testing.T) {
+	blockName := newBlockName("datasource-ssh-key")
+	sshKeyName := newResourceName()
+	config, err := parsedAccConfig(
+		dataSourceSSHKeyConfig{
+			BlockName: blockName,
+			Name:      sshKeyName,
+		},
+		dataSourceSSHKeyConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkDataSourceSSHKey(
+					fmt.Sprintf("data.oxide_ssh_key.%s", blockName),
+					sshKeyName,
+				),
+			},
+		},
+	})
+}
+
+func checkDataSourceSSHKey(dataName string, resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(dataName, "id"),
+		resource.TestCheckResourceAttr(dataName, "name", resourceName),
+		resource.TestCheckResourceAttr(dataName, "description", ""),
+		resource.TestCheckResourceAttrSet(dataName, "public_key"),
+		resource.TestCheckResourceAttrSet(dataName, "silo_user_id"),
+		resource.TestCheckResourceAttrSet(dataName, "time_created"),
+		resource.TestCheckResourceAttrSet(dataName, "time_modified"),
+		resource.TestCheckResourceAttr(dataName, "timeouts.read", "1m"),
+	}...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -144,6 +144,7 @@ func (p *oxideProvider) Resources(_ context.Context) []func() resource.Resource 
 		NewInstanceResource,
 		NewProjectResource,
 		NewSnapshotResource,
+		NewSSHKeyResource,
 		NewVPCResource,
 		NewVPCSubnetResource,
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -131,6 +131,7 @@ func (p *oxideProvider) DataSources(_ context.Context) []func() datasource.DataS
 		NewInstanceExternalIPsDataSource,
 		NewProjectDataSource,
 		NewProjectsDataSource,
+		NewSSHKeyDataSource,
 		NewVPCDataSource,
 		NewVPCSubnetDataSource,
 	}

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -222,6 +222,10 @@ func (r *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 // attributes. If an update API is created in the future this method should be
 // implemented.
 func (r *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Error updating SSH key",
+		"the oxide API currently does not support updating SSH keys",
+	)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -1,0 +1,257 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource              = (*sshKeyResource)(nil)
+	_ resource.ResourceWithConfigure = (*sshKeyResource)(nil)
+)
+
+// NewSSHKeyResource is a helper function to simplify the provider implementation.
+func NewSSHKeyResource() resource.Resource {
+	return &sshKeyResource{}
+}
+
+// sshKeyResource is the resource implementation.
+type sshKeyResource struct {
+	client *oxide.Client
+}
+
+// sshKeyResourceModel are the attributes that are supported on this resource.
+type sshKeyResourceModel struct {
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	Description  types.String   `tfsdk:"description"`
+	PublicKey    types.String   `tfsdk:"public_key"`
+	SiloUserID   types.String   `tfsdk:"silo_user_id"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Metadata sets the resource type name.
+func (r *sshKeyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "oxide_ssh_key"
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *sshKeyResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*oxide.Client)
+}
+
+// ImportState configures the resource to be imported by its ID.
+func (r *sshKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Schema defines the schema for the resource.
+func (r *sshKeyResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the SSH key.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the SSH key.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Description for the SSH key.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"public_key": schema.StringAttribute{
+				Required:    true,
+				Description: "Public SSH key.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"silo_user_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "User ID that owns this SSH key.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SSH key was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SSH key was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan sshKeyResourceModel
+
+	// Read Terraform plan data into the model.
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	params := oxide.CurrentUserSshKeyCreateParams{
+		Body: &oxide.SshKeyCreate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+			PublicKey:   plan.PublicKey.ValueString(),
+		},
+	}
+
+	sshKey, err := r.client.CurrentUserSshKeyCreate(params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating SSH key",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("created SSH key with ID: %v", sshKey.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate computed attribute values.
+	plan.ID = types.StringValue(sshKey.Id)
+	plan.SiloUserID = types.StringValue(sshKey.SiloUserId)
+	plan.TimeCreated = types.StringValue(sshKey.TimeCreated.String())
+	plan.TimeModified = types.StringValue(sshKey.TimeModified.String())
+
+	// Save plan into Terraform state.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state sshKeyResourceModel
+
+	// Read Terraform prior state data into the model.
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	sshKey, err := r.client.CurrentUserSshKeyView(oxide.CurrentUserSshKeyViewParams{
+		SshKey: oxide.NameOrId(state.ID.ValueString()),
+	})
+	if err != nil {
+		if is404(err) {
+			// Remove resource from state during a refresh
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to read SSH key:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read SSH key with ID: %v", sshKey.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(sshKey.Description)
+	state.ID = types.StringValue(sshKey.Id)
+	state.Name = types.StringValue(string(sshKey.Name))
+	state.PublicKey = types.StringValue(string(sshKey.PublicKey))
+	state.SiloUserID = types.StringValue(string(sshKey.SiloUserId))
+	state.TimeCreated = types.StringValue(sshKey.TimeCreated.String())
+	state.TimeModified = types.StringValue(sshKey.TimeModified.String())
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update is intentionally unimplemented since SSH keys do not have an update
+// API. All of its configurable attributes are marked as requiring replacement
+// to tell Terraform to destroy and create this resource upon change to its
+// attributes. If an update API is created in the future this method should be
+// implemented.
+func (r *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *sshKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state sshKeyResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	_, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	if err := r.client.CurrentUserSshKeyDelete(oxide.CurrentUserSshKeyDeleteParams{
+		SshKey: oxide.NameOrId(state.ID.ValueString()),
+	}); err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Error deleting SSH key:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted SSH key with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+}

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+type resourceSSHKeyConfig struct {
+	BlockName   string
+	Name        string
+	Description string
+	PublicKey   string
+}
+
+var resourceSSHKeyConfigTpl = `
+resource "oxide_ssh_key" "{{.BlockName}}" {
+  name        = "{{.Name}}"
+  description = "{{.Description}}"
+  public_key  = "{{.PublicKey}}"
+  timeouts = {
+    read   = "1m"
+    create = "3m"
+    delete = "2m"
+    update = "4m"
+  }
+}
+`
+
+var resourceSSHKeyUpdateConfigTpl = `
+resource "oxide_ssh_key" "{{.BlockName}}" {
+  name        = "{{.Name}}"
+  description = "{{.Description}}"
+  public_key  = "{{.PublicKey}}"
+  timeouts = {
+    read   = "1m"
+    create = "3m"
+    delete = "2m"
+    update = "4m"
+  }
+}
+`
+
+func TestAccResourceSSHKey_full(t *testing.T) {
+	sshKeyName := newResourceName()
+	description := "An SSH key."
+	publicKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1clIQrzlQNqxgvpCCUFFOcTTFDOaqV+aocfsDZvxqB"
+	blockName := newBlockName("ssh_key")
+	resourceName := fmt.Sprintf("oxide_ssh_key.%s", blockName)
+	config, err := parsedAccConfig(
+		resourceSSHKeyConfig{
+			BlockName:   blockName,
+			Name:        sshKeyName,
+			Description: description,
+			PublicKey:   publicKey,
+		},
+		resourceSSHKeyConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	sshKeyNameUpdated := sshKeyName + "-updated"
+	configUpdate, err := parsedAccConfig(
+		resourceSSHKeyConfig{
+			BlockName:   blockName,
+			Name:        sshKeyNameUpdated,
+			Description: description,
+			PublicKey:   publicKey,
+		},
+		resourceSSHKeyUpdateConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  checkResourceSSHKey(resourceName, sshKeyName),
+			},
+			{
+				Config: configUpdate,
+				Check:  checkResourceSSHKeyUpdate(resourceName, sshKeyNameUpdated),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func checkResourceSSHKey(resourceName, sshKeyName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "name", sshKeyName),
+		resource.TestCheckResourceAttr(resourceName, "description", "An SSH Key."),
+		resource.TestCheckResourceAttr(resourceName, "public_key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1clIQrzlQNqxgvpCCUFFOcTTFDOaqV+aocfsDZvxqB"),
+		resource.TestCheckResourceAttrSet(resourceName, "silo_user_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "1m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "4m"),
+	}...)
+}
+
+func checkResourceSSHKeyUpdate(resourceName, sshKeyName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "name", sshKeyName),
+		resource.TestCheckResourceAttr(resourceName, "description", "An updated SSH key."),
+		resource.TestCheckResourceAttr(resourceName, "public_key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1clIQrzlQNqxgvpCCUFFOcTTFDOaqV+aocfsDZvxqB"),
+		resource.TestCheckResourceAttrSet(resourceName, "silo_user_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccSSHKeyDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_ssh_key" {
+			continue
+		}
+
+		params := oxide.CurrentUserSshKeyViewParams{
+			SshKey: oxide.NameOrId(rs.Primary.Attributes["id"]),
+		}
+		res, err := client.CurrentUserSshKeyView(params)
+		if err != nil && is404(err) {
+			continue
+		}
+
+		return fmt.Errorf("ssh key (%v) still exists", &res.Name)
+	}
+
+	return nil
+}

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -34,20 +34,6 @@ resource "oxide_ssh_key" "{{.BlockName}}" {
 }
 `
 
-var resourceSSHKeyUpdateConfigTpl = `
-resource "oxide_ssh_key" "{{.BlockName}}" {
-  name        = "{{.Name}}"
-  description = "{{.Description}}"
-  public_key  = "{{.PublicKey}}"
-  timeouts = {
-    read   = "1m"
-    create = "3m"
-    delete = "2m"
-    update = "4m"
-  }
-}
-`
-
 func TestAccResourceSSHKey_full(t *testing.T) {
 	sshKeyName := newResourceName()
 	description := "An SSH key."

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -67,20 +67,6 @@ func TestAccResourceSSHKey_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	sshKeyNameUpdated := sshKeyName + "-updated"
-	configUpdate, err := parsedAccConfig(
-		resourceSSHKeyConfig{
-			BlockName:   blockName,
-			Name:        sshKeyNameUpdated,
-			Description: description,
-			PublicKey:   publicKey,
-		},
-		resourceSSHKeyUpdateConfigTpl,
-	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -89,10 +75,6 @@ func TestAccResourceSSHKey_full(t *testing.T) {
 			{
 				Config: config,
 				Check:  checkResourceSSHKey(resourceName, sshKeyName),
-			},
-			{
-				Config: configUpdate,
-				Check:  checkResourceSSHKeyUpdate(resourceName, sshKeyNameUpdated),
 			},
 			{
 				ResourceName:      resourceName,
@@ -116,18 +98,6 @@ func checkResourceSSHKey(resourceName, sshKeyName string) resource.TestCheckFunc
 		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
 		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
 		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "4m"),
-	}...)
-}
-
-func checkResourceSSHKeyUpdate(resourceName, sshKeyName string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
-		resource.TestCheckResourceAttrSet(resourceName, "id"),
-		resource.TestCheckResourceAttr(resourceName, "name", sshKeyName),
-		resource.TestCheckResourceAttr(resourceName, "description", "An updated SSH key."),
-		resource.TestCheckResourceAttr(resourceName, "public_key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1clIQrzlQNqxgvpCCUFFOcTTFDOaqV+aocfsDZvxqB"),
-		resource.TestCheckResourceAttrSet(resourceName, "silo_user_id"),
-		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
-		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
 	}...)
 }
 


### PR DESCRIPTION
This pull request implements a new `oxide_ssh_key` resource and data source.

When I was using an Oxide rack with Terraform a few weeks ago I noticed that there was no support for an SSH key resource. Instead, I had to manually create an SSH key either using the UI, API, or CLI.