### PR TITLE
oxide_instance: allow in-place `external_ips` modification

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -1530,22 +1530,22 @@ func (f instanceExternalIPValidator) MarkdownDescription(context.Context) string
 // already deduplicates sets within configuration. For example, the following
 // configuration in Terraform results in a single ephemeral external IP.
 //
-//   resource "oxide_instance" "example" {
-//     external_ips = [
-//       { type = "ephemeral"},
-//       { type = "ephemeral"},
-//     ]
-//   }
+//	resource "oxide_instance" "example" {
+//	  external_ips = [
+//	    { type = "ephemeral"},
+//	    { type = "ephemeral"},
+//	  ]
+//	}
 //
 // However, that deduplication does not extend to sets that contain different
 // attributes, like so.
-// 
-//   resource "oxide_instance" "example" {
-//     external_ips = [
-//       { type = "ephemeral", id = "a58dc21d-896d-4e5a-bb77-b0922a04e553"},
-//       { type = "ephemeral"},
-//     ]
-//   }
+//
+//	resource "oxide_instance" "example" {
+//	  external_ips = [
+//	    { type = "ephemeral", id = "a58dc21d-896d-4e5a-bb77-b0922a04e553"},
+//	    { type = "ephemeral"},
+//	  ]
+//	}
 //
 // That's where this validator comes in. This validator errors with the above
 // configuration, preventing a user from using multiple ephemeral external IPs.


### PR DESCRIPTION
Closes https://github.com/oxidecomputer/terraform-provider-oxide/issues/378.

This patch updates the `oxide_instance` resource to support in-place modifications to its `external_ips` attribute. That is, the instance will no longer be destroyed and recreated when `external_ips` is modified. Instead, the instance will be stopped, external IPs will be detached and/or attached, and the instance will be started.

This patch also updates the `Read` method to refresh the external IPs attached to the instance. Previously, since the external IPs required a resource replacement there was no need to refresh them.

There are 2 types of external IPs, ephemeral and floating. There can be at most 1 ephemeral external IP attached to an instance and any number of floating external IPs. That means in order to modify ephemeral external IPs the external IPs must be detached first and then attached.

This patch needs the following work before it can be merged.
- [x] Add tests for the new `external_ips` modification logic.
- [x] Add validation logic to `external_ips` to enforce at most 1 ephemeral external IP. This was previously "validated" during instance creation but is not updated during instance update.

Here's the error that's returned when an instance is created with more than 1 ephemeral external IP.

```
oxide_instance.foo: Creating...
╷
│ Error: Error creating instance
│
│   with oxide_instance.foo,
│   on main.tf line 24, in resource "oxide_instance" "foo":
│   24: resource "oxide_instance" "foo" {
│
│ API error: POST https://oxide.example.com/v1/instances?project=5476ccc9-464d-4dc4-bfc0-5154de1c986f
│ ----------- RESPONSE -----------
│ Status: 400 InvalidRequest
│ Message: An instance may not have more than 1 ephemeral IP address
│ RequestID: fc6144e5-fa76-4583-a024-2e49ce17140e
│ ------- RESPONSE HEADERS -------
│ Content-Type: [application/json]
│ X-Request-Id: [fc6144e5-fa76-4583-a024-2e49ce17140e]
│ Date: [Thu, 09 Jan 2025 03:28:48 GMT]
│ Content-Length: [166]
│
╵
```