### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = ">= 0.1.0-beta"
+      version = "0.1.0-beta"
     }
   }
 }


### PR DESCRIPTION
Updated the oxide provider definition in the example.  The greater-than-or-equal on the oxide provider definition causes the terraform init to fail with a "Error: Failed to query available provider packages" at this time.  Updating the example.  This may change as new versions are released.