### PR TITLE
Fix example on returning instance external ip

### DIFF
--- a/examples/instance_resource/instance.tf
+++ b/examples/instance_resource/instance.tf
@@ -132,6 +132,10 @@ resource "oxide_instance" "test" {
   user_data = filebase64("./init.sh")
 }
 
+data "oxide_instance_external_ips" "example" {
+  instance_id = oxide_instance.test.id
+}
+
 output "instance_external_ip" {
   value = data.oxide_instance_external_ips.example.external_ips.0.ip
 }


### PR DESCRIPTION
A customer reported that the exmaple was missing a declaration of the instance external ip data. They identified the missing part which I inserted in this PR. I was able to verify the fix by deploying it against an internal rack.