### PR TITLE
Update goreleaser version to 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:


### PR DESCRIPTION
Following update instructions here https://goreleaser.com/blog/goreleaser-v2/

Related: https://github.com/oxidecomputer/terraform-provider-oxide/pull/324
