### PR TITLE
Automatically remove system created VPC and subnet when deleting projects and VPCs

### DIFF
--- a/.changelog/0.1.0.toml
+++ b/.changelog/0.1.0.toml
@@ -21,3 +21,7 @@ description = "Image creation via URL is no longer supported [#228](https://gith
 [[enhancements]]
 title = "Image resource"
 description = "Deletes are now supported [#228](https://github.com/oxidecomputer/terraform-provider-oxide/pull/228)"
+
+[[enhancements]]
+title = "VPC and project resources"
+description = "System created default VPCs and subnets are now removed automatically when deleting a VPC or project [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"

--- a/.changelog/0.1.0.toml
+++ b/.changelog/0.1.0.toml
@@ -24,4 +24,4 @@ description = "Deletes are now supported [#228](https://github.com/oxidecomputer
 
 [[enhancements]]
 title = "VPC and project resources"
-description = "System created default VPCs and subnets are now removed automatically when deleting a VPC or project [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"
+description = "System created default VPCs and subnets are now removed automatically when deleting a VPC or project [#229](https://github.com/oxidecomputer/terraform-provider-oxide/pull/229)"

--- a/docs/resources/oxide_project.md
+++ b/docs/resources/oxide_project.md
@@ -6,8 +6,6 @@ page_title: "oxide_project Resource - terraform-provider-oxide"
 
 This resource manages projects.
 
-!> A default VPC is created within each project. Before deleting a project, this VPC must be removed.
-
 ## Example Usage
 
 ```hcl

--- a/docs/resources/oxide_vpc.md
+++ b/docs/resources/oxide_vpc.md
@@ -6,8 +6,6 @@ page_title: "oxide_vpc Resource - terraform-provider-oxide"
 
 This resource manages VPCs.
 
-!> A default subnet is created within each VPC. Before deleting a VPC, this subnet must be removed.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/224