### PR TITLE
Bump go SDK to v0.1.0-beta7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
-	github.com/oxidecomputer/oxide.go v0.1.0-beta6.0.20240701000921-06dd780c95ec
+	github.com/oxidecomputer/oxide.go v0.1.0-beta7
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.1.0-beta6.0.20240701000921-06dd780c95ec h1:EoMd7j9Ke0n03fLPVxjB7ZqCnQOLSh7Mx7t4PjJfIBw=
-github.com/oxidecomputer/oxide.go v0.1.0-beta6.0.20240701000921-06dd780c95ec/go.mod h1:C0a0iGDvSArabJb8uXZozVt1IHFAA/aGFcS4Ow3wwgo=
+github.com/oxidecomputer/oxide.go v0.1.0-beta7 h1:GLtwzTfe8xfcYQgEU+xIkdGRj/QLW+MWrO+KdG8ygM0=
+github.com/oxidecomputer/oxide.go v0.1.0-beta7/go.mod h1:btQiCyedDddzFCn9IrhAgT23zb/lvlA67GRisFA/agc=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Ran acceptance tests manually against colo rack

```console
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceImage_full
=== PAUSE TestAccCloudDataSourceImage_full
=== RUN   TestAccCloudDataSourceImages_project
=== PAUSE TestAccCloudDataSourceImages_project
=== RUN   TestAccCloudDataSourceImages_silo
=== PAUSE TestAccCloudDataSourceImages_silo
=== RUN   TestAccCloudDataSourceInstanceExternalIPs_full
=== PAUSE TestAccCloudDataSourceInstanceExternalIPs_full
=== RUN   TestAccCloudDataSourceProject_full
=== PAUSE TestAccCloudDataSourceProject_full
=== RUN   TestAccCloudDataSourceProjects_full
=== PAUSE TestAccCloudDataSourceProjects_full
=== RUN   TestAccCloudDataSourceSSHKey_full
=== PAUSE TestAccCloudDataSourceSSHKey_full
=== RUN   TestAccCloudDataSourceVPCSubnet_full
=== PAUSE TestAccCloudDataSourceVPCSubnet_full
=== RUN   TestAccCloudDataSourceVPC_full
=== PAUSE TestAccCloudDataSourceVPC_full
=== RUN   TestAccCloudResourceDisk_full
=== PAUSE TestAccCloudResourceDisk_full
=== RUN   TestAccCloudResourceImage_full
=== PAUSE TestAccCloudResourceImage_full
=== RUN   TestAccCloudResourceInstance_full
=== PAUSE TestAccCloudResourceInstance_full
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== RUN   TestAccCloudResourceInstance_sshKeys
=== PAUSE TestAccCloudResourceInstance_sshKeys
=== RUN   TestAccCloudResourceInstance_nic
=== PAUSE TestAccCloudResourceInstance_nic
=== RUN   TestAccCloudResourceInstance_disk
=== PAUSE TestAccCloudResourceInstance_disk
=== RUN   TestAccCloudResourceProject_full
=== PAUSE TestAccCloudResourceProject_full
=== RUN   TestAccCloudResourceSnapshot_full
=== PAUSE TestAccCloudResourceSnapshot_full
=== RUN   TestAccCloudResourceSSHKey_full
=== PAUSE TestAccCloudResourceSSHKey_full
=== RUN   TestAccCloudResourceFirewallRules_full
=== PAUSE TestAccCloudResourceFirewallRules_full
=== RUN   TestAccCloudResourceVPCSubnet_full
=== PAUSE TestAccCloudResourceVPCSubnet_full
=== RUN   TestAccCloudResourceVPC_full
=== PAUSE TestAccCloudResourceVPC_full
=== CONT  TestAccCloudDataSourceImage_full
=== CONT  TestAccCloudResourceVPCSubnet_full
=== CONT  TestAccCloudResourceVPC_full
=== CONT  TestAccCloudDataSourceProjects_full
=== CONT  TestAccCloudResourceImage_full
=== CONT  TestAccCloudResourceFirewallRules_full
--- PASS: TestAccCloudDataSourceProjects_full (1.69s)
=== CONT  TestAccCloudResourceSSHKey_full
--- PASS: TestAccCloudResourceSSHKey_full (1.75s)
=== CONT  TestAccCloudResourceSnapshot_full
--- PASS: TestAccCloudDataSourceImage_full (3.55s)
=== CONT  TestAccCloudResourceProject_full
--- PASS: TestAccCloudResourceProject_full (4.01s)
=== CONT  TestAccCloudResourceInstance_disk
--- PASS: TestAccCloudResourceVPC_full (9.07s)
=== CONT  TestAccCloudResourceInstance_nic
--- PASS: TestAccCloudResourceImage_full (10.76s)
=== CONT  TestAccCloudResourceInstance_sshKeys
--- PASS: TestAccCloudResourceFirewallRules_full (11.07s)
=== CONT  TestAccCloudResourceInstance_extIPs
--- PASS: TestAccCloudResourceVPCSubnet_full (11.26s)
=== CONT  TestAccCloudResourceInstance_full
--- PASS: TestAccCloudResourceSnapshot_full (8.81s)
=== CONT  TestAccCloudDataSourceInstanceExternalIPs_full
--- PASS: TestAccCloudResourceInstance_sshKeys (8.35s)
=== CONT  TestAccCloudDataSourceProject_full
--- PASS: TestAccCloudDataSourceProject_full (1.03s)
=== CONT  TestAccCloudDataSourceVPC_full
--- PASS: TestAccCloudResourceInstance_extIPs (9.16s)
=== CONT  TestAccCloudResourceDisk_full
--- PASS: TestAccCloudDataSourceInstanceExternalIPs_full (8.82s)
=== CONT  TestAccCloudDataSourceImages_silo
--- PASS: TestAccCloudDataSourceVPC_full (1.20s)
=== CONT  TestAccCloudDataSourceImages_project
--- PASS: TestAccCloudDataSourceImages_silo (1.09s)
=== CONT  TestAccCloudDataSourceVPCSubnet_full
--- PASS: TestAccCloudDataSourceImages_project (2.12s)
=== CONT  TestAccCloudDataSourceSSHKey_full
--- PASS: TestAccCloudDataSourceVPCSubnet_full (1.44s)
--- PASS: TestAccCloudResourceDisk_full (4.49s)
--- PASS: TestAccCloudDataSourceSSHKey_full (2.41s)
--- PASS: TestAccCloudResourceInstance_nic (23.60s)
--- PASS: TestAccCloudResourceInstance_disk (31.92s)
--- PASS: TestAccCloudResourceInstance_full (29.24s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	40.518s

```