### PR TITLE
IP pools resource

### DIFF
--- a/.changelog/0.4.0.toml
+++ b/.changelog/0.4.0.toml
@@ -4,4 +4,4 @@ description = "Setting an empty array for `filters.hosts`, `filters.ports` and `
 
 [[features]]
 title = "New resource"
-description = "`oxide_ip_pool` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"
+description = "`oxide_ip_pool` [#337](https://github.com/oxidecomputer/terraform-provider-oxide/pull/337)"

--- a/.changelog/0.4.0.toml
+++ b/.changelog/0.4.0.toml
@@ -1,3 +1,7 @@
 [[breaking]]
 title = "`oxide_vpc_firewall_rules` resource"
 description = "Setting an empty array for `filters.hosts`, `filters.ports` and `filters.protocols` is no longer supported. To omit they must be unset. [#322](https://github.com/oxidecomputer/terraform-provider-oxide/pull/322)"
+
+[[features]]
+title = "New resource"
+description = "`oxide_ip_pool` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"

--- a/docs/resources/oxide_ip_pool.md
+++ b/docs/resources/oxide_ip_pool.md
@@ -1,0 +1,71 @@
+---
+page_title: "oxide_ip_pool Resource - terraform-provider-oxide"
+---
+
+# oxide_ip_pool (Resource)
+
+This resource manages IP pools.
+
+## Example Usage
+
+```hcl
+resource "oxide_ip_pool" "example" {
+  description = "a test IP pool"
+  name        = "myippool"
+  ranges = [
+    {
+      first_address = "172.20.18.227"
+      last_address  = "172.20.18.239"
+    }
+  ]
+  timeouts = {
+    read   = "1m"
+    create = "3m"
+    delete = "2m"
+    update = "2m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `description` (String) Description for the IP pool.
+- `name` (String) Name of the IP pool.
+
+### Optional
+
+- `ranges` (List of Object, Optional) Adds IP ranges to the created IP pool. Can be IPv4 or IPv6. (see [below for nested schema](#nestedblock--ranges))
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the IP pool.
+- `time_created` (String) Timestamp of when this IP pool was created.
+- `time_modified` (String) Timestamp of when this IP pool was last modified.
+
+<a id="nestedblock--ranges"></a>
+
+### Nested Schema for `ranges`
+
+Required:
+
+- `first_address` (String) First address in the range.
+- `last_address` (String) Last address in the range.
+
+Read-Only:
+
+- `id` (String) Unique, immutable, system-controlled identifier.
+- `time_created` (String) Timestamp of when this range was added to the IP pool.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String, Default `10m`)
+- `delete` (String, Default `10m`)
+- `read` (String, Default `10m`)
+- `update` (String, Default `10m`)

--- a/docs/resources/oxide_ip_pool.md
+++ b/docs/resources/oxide_ip_pool.md
@@ -36,7 +36,7 @@ resource "oxide_ip_pool" "example" {
 
 ### Optional
 
-- `ranges` (List of Object, Optional) Adds IP ranges to the created IP pool. Can be IPv4 or IPv6. (see [below for nested schema](#nestedblock--ranges))
+- `ranges` (List of Object, Optional) Adds IP ranges to the created IP pool. (see [below for nested schema](#nestedblock--ranges))
 - `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -53,11 +53,6 @@ Required:
 
 - `first_address` (String) First address in the range.
 - `last_address` (String) Last address in the range.
-
-Read-Only:
-
-- `id` (String) Unique, immutable, system-controlled identifier.
-- `time_created` (String) Timestamp of when this range was added to the IP pool.
 
 <a id="nestedatt--timeouts"></a>
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -149,6 +149,7 @@ func (p *oxideProvider) Resources(_ context.Context) []func() resource.Resource 
 		NewDiskResource,
 		NewImageResource,
 		NewInstanceResource,
+		NewIPPoolResource,
 		NewProjectResource,
 		NewSnapshotResource,
 		NewSSHKeyResource,

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -1,0 +1,575 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+	oxideSDK "github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource              = (*ipPoolResource)(nil)
+	_ resource.ResourceWithConfigure = (*ipPoolResource)(nil)
+)
+
+// NewIPPoolResource is a helper function to simplify the provider implementation.
+func NewIPPoolResource() resource.Resource {
+	return &ipPoolResource{}
+}
+
+// ipPoolResource is the resource implementation.
+type ipPoolResource struct {
+	client *oxideSDK.Client
+}
+
+type ipPoolResourceModel struct {
+	Description  types.String               `tfsdk:"description"`
+	ID           types.String               `tfsdk:"id"`
+	Name         types.String               `tfsdk:"name"`
+	Ranges       []ipPoolResourceRangeModel `tfsdk:"ranges"`
+	TimeCreated  types.String               `tfsdk:"time_created"`
+	TimeModified types.String               `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value             `tfsdk:"timeouts"`
+}
+
+type ipPoolResourceRangeModel struct {
+	FirstAddress types.String `tfsdk:"first_address"`
+	LastAddress  types.String `tfsdk:"last_address"`
+	// ID           types.String `tfsdk:"id"`
+	// TimeCreated  types.String `tfsdk:"time_created"`
+}
+
+// Metadata returns the resource type name.
+func (r *ipPoolResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "oxide_ip_pool"
+}
+
+// Configure adds the provider configured client to the data source.
+func (r *ipPoolResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*oxideSDK.Client)
+}
+
+func (r *ipPoolResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Schema defines the schema for the resource.
+func (r *ipPoolResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the IP Pool.",
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Description for the IP Pool.",
+			},
+			"ranges": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"first_address": schema.StringAttribute{
+							Description: "First address in the range",
+							Required:    true,
+						},
+						"last_address": schema.StringAttribute{
+							Description: "Last address in the range",
+							Required:    true,
+						},
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "Unique, immutable, system-controlled identifier of the range.",
+						},
+						"time_created": schema.StringAttribute{
+							Computed:    true,
+							Description: "Timestamp of when this range was created.",
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the IP Pool.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this IP Pool was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this IP Pool was last modified.",
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *ipPoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ipPoolResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	params := oxideSDK.IpPoolCreateParams{
+		Body: &oxideSDK.IpPoolCreate{
+			Description: plan.Description.ValueString(),
+			Name:        oxideSDK.Name(plan.Name.ValueString()),
+		},
+	}
+	ipPool, err := r.client.IpPoolCreate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating IP Pool",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("created IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(ipPool.Id)
+	plan.TimeCreated = types.StringValue(ipPool.TimeCreated.String())
+	plan.TimeModified = types.StringValue(ipPool.TimeCreated.String())
+
+	for index, ipPoolRange := range plan.Ranges {
+		var body oxideSDK.IpRange
+
+		// TODO: Error checking here can be improved by checking both addresses
+		// TODO: Check if I really need the unquote if I use ValueString() instead
+		firstAddress, err := strconv.Unquote(ipPoolRange.FirstAddress.String())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error creating range within IP Pool",
+				err.Error(),
+			)
+			return
+		}
+		// TODO: Check if I really need the unquote if I use ValueString() instead
+		lastAddress, err := strconv.Unquote(ipPoolRange.LastAddress.String())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error creating range within IP Pool",
+				err.Error(),
+			)
+			return
+		}
+		if isIPv4(firstAddress) {
+			body = oxideSDK.Ipv4Range{
+				First: firstAddress,
+				Last:  lastAddress,
+			}
+		} else if isIPv6(firstAddress) {
+			body = oxideSDK.Ipv6Range{
+				First: firstAddress,
+				Last:  lastAddress,
+			}
+		} else {
+			resp.Diagnostics.AddError(
+				"Error creating range within IP Pool",
+				fmt.Errorf("%s is neither a valid IPv4 or IPv6",
+					firstAddress).Error(),
+			)
+			return
+		}
+
+		params := oxideSDK.IpPoolRangeAddParams{
+			Pool: oxideSDK.NameOrId(plan.ID.ValueString()),
+			Body: &body,
+		}
+
+		ipR, err := r.client.IpPoolRangeAdd(ctx, params)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error creating range within IP Pool",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+		tflog.Trace(ctx, fmt.Sprintf("added IP Pool range with ID: %v", ipR.Id), map[string]any{"success": true})
+
+		//	ipPoolRange.ID = types.StringValue(ipR.Id)
+		//	ipPoolRange.TimeCreated = types.StringValue(ipR.TimeCreated.String())
+
+		plan.Ranges[index] = ipPoolRange
+	}
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *ipPoolResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ipPoolResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	ipPool, err := r.client.IpPoolView(ctx, oxideSDK.IpPoolViewParams{
+		Pool: oxideSDK.NameOrId(state.ID.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read IP Pool:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(ipPool.Description)
+	state.ID = types.StringValue(ipPool.Id)
+	state.Name = types.StringValue(string(ipPool.Name))
+	state.TimeCreated = types.StringValue(ipPool.TimeCreated.String())
+	state.TimeModified = types.StringValue(ipPool.TimeCreated.String())
+
+	// Append information about IP Pool ranges
+	listParams := oxideSDK.IpPoolRangeListParams{
+		Pool:  oxideSDK.NameOrId(ipPool.Id),
+		Limit: 1000000000,
+	}
+	ipPoolRanges, err := r.client.IpPoolRangeList(ctx, listParams)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read IP Pool ranges:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read all IP pool ranges from IP pool with ID: %v", ipPool.Id), map[string]any{"success": true})
+
+	// Set the size of the slice to avoid a panic when importing
+	if len(state.Ranges) == 0 && len(ipPoolRanges.Items) != 0 {
+		state.Ranges = make([]ipPoolResourceRangeModel, len(ipPoolRanges.Items))
+	}
+
+	for index, item := range ipPoolRanges.Items {
+		ipPoolRange := ipPoolResourceRangeModel{
+			//	ID:          types.StringValue(item.Id),
+			//	TimeCreated: types.StringValue(item.TimeCreated.String()),
+		}
+
+		// TODO: For the time being we are using interfaces for nested allOf within oneOf objects in
+		// the OpenAPI spec. When we come up with a better approach this should be edited to reflect that.
+		switch item.Range.(type) {
+		case map[string]interface{}:
+			rs := item.Range.(map[string]interface{})
+			ipPoolRange.FirstAddress = types.StringValue(rs["first"].(string))
+			ipPoolRange.LastAddress = types.StringValue(rs["last"].(string))
+		default:
+			// Theoretically this should never happen. Just in case though!
+			resp.Diagnostics.AddError(
+				"Unable to read IP Pool ranges:",
+				fmt.Sprintf(
+					"internal error: %v is not map[string]interface{}. Debugging content: %+v. If you hit this bug, please contact support",
+					reflect.TypeOf(item.Range),
+					item.Range,
+				),
+			)
+			return
+		}
+
+		state.Ranges[index] = ipPoolRange
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *ipPoolResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ipPoolResourceModel
+	var state ipPoolResourceModel
+
+	// Read Terraform plan data into the plan model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Read Terraform prior state data into the state model to retrieve ID
+	// which is a computed attribute, so it won't show up in the plan.
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	//	// TODO: Support updates here
+	//	if !reflect.DeepEqual(plan.Ranges, state.Ranges) {
+	//		resp.Diagnostics.AddError(
+	//			"Error updating IP Pool",
+	//			"IP pool ranges cannot be updated; please revert to previous configuration",
+	//		)
+	//		return
+	//	}
+
+	planRanges := plan.Ranges
+	stateRanges := state.Ranges
+	rangesToAdd := sliceDiff(planRanges, stateRanges)
+	resp.Diagnostics.Append(addRanges(ctx, r.client, rangesToAdd, state.ID.ValueString())...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	params := oxideSDK.IpPoolUpdateParams{
+		Pool: oxideSDK.NameOrId(state.ID.ValueString()),
+		Body: &oxideSDK.IpPoolUpdate{
+			Description: plan.Description.ValueString(),
+			Name:        oxideSDK.Name(plan.Name.ValueString()),
+		},
+	}
+
+	ipPool, err := r.client.IpPoolUpdate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating IP Pool",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("updated IP Pool with ID: %v", ipPool.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(ipPool.Id)
+	plan.TimeCreated = types.StringValue(ipPool.TimeCreated.String())
+	plan.TimeModified = types.StringValue(ipPool.TimeCreated.String())
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *ipPoolResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ipPoolResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	_, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	// Remove all IP pool ranges first
+	ranges, err := r.client.IpPoolRangeList(
+		ctx,
+		oxideSDK.IpPoolRangeListParams{
+			Pool:  oxideSDK.NameOrId(state.ID.ValueString()),
+			Limit: 1000000000,
+		},
+	)
+	if err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Error retrieving IP Pool ranges:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read all IP pool ranges from IP pool with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+
+	for _, item := range ranges.Items {
+		var ipRange oxideSDK.IpRange
+		rs := item.Range.(map[string]interface{})
+		if isIPv4(rs["first"].(string)) {
+			ipRange = oxideSDK.Ipv4Range{
+				First: rs["first"].(string),
+				Last:  rs["last"].(string),
+			}
+		} else if isIPv6(rs["first"].(string)) {
+			ipRange = oxideSDK.Ipv6Range{
+				First: rs["first"].(string),
+				Last:  rs["last"].(string),
+			}
+		} else {
+			// This should never happen as we are retrieving information from Nexus. If we do encounter
+			// this error we have a huge problem.
+			resp.Diagnostics.AddError(
+				"Unable to read IP Pool ranges:",
+				fmt.Sprintf(
+					"internal error: %v is not map[string]interface{}. Debugging content: %+v. If you hit this bug, please contact support",
+					reflect.TypeOf(item.Range),
+					item.Range,
+				),
+			)
+			return
+		}
+
+		params := oxideSDK.IpPoolRangeRemoveParams{
+			Pool: oxideSDK.NameOrId(state.ID.ValueString()),
+			Body: &ipRange,
+		}
+		if err := r.client.IpPoolRangeRemove(ctx, params); err != nil {
+			if !is404(err) {
+				resp.Diagnostics.AddError(
+					"Error deleting IP Pool range:",
+					"API error: "+err.Error(),
+				)
+				return
+			}
+		}
+		tflog.Trace(ctx, fmt.Sprintf(
+			"removed IP pool range %v - %v from IP pool with ID: %v",
+			rs["first"].(string),
+			rs["last"].(string),
+			state.ID.ValueString(),
+		), map[string]any{"success": true})
+	}
+
+	if err := r.client.IpPoolDelete(
+		ctx,
+		oxideSDK.IpPoolDeleteParams{
+			Pool: oxideSDK.NameOrId(state.ID.ValueString()),
+		}); err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Error deleting IP Pool:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted IP pool with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+}
+
+func addRanges(ctx context.Context, client *oxide.Client, ranges []ipPoolResourceRangeModel, poolID string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	addedRanges := []ipPoolResourceRangeModel{}
+	for index, ipPoolRange := range ranges {
+		var body oxideSDK.IpRange
+
+		// TODO: Error checking here can be improved by checking both addresses
+		// TODO: Check if I really need the unquote if I use ValueString() instead
+		firstAddress, err := strconv.Unquote(ipPoolRange.FirstAddress.String())
+		if err != nil {
+			diags.AddError(
+				"Error creating range within IP Pool",
+				err.Error(),
+			)
+			return diags
+		}
+		// TODO: Check if I really need the unquote if I use ValueString() instead
+		lastAddress, err := strconv.Unquote(ipPoolRange.LastAddress.String())
+		if err != nil {
+			diags.AddError(
+				"Error creating range within IP Pool",
+				err.Error(),
+			)
+			return diags
+		}
+		if isIPv4(firstAddress) {
+			body = oxideSDK.Ipv4Range{
+				First: firstAddress,
+				Last:  lastAddress,
+			}
+		} else if isIPv6(firstAddress) {
+			body = oxideSDK.Ipv6Range{
+				First: firstAddress,
+				Last:  lastAddress,
+			}
+		} else {
+			diags.AddError(
+				"Error creating range within IP Pool",
+				fmt.Errorf("%s is neither a valid IPv4 or IPv6",
+					firstAddress).Error(),
+			)
+			return diags
+		}
+
+		params := oxideSDK.IpPoolRangeAddParams{
+			Pool: oxideSDK.NameOrId(poolID),
+			Body: &body,
+		}
+
+		ipR, err := client.IpPoolRangeAdd(ctx, params)
+		if err != nil {
+			diags.AddError(
+				"Error creating range within IP Pool",
+				"API error: "+err.Error(),
+			)
+			return diags
+		}
+		tflog.Trace(ctx, fmt.Sprintf("added IP Pool range with ID: %v", ipR.Id), map[string]any{"success": true})
+
+		//	ipPoolRange.ID = types.StringValue(ipR.Id)
+		//	ipPoolRange.TimeCreated = types.StringValue(ipR.TimeCreated.String())
+
+		addedRanges[index] = ipPoolRange
+	}
+
+	return nil
+}

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -1,0 +1,155 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+func TestAccResourceIpPool_full(t *testing.T) {
+	resourceName := "oxide_ip_pool.test"
+	resourceName2 := "oxide_ip_pool.test2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccIPPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceIPPoolConfig,
+				Check:  checkResourceIPPool(resourceName),
+			},
+			{
+				Config: testResourceIPPoolUpdateConfig,
+				Check:  checkResourceIPPoolUpdate(resourceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testResourceIPPoolRangesConfig,
+				Check:  checkResourceIPPoolRanges(resourceName2),
+			},
+			{
+				ResourceName:      resourceName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var testResourceIPPoolConfig = `
+resource "oxide_ip_pool" "test" {
+	description       = "a test ip_pool"
+	name              = "terraform-acc-myippool"
+	timeouts = {
+		read   = "1m"
+		create = "3m"
+		delete = "2m"
+		update = "4m"
+	}
+}
+`
+
+func checkResourceIPPool(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test ip_pool"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "1m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "4m"),
+	}...)
+}
+
+var testResourceIPPoolUpdateConfig = `
+resource "oxide_ip_pool" "test" {
+	description       = "a new description for ip_pool"
+	name              = "terraform-acc-myippool-new"
+}
+`
+
+func checkResourceIPPoolUpdate(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a new description for ip_pool"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool-new"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+var testResourceIPPoolRangesConfig = `
+resource "oxide_ip_pool" "test2" {
+	description       = "a test ip_pool"
+	name              = "terraform-acc-myippool2"
+	ranges = [
+    {
+		first_address = "172.20.15.227"
+		last_address  = "172.20.15.239"
+	}
+  ]
+}
+`
+
+func checkResourceIPPoolRanges(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test ip_pool"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool2"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.227"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.239"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.id"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.time_created"),
+	}...)
+}
+
+func testAccIPPoolDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_ip_pool" {
+			continue
+		}
+
+		ctx := context.Background()
+
+		res, err := client.IpPoolView(
+			ctx,
+			oxide.IpPoolViewParams{Pool: "terraform-acc-myippool"},
+		)
+		if err == nil || !is404(err) {
+			return fmt.Errorf("ip_pool (%v) still exists", &res.Name)
+		}
+
+		res2, err := client.IpPoolView(
+			ctx,
+			oxide.IpPoolViewParams{Pool: "terraform-acc-myippool2"},
+		)
+		if err != nil && is404(err) {
+			continue
+		}
+		return fmt.Errorf("ip_pool (%v) still exists", &res2.Name)
+	}
+
+	return nil
+}

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -80,6 +80,12 @@ var testResourceIPPoolUpdateConfig = `
 resource "oxide_ip_pool" "test" {
 	description       = "a new description for ip_pool"
 	name              = "terraform-acc-myippool-new"
+	ranges = [
+    {
+		first_address = "172.20.15.227"
+		last_address  = "172.20.15.239"
+	}
+  ]
 }
 `
 
@@ -90,6 +96,8 @@ func checkResourceIPPoolUpdate(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool-new"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.227"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.239"),
 	}...)
 }
 
@@ -99,8 +107,8 @@ resource "oxide_ip_pool" "test2" {
 	name              = "terraform-acc-myippool2"
 	ranges = [
     {
-		first_address = "172.20.15.227"
-		last_address  = "172.20.15.239"
+		first_address = "172.20.15.240"
+		last_address  = "172.20.15.249"
 	}
   ]
 }
@@ -113,10 +121,8 @@ func checkResourceIPPoolRanges(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool2"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.227"),
-		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.239"),
-		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.id"),
-		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.time_created"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.240"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.249"),
 	}...)
 }
 

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -37,6 +37,15 @@ func TestAccResourceIpPool_full(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testResourceIPPoolRemoveUpdateConfig,
+				Check:  checkResourceIPPoolRemoveUpdate(resourceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testResourceIPPoolRangesConfig,
 				Check:  checkResourceIPPoolRanges(resourceName2),
 			},
@@ -83,6 +92,10 @@ resource "oxide_ip_pool" "test" {
 	ranges = [
     {
 		first_address = "172.20.15.227"
+		last_address  = "172.20.15.230"
+	},
+	{
+		first_address = "172.20.15.231"
 		last_address  = "172.20.15.239"
 	}
   ]
@@ -96,8 +109,35 @@ func checkResourceIPPoolUpdate(resourceName string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool-new"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.first_address"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.0.last_address"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.1.first_address"),
+		resource.TestCheckResourceAttrSet(resourceName, "ranges.1.last_address"),
+	}...)
+}
+
+var testResourceIPPoolRemoveUpdateConfig = `
+resource "oxide_ip_pool" "test" {
+	description       = "a new description for ip_pool"
+	name              = "terraform-acc-myippool-new"
+	ranges = [
+    {
+		first_address = "172.20.15.227"
+		last_address  = "172.20.15.230"
+	}
+  ]
+}
+`
+
+func checkResourceIPPoolRemoveUpdate(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a new description for ip_pool"),
+		resource.TestCheckResourceAttr(resourceName, "name", "terraform-acc-myippool-new"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
 		resource.TestCheckResourceAttr(resourceName, "ranges.0.first_address", "172.20.15.227"),
-		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.239"),
+		resource.TestCheckResourceAttr(resourceName, "ranges.0.last_address", "172.20.15.230"),
 	}...)
 }
 

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
-func TestAccResourceIpPool_full(t *testing.T) {
+func TestAccSiloResourceIpPool_full(t *testing.T) {
 	resourceName := "oxide_ip_pool.test"
 	resourceName2 := "oxide_ip_pool.test2"
 


### PR DESCRIPTION
## Usage

```HCL
resource "oxide_ip_pool" "test" {
	description       = "a new description for ip_pool"
	name              = "myippool"
	ranges = [
    {
		first_address = "172.20.15.227"
		last_address  = "172.20.15.230"
	},
	{
		first_address = "172.20.15.231"
		last_address  = "172.20.15.239"
	}
  ]
}
```

## Manual testing on simulated omicron

```console
$ TEST_ACC_NAME=TestAccResourceIpPool_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccResourceIpPool_full
=== PAUSE TestAccResourceIpPool_full
=== CONT  TestAccResourceIpPool_full
--- PASS: TestAccResourceIpPool_full (2.92s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	2.926s

```

Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/335