### PR TITLE
Update to Go SDK eb153ea

### DIFF
--- a/.changelog/0.6.0.toml
+++ b/.changelog/0.6.0.toml
@@ -8,7 +8,7 @@ description = ""
 
 [[enhancements]]
 title = "Instance resource"
-description = "Updates to `Memory` and `NCPUs` no longer require resource replace [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+description = "Updates to `Memory` and `NCPUs` no longer require resource replace [#370](https://github.com/oxidecomputer/terraform-provider-oxide/pull/370)."
 
 [[bugs]]
 title = ""

--- a/.changelog/0.6.0.toml
+++ b/.changelog/0.6.0.toml
@@ -7,8 +7,8 @@ title = ""
 description = ""
 
 [[enhancements]]
-title = ""
-description = ""
+title = "Instance resource"
+description = "Updates to `Memory` and `NCPUs` no longer require resource replace [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
 
 [[bugs]]
 title = ""

--- a/docs/resources/oxide_instance.md
+++ b/docs/resources/oxide_instance.md
@@ -6,7 +6,7 @@ page_title: "oxide_instance Resource - terraform-provider-oxide"
 
 This resource manages instances.
 
--> Boot disk, disk attachment, and network interface updates will stop and reboot the instance.
+-> Updates will stop and reboot the instance.
 
 -> When setting a boot disk, the boot disk ID should also be included as part of `disk_attachments`.
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
-	github.com/oxidecomputer/oxide.go v0.1.0-beta8.0.20241002225252-92053e192b28
+	github.com/oxidecomputer/oxide.go v0.1.0-beta9.0.20241125050113-eb153ea4db8c
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -51,6 +51,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,10 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.1.0-beta8.0.20241002225252-92053e192b28 h1:EXm6ATVUL2fIdxz8Jzvf0W3WhIP5/vnXyYZPLvs1z7Q=
-github.com/oxidecomputer/oxide.go v0.1.0-beta8.0.20241002225252-92053e192b28/go.mod h1:9TBnNt4BsYikmgOEdQ8bDhENhpa3lBE4CpekqpzqPCQ=
+github.com/oxidecomputer/oxide.go v0.1.0-beta9.0.20241125050113-eb153ea4db8c h1:w3WgeFerjCSXGNT9u3vyJIaZ8Yxa82DZYhwOL9gi1CU=
+github.com/oxidecomputer/oxide.go v0.1.0-beta9.0.20241125050113-eb153ea4db8c/go.mod h1:Fn/YWG8Ycr9qFeQJszDGRooZSQr2P/kco+34iOHotmw=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -597,7 +597,10 @@ func (r *instanceResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	// Update instance only if configurable instance params change
+	// Update instance only if configurable instance params change.
+	// Due to the design of the API, when updating an instance all
+	// parameters must be set. This means we set all of the parameters
+	// even if only a single one changed.
 	if state.BootDiskID != plan.BootDiskID ||
 		state.Memory != plan.Memory ||
 		state.NCPUs != plan.NCPUs {

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -510,7 +510,7 @@ resource "oxide_instance" "{{.BlockName}}" {
   name            = "{{.InstanceName}}"
   host_name       = "terraform-acc-myhost"
   memory          = 1073741824
-  ncpus           = 2
+  ncpus           = 1
   start_on_create = true
   disk_attachments = [oxide_disk.{{.DiskBlockName}}.id]
 }
@@ -576,6 +576,137 @@ resource "oxide_instance" "{{.BlockName}}" {
 			},
 			{
 				ResourceName:      resourceNameInstanceDisk,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// This option is only relevant for create, this means that it will
+				// never be imported
+				ImportStateVerifyIgnore: []string{"start_on_create"},
+			},
+		},
+	})
+}
+
+func TestAccCloudResourceInstance_update(t *testing.T) {
+	type resourceInstanceUpdateConfig struct {
+		BlockName        string
+		InstanceName     string
+		SupportBlockName string
+	}
+
+	resourceInstanceConfigTpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  host_name       = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 1
+  start_on_create = true
+}
+`
+
+	resourceInstanceConfigUpdateTpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  host_name       = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 2
+  start_on_create = true
+}
+`
+
+	resourceInstanceConfigUpdate2Tpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  host_name       = "terraform-acc-myhost"
+  memory          = 2147483648
+  ncpus           = 2
+  start_on_create = true
+}
+`
+	instanceName := newResourceName()
+	supportBlockName := newBlockName("support")
+	supportBlockName2 := newBlockName("support-update")
+	blockNameInstance := newBlockName("instance")
+	resourceNameInstance := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
+	config, err := parsedAccConfig(
+		resourceInstanceUpdateConfig{
+			BlockName:        blockNameInstance,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName,
+		},
+		resourceInstanceConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	configUpdate, err := parsedAccConfig(
+		resourceInstanceUpdateConfig{
+			BlockName:        blockNameInstance,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName2,
+		},
+		resourceInstanceConfigUpdateTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	configUpdate2, err := parsedAccConfig(
+		resourceInstanceUpdateConfig{
+			BlockName:        blockNameInstance,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName2,
+		},
+		resourceInstanceConfigUpdate2Tpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  checkResourceInstanceUpdate(resourceNameInstance, instanceName),
+			},
+			{
+				// Update NCPUs
+				Config: configUpdate,
+				Check:  checkResourceInstanceUpdate2(resourceNameInstance, instanceName),
+			},
+			{
+				// Update Menory
+				Config: configUpdate2,
+				Check:  checkResourceInstanceUpdate3(resourceNameInstance, instanceName),
+			},
+			{
+				// Update all
+				Config: config,
+				Check:  checkResourceInstanceUpdate(resourceNameInstance, instanceName),
+			},
+			{
+				ResourceName:      resourceNameInstance,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// This option is only relevant for create, this means that it will
@@ -674,7 +805,7 @@ func checkResourceInstanceDiskUpdate(resourceName, instanceName string) resource
 		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
 		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
 		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
-		resource.TestCheckResourceAttr(resourceName, "ncpus", "2"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
@@ -733,6 +864,51 @@ func checkResourceInstanceSSHKeys(resourceName, instanceName string) resource.Te
 		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
 		resource.TestCheckResourceAttr(resourceName, "start_on_create", "false"),
 		resource.TestCheckResourceAttrSet(resourceName, "ssh_public_keys.0"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func checkResourceInstanceUpdate(resourceName, instanceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
+		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func checkResourceInstanceUpdate2(resourceName, instanceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
+		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "2"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func checkResourceInstanceUpdate3(resourceName, instanceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
+		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "2147483648"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "2"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -510,7 +510,7 @@ resource "oxide_instance" "{{.BlockName}}" {
   name            = "{{.InstanceName}}"
   host_name       = "terraform-acc-myhost"
   memory          = 1073741824
-  ncpus           = 1
+  ncpus           = 2
   start_on_create = true
   disk_attachments = [oxide_disk.{{.DiskBlockName}}.id]
 }
@@ -674,7 +674,7 @@ func checkResourceInstanceDiskUpdate(resourceName, instanceName string) resource
 		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
 		resource.TestCheckResourceAttr(resourceName, "host_name", "terraform-acc-myhost"),
 		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
-		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "2"),
 		resource.TestCheckResourceAttr(resourceName, "start_on_create", "true"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),


### PR DESCRIPTION
Updates the provider to include the new memory and ncpu update functionality.

#### Tested against dogfood rack

```console
$ make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceInstance_update
=== PAUSE TestAccCloudResourceInstance_update
=== CONT  TestAccCloudResourceInstance_update
--- PASS: TestAccCloudResourceInstance_update (64.81s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	65.317s
```