### PR TITLE
Do not support empty arrays for filters

### DIFF
--- a/.changelog/0.4.0.toml
+++ b/.changelog/0.4.0.toml
@@ -1,3 +1,3 @@
 [[breaking]]
 title = "`oxide_vpc_firewall_rules` resource"
-description = "Setting an empty array for `filters.hosts`, `filters.ports` and `filters.protocols` is no longer supported. To omit they must be unset. [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"
+description = "Setting an empty array for `filters.hosts`, `filters.ports` and `filters.protocols` is no longer supported. To omit they must be unset. [#322](https://github.com/oxidecomputer/terraform-provider-oxide/pull/322)"

--- a/.changelog/0.4.0.toml
+++ b/.changelog/0.4.0.toml
@@ -1,0 +1,3 @@
+[[breaking]]
+title = "`oxide_vpc_firewall_rules` resource"
+description = "Setting an empty array for `filters.hosts`, `filters.ports` and `filters.protocols` is no longer supported. To omit they must be unset. [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"

--- a/internal/provider/resource_vpc_firewall_rules_test.go
+++ b/internal/provider/resource_vpc_firewall_rules_test.go
@@ -75,8 +75,6 @@ resource "oxide_vpc_firewall_rules" "{{.BlockName}}" {
 				value = oxide_vpc.{{.SupportBlockName2}}.name
 			 }
 		   ]
-		   ports = []
-		   protocols = []
 		 }
 		 targets = [
 		   {
@@ -118,12 +116,6 @@ resource "oxide_vpc_firewall_rules" "{{.BlockName}}" {
 		 priority = 50
 		 status = "enabled"
 		 filters = {
-		   hosts = [
-			 {
-				type = "vpc"
-				value = oxide_vpc.{{.SupportBlockName2}}.name
-			 }
-		   ]
 		   ports = ["8123"]
 		   protocols = ["ICMP"]
 		 },
@@ -237,7 +229,7 @@ func TestAccCloudResourceFirewallRules_full(t *testing.T) {
 			},
 			{
 				Config: configUpdate,
-				Check:  checkResourceFirewallRulesUpdate(resourceName, vpcName),
+				Check:  checkResourceFirewallRulesUpdate(resourceName),
 			},
 			{
 				Config: configUpdate2,
@@ -285,15 +277,15 @@ func checkResourceFirewallRules(resourceName, vpcName string) resource.TestCheck
 	}...)
 }
 
-func checkResourceFirewallRulesUpdate(resourceName, vpcName string) resource.TestCheckFunc {
+func checkResourceFirewallRulesUpdate(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.action", "deny"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.description", "custom deny"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.direction", "inbound"),
-		resource.TestCheckResourceAttr(resourceName, "rules.0.filters.hosts.0.type", "vpc"),
-		resource.TestCheckResourceAttr(resourceName, "rules.0.filters.hosts.0.value", vpcName),
+		resource.TestCheckNoResourceAttr(resourceName, "rules.0.filters.hosts.0.type"),
+		resource.TestCheckNoResourceAttr(resourceName, "rules.0.filters.hosts.0.value"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.filters.ports.0", "8123"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.filters.protocols.0", "ICMP"),
 		resource.TestCheckResourceAttrSet(resourceName, "rules.0.id"),


### PR DESCRIPTION
This commit makes it possible to omit `filters.hosts`, `filters.ports` and `filters.protocols` for each firewall rule.

Unfortunately, a side effect of this change is that setting these attributes as empty arrays will no longer be supported. Initially, I intended to keep both but there are a few Terraform quirks that make this non-viable:

- Terraform differentiates between empty and nil, this means that I can't just set one or the other fully.
- I can't use a plan modifier to make Terraform believe null is the same as empty and correctly apply the plan without errors, but will always report a plan change when running `terraform plan`.
- I can't use a default value of empty array on nil, for the same reason as above.
- Sets are unordered lists, so I can't just copy values in order from the plan onto the state, the only immutable identifiers are the `id` attribute, but that is only known after applying the plan.

Running acceptance tests against the colo rack
```console
$ TEST_ACC_NAME=TestAccCloudResourceFirewallRules_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceFirewallRules_full
=== PAUSE TestAccCloudResourceFirewallRules_full
=== CONT  TestAccCloudResourceFirewallRules_full
--- PASS: TestAccCloudResourceFirewallRules_full (10.72s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	10.726s
```

Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/321 