### PR TITLE
codeowners: update owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @karencfv @augustuswm @inickles
+*       @karencfv @sudomateo


### PR DESCRIPTION
This patch adds Matthew Sanabria (`@sudomateo`) to `CODEOWNERS` and removes those who have served their time.