### PR TITLE
New oxide_vpc_router resource and datasource

### DIFF
--- a/.changelog/0.7.0.toml
+++ b/.changelog/0.7.0.toml
@@ -3,8 +3,8 @@ title = ""
 description = ""
 
 [[features]]
-title = "Profile Argument for Terraform Provider"
-description = "Allows authentication via a authenticated `profile` in `credentials.toml` [#383](https://github.com/oxidecomputer/terraform-provider-oxide/pull/383)."
+title = "Profile attribute in provider block"
+description = "Allows authentication via an authenticated `profile` in `credentials.toml` [#383](https://github.com/oxidecomputer/terraform-provider-oxide/pull/383)."
 
 [[features]]
 title = "New resource"

--- a/.changelog/0.7.0.toml
+++ b/.changelog/0.7.0.toml
@@ -8,11 +8,11 @@ description = "Allows authentication via a authenticated `profile` in `credentia
 
 [[features]]
 title = "New resource"
-description = "`oxide_vpc_router` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+description = "`oxide_vpc_router` [#388](https://github.com/oxidecomputer/terraform-provider-oxide/pull/388)."
 
 [[features]]
 title = "New datasource"
-description = "`oxide_vpc_router` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+description = "`oxide_vpc_router` [#388](https://github.com/oxidecomputer/terraform-provider-oxide/pull/388)."
 
 [[enhancements]]
 title = ""

--- a/.changelog/0.7.0.toml
+++ b/.changelog/0.7.0.toml
@@ -6,6 +6,14 @@ description = ""
 title = "Profile Argument for Terraform Provider"
 description = "Allows authentication via a authenticated `profile` in `credentials.toml` [#383](https://github.com/oxidecomputer/terraform-provider-oxide/pull/383)."
 
+[[features]]
+title = "New resource"
+description = "`oxide_vpc_router` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+
+[[features]]
+title = "New datasource"
+description = "`oxide_vpc_router` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+
 [[enhancements]]
 title = ""
 description = ""

--- a/docs/data-sources/oxide_vpc_router.md
+++ b/docs/data-sources/oxide_vpc_router.md
@@ -1,0 +1,49 @@
+---
+page_title: "oxide_vpc_router Data Source - terraform-provider-oxide"
+---
+
+# oxide_vpc_router (Data Source)
+
+Retrieve information about a specified VPC router.
+
+## Example Usage
+
+```hcl
+data "oxide_vpc_router" "example" {
+  project_name = "my-project"
+  name         = "system"
+  vpc_name     = "default"
+  timeouts = {
+    read = "1m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the router.
+- `project_name` (String) Name of the project that contains the router.
+- `vpc_name` (String) Name of the VPC that contains the router.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `description` (String) Description for the VPC router.
+- `id` (String) Unique, immutable, system-controlled identifier of the VPC router.
+- `name` (String) Name of the VPC router.
+- `vpc_id` (String) ID of the VPC that contains the router.
+- `time_created` (String) Timestamp of when this VPC router was created.
+- `time_modified` (String) Timestamp of when this VPC router was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `read` (String, Default `10m`)

--- a/docs/data-sources/oxide_vpc_router.md
+++ b/docs/data-sources/oxide_vpc_router.md
@@ -35,6 +35,7 @@ data "oxide_vpc_router" "example" {
 
 - `description` (String) Description for the VPC router.
 - `id` (String) Unique, immutable, system-controlled identifier of the VPC router.
+- `kind` (String) Whether the VPC router is custom or system created.
 - `name` (String) Name of the VPC router.
 - `vpc_id` (String) ID of the VPC that contains the router.
 - `time_created` (String) Timestamp of when this VPC router was created.

--- a/docs/resources/oxide_vpc_router.md
+++ b/docs/resources/oxide_vpc_router.md
@@ -37,6 +37,7 @@ resource "oxide_vpc_router" "example" {
 ### Read-Only
 
 - `id` (String) Unique, immutable, system-controlled identifier of the VPC router.
+- `kind` (String) Whether the VPC router is custom or system created.
 - `time_created` (String) Timestamp of when this VPC router was created.
 - `time_modified` (String) Timestamp of when this VPC router was last modified.
 

--- a/docs/resources/oxide_vpc_router.md
+++ b/docs/resources/oxide_vpc_router.md
@@ -1,0 +1,52 @@
+---
+page_title: "oxide_vpc_router Resource - terraform-provider-oxide"
+---
+
+# oxide_vpc_router (Resource)
+
+This resource manages VPC routers.
+
+## Example Usage
+
+```hcl
+resource "oxide_vpc_router" "example" {
+  vpc_id      = "c1dee930-a8e4-11ed-afa1-0242ac120002"
+  description = "a sample vpc router"
+  name        = "myrouter"
+  timeouts = {
+    read   = "1m"
+    create = "3m"
+    delete = "2m"
+    update = "2m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `description` (String) Description for the VPC router.
+- `name` (String) Name of the VPC router.
+- `vpc_id` (String) ID of the VPC that will contain the router.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the VPC router.
+- `time_created` (String) Timestamp of when this VPC router was created.
+- `time_modified` (String) Timestamp of when this VPC router was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String, Default `10m`)
+- `delete` (String, Default `10m`)
+- `read` (String, Default `10m`)
+- `update` (String, Default `10m`)

--- a/internal/provider/data_source_vpc_router.go
+++ b/internal/provider/data_source_vpc_router.go
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var (
+	_ datasource.DataSource              = (*vpcRouterDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*vpcRouterDataSource)(nil)
+)
+
+// NewVPCRouterDataSource initialises an images datasource
+func NewVPCRouterDataSource() datasource.DataSource {
+	return &vpcRouterDataSource{}
+}
+
+type vpcRouterDataSource struct {
+	client *oxide.Client
+}
+
+type vpcRouterDataSourceModel struct {
+	Description  types.String   `tfsdk:"description"`
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	ProjectName  types.String   `tfsdk:"project_name"`
+	VPCID        types.String   `tfsdk:"vpc_id"`
+	VPCName      types.String   `tfsdk:"vpc_name"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+func (d *vpcRouterDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "oxide_vpc_router"
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *vpcRouterDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.client = req.ProviderData.(*oxide.Client)
+}
+
+func (d *vpcRouterDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the project that contains the VPC router.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the VPC router.",
+			},
+			"vpc_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the VPC that contains the VPC router.",
+			},
+			"vpc_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the VPC that contains the VPC router.",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Description for the VPC router.",
+			},
+			"timeouts": timeouts.Attributes(ctx),
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the VPC.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this VPC router was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this VPC router was last modified.",
+			},
+		},
+	}
+}
+
+func (d *vpcRouterDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state vpcRouterDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.VpcRouterViewParams{
+		Router:  oxide.NameOrId(state.Name.ValueString()),
+		Vpc:     oxide.NameOrId(state.VPCName.ValueString()),
+		Project: oxide.NameOrId(state.ProjectName.ValueString()),
+	}
+	router, err := d.client.VpcRouterView(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read VPC router:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read VPC router with ID: %v", router.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(router.Description)
+	state.ID = types.StringValue(router.Id)
+	state.Name = types.StringValue(string(router.Name))
+	state.VPCID = types.StringValue(router.VpcId)
+	state.TimeCreated = types.StringValue(router.TimeCreated.String())
+	state.TimeModified = types.StringValue(router.TimeModified.String())
+
+	// Save state into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/data_source_vpc_router.go
+++ b/internal/provider/data_source_vpc_router.go
@@ -33,6 +33,7 @@ type vpcRouterDataSource struct {
 type vpcRouterDataSourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	ID           types.String   `tfsdk:"id"`
+	Kind         types.String   `tfsdk:"kind"`
 	Name         types.String   `tfsdk:"name"`
 	ProjectName  types.String   `tfsdk:"project_name"`
 	VPCID        types.String   `tfsdk:"vpc_id"`
@@ -81,7 +82,11 @@ func (d *vpcRouterDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			"timeouts": timeouts.Attributes(ctx),
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "Unique, immutable, system-controlled identifier of the VPC.",
+				Description: "Unique, immutable, system-controlled identifier of the VPC router.",
+			},
+			"kind": schema.StringAttribute{
+				Computed:    true,
+				Description: "Whether the VPC router is custom or system created.",
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,
@@ -129,6 +134,7 @@ func (d *vpcRouterDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	state.Description = types.StringValue(router.Description)
 	state.ID = types.StringValue(router.Id)
+	state.Kind = types.StringValue(string(router.Kind))
 	state.Name = types.StringValue(string(router.Name))
 	state.VPCID = types.StringValue(router.VpcId)
 	state.TimeCreated = types.StringValue(router.TimeCreated.String())

--- a/internal/provider/data_source_vpc_router_test.go
+++ b/internal/provider/data_source_vpc_router_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
 type dataSourceVPCRouterConfig struct {
@@ -63,6 +64,7 @@ func checkDataSourceVPCRouter(dataName string) resource.TestCheckFunc {
 			"Routes are automatically added to this router as vpc subnets are created",
 		),
 		resource.TestCheckResourceAttr(dataName, "name", "system"),
+		resource.TestCheckResourceAttr(dataName, "kind", string(oxide.VpcRouterKindSystem)),
 		resource.TestCheckResourceAttrSet(dataName, "vpc_id"),
 		resource.TestCheckResourceAttrSet(dataName, "time_created"),
 		resource.TestCheckResourceAttrSet(dataName, "time_modified"),

--- a/internal/provider/data_source_vpc_router_test.go
+++ b/internal/provider/data_source_vpc_router_test.go
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type dataSourceVPCRouterConfig struct {
+	BlockName        string
+	SupportBlockName string
+}
+
+var dataSourceVPCRouterConfigTpl = `
+data "oxide_vpc_router" "{{.BlockName}}" {
+  project_name = "tf-acc-test"
+  vpc_name     = "default"
+  name         = "system"
+  timeouts = {
+    read = "1m"
+  }
+}
+`
+
+func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
+	blockName := newBlockName("datasource-vpc-router")
+	config, err := parsedAccConfig(
+		dataSourceVPCRouterConfig{
+			BlockName:        blockName,
+			SupportBlockName: newBlockName("support"),
+		},
+		dataSourceVPCRouterConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkDataSourceVPCRouter(
+					fmt.Sprintf("data.oxide_vpc_router.%s", blockName),
+				),
+			},
+		},
+	})
+}
+
+func checkDataSourceVPCRouter(dataName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(dataName, "id"),
+		resource.TestCheckResourceAttr(
+			dataName,
+			"description",
+			"Routes are automatically added to this router as vpc subnets are created",
+		),
+		resource.TestCheckResourceAttr(dataName, "name", "system"),
+		resource.TestCheckResourceAttrSet(dataName, "vpc_id"),
+		resource.TestCheckResourceAttrSet(dataName, "time_created"),
+		resource.TestCheckResourceAttrSet(dataName, "time_modified"),
+		resource.TestCheckResourceAttr(dataName, "timeouts.read", "1m"),
+	}...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -170,6 +170,7 @@ func (p *oxideProvider) DataSources(_ context.Context) []func() datasource.DataS
 		NewSiloDataSource,
 		NewSSHKeyDataSource,
 		NewVPCDataSource,
+		NewVPCRouterDataSource,
 		NewVPCSubnetDataSource,
 	}
 }
@@ -187,6 +188,7 @@ func (p *oxideProvider) Resources(_ context.Context) []func() resource.Resource 
 		NewSSHKeyResource,
 		NewVPCResource,
 		NewVPCFirewallRulesResource,
+		NewVpcRouterResource,
 		NewVPCSubnetResource,
 	}
 }

--- a/internal/provider/resource_vpc_router.go
+++ b/internal/provider/resource_vpc_router.go
@@ -1,0 +1,292 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource              = (*vpcRouterResource)(nil)
+	_ resource.ResourceWithConfigure = (*vpcRouterResource)(nil)
+)
+
+// NewVpcRouterResource is a helper function to simplify the provider implementation.
+func NewVpcRouterResource() resource.Resource {
+	return &vpcRouterResource{}
+}
+
+// vpcRouterResource is the resource implementation.
+type vpcRouterResource struct {
+	client *oxide.Client
+}
+
+type vpcRouterResourceModel struct {
+	Description  types.String   `tfsdk:"description"`
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	VPCID        types.String   `tfsdk:"vpc_id"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Metadata returns the resource type name.
+func (r *vpcRouterResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "oxide_vpc_router"
+}
+
+// Configure adds the provider configured client to the data source.
+func (r *vpcRouterResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*oxide.Client)
+}
+
+func (r *vpcRouterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Schema defines the schema for the resource.
+func (r *vpcRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the VPC router.",
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Description for the VPC Router.",
+			},
+			"vpc_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the VPC that will contain the VPC router.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the VPC router.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this VPC router was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this VPC router was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *vpcRouterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan vpcRouterResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	params := oxide.VpcRouterCreateParams{
+		Vpc: oxide.NameOrId(plan.VPCID.ValueString()),
+		Body: &oxide.VpcRouterCreate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+		},
+	}
+
+	vpcRouter, err := r.client.VpcRouterCreate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating vpcRouter",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("created VPC router with ID: %v", vpcRouter.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(vpcRouter.Id)
+	plan.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
+	plan.TimeModified = types.StringValue(vpcRouter.TimeModified.String())
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *vpcRouterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state vpcRouterResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.VpcRouterViewParams{
+		Router: oxide.NameOrId(state.ID.ValueString()),
+	}
+	vpcRouter, err := r.client.VpcRouterView(ctx, params)
+	if err != nil {
+		if is404(err) {
+			// Remove resource from state during a refresh
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to read vpcRouter:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read VPC Router with ID: %v", vpcRouter.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(vpcRouter.Description)
+	state.ID = types.StringValue(vpcRouter.Id)
+	state.Name = types.StringValue(string(vpcRouter.Name))
+	state.VPCID = types.StringValue(string(vpcRouter.VpcId))
+	state.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
+	state.TimeModified = types.StringValue(vpcRouter.TimeModified.String())
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *vpcRouterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan vpcRouterResourceModel
+	var state vpcRouterResourceModel
+
+	// Read Terraform plan data into the plan model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Read Terraform prior state data into the state model to retrieve ID
+	// which is a computed attribute, so it won't show up in the plan.
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	params := oxide.VpcRouterUpdateParams{
+		Router: oxide.NameOrId(state.ID.ValueString()),
+		Body: &oxide.VpcRouterUpdate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+		},
+	}
+	vpcRouter, err := r.client.VpcRouterUpdate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating VPC router",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("updated VPC router with ID: %v", vpcRouter.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(vpcRouter.Id)
+	plan.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
+	plan.TimeModified = types.StringValue(vpcRouter.TimeModified.String())
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *vpcRouterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state vpcRouterResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	params := oxide.VpcRouterDeleteParams{
+		Router: oxide.NameOrId(state.ID.ValueString()),
+	}
+	if err := r.client.VpcRouterDelete(ctx, params); err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Unable to delete VPC router:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("deleted VPC router with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+}

--- a/internal/provider/resource_vpc_router.go
+++ b/internal/provider/resource_vpc_router.go
@@ -38,6 +38,7 @@ type vpcRouterResource struct {
 type vpcRouterResourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	ID           types.String   `tfsdk:"id"`
+	Kind         types.String   `tfsdk:"kind"`
 	Name         types.String   `tfsdk:"name"`
 	VPCID        types.String   `tfsdk:"vpc_id"`
 	TimeCreated  types.String   `tfsdk:"time_created"`
@@ -85,6 +86,10 @@ func (r *vpcRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the VPC router.",
+			},
+			"kind": schema.StringAttribute{
+				Computed:    true,
+				Description: "Whether the VPC router is custom or system created.",
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,
@@ -142,6 +147,7 @@ func (r *vpcRouterResource) Create(ctx context.Context, req resource.CreateReque
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(vpcRouter.Id)
+	plan.Kind = types.StringValue(string(vpcRouter.Kind))
 	plan.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
 	plan.TimeModified = types.StringValue(vpcRouter.TimeModified.String())
 
@@ -190,6 +196,7 @@ func (r *vpcRouterResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	state.Description = types.StringValue(vpcRouter.Description)
 	state.ID = types.StringValue(vpcRouter.Id)
+	state.Kind = types.StringValue(string(vpcRouter.Kind))
 	state.Name = types.StringValue(string(vpcRouter.Name))
 	state.VPCID = types.StringValue(string(vpcRouter.VpcId))
 	state.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
@@ -247,6 +254,7 @@ func (r *vpcRouterResource) Update(ctx context.Context, req resource.UpdateReque
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(vpcRouter.Id)
+	plan.Kind = types.StringValue(string(vpcRouter.Kind))
 	plan.TimeCreated = types.StringValue(vpcRouter.TimeCreated.String())
 	plan.TimeModified = types.StringValue(vpcRouter.TimeModified.String())
 

--- a/internal/provider/resource_vpc_router_test.go
+++ b/internal/provider/resource_vpc_router_test.go
@@ -129,6 +129,7 @@ func checkResourceVPCRouter(resourceName, routerName string) resource.TestCheckF
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttr(resourceName, "description", "a test router"),
+		resource.TestCheckResourceAttr(resourceName, "kind", string(oxide.RouterRouteKindCustom)),
 		resource.TestCheckResourceAttr(resourceName, "name", routerName),
 		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
@@ -145,6 +146,7 @@ func checkResourceVPCRouterUpdate(resourceName, routerName string) resource.Test
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 		resource.TestCheckResourceAttr(resourceName, "description", "a new description for router"),
+		resource.TestCheckResourceAttr(resourceName, "kind", string(oxide.RouterRouteKindCustom)),
 		resource.TestCheckResourceAttr(resourceName, "name", routerName),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),

--- a/internal/provider/resource_vpc_router_test.go
+++ b/internal/provider/resource_vpc_router_test.go
@@ -1,0 +1,180 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+type resourceVPCRouterConfig struct {
+	BlockName        string
+	VPCName          string
+	SupportBlockName string
+	VPCBlockName     string
+	VPCRouterName    string
+}
+
+var resourceVPCRouterConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_vpc" "{{.VPCBlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	description = "a test vpc"
+	name        = "{{.VPCName}}"
+	dns_name    = "my-vpc"
+}
+
+resource "oxide_vpc_router" "{{.BlockName}}" {
+	description = "a test router"
+	name        = "{{.VPCRouterName}}"
+	vpc_id      = oxide_vpc.{{.VPCBlockName}}.id
+	timeouts = {
+		read   = "1m"
+		create = "3m"
+		delete = "2m"
+		update = "4m"
+	}
+  }
+`
+
+var resourceVPCRouterUpdateConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_vpc" "{{.VPCBlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	description = "a test vpc"
+	name        = "{{.VPCName}}"
+	dns_name    = "my-vpc"
+}
+
+resource "oxide_vpc_router" "{{.BlockName}}" {
+	description = "a new description for router"
+	name        = "{{.VPCRouterName}}"
+	vpc_id      = oxide_vpc.{{.VPCBlockName}}.id
+  }
+`
+
+func TestAccCloudResourceVPCRouter_full(t *testing.T) {
+	vpcName := newResourceName()
+	routerName := newResourceName()
+	blockName := newBlockName("router")
+	supportBlockName := newBlockName("support")
+	vpcBlockName := newBlockName("vpc")
+	resourceName := fmt.Sprintf("oxide_vpc_router.%s", blockName)
+	config, err := parsedAccConfig(
+		resourceVPCRouterConfig{
+			VPCName:          vpcName,
+			SupportBlockName: supportBlockName,
+			VPCBlockName:     vpcBlockName,
+			BlockName:        blockName,
+			VPCRouterName:    routerName,
+		},
+		resourceVPCRouterConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	routerNameUpdated := routerName + "-updated"
+	configUpdate, err := parsedAccConfig(
+		resourceVPCRouterConfig{
+			VPCName:          vpcName,
+			SupportBlockName: supportBlockName,
+			VPCBlockName:     vpcBlockName,
+			BlockName:        blockName,
+			VPCRouterName:    routerNameUpdated,
+		},
+		resourceVPCRouterUpdateConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccVPCRouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  checkResourceVPCRouter(resourceName, routerName),
+			},
+			{
+				Config: configUpdate,
+				Check:  checkResourceVPCRouterUpdate(resourceName, routerNameUpdated),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func checkResourceVPCRouter(resourceName, routerName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test router"),
+		resource.TestCheckResourceAttr(resourceName, "name", routerName),
+		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "1m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "4m"),
+	}...)
+}
+
+func checkResourceVPCRouterUpdate(resourceName, routerName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a new description for router"),
+		resource.TestCheckResourceAttr(resourceName, "name", routerName),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccVPCRouterDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_vpc_router" {
+			continue
+		}
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+
+		params := oxide.VpcRouterViewParams{
+			Router: oxide.NameOrId(rs.Primary.Attributes["id"]),
+		}
+		res, err := client.VpcRouterView(ctx, params)
+		if err != nil && is404(err) {
+			continue
+		}
+		return fmt.Errorf("router (%v) still exists", &res.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit introduces the `oxide_vpc_router` resource and datasource.

Tested against the colo rack:

```console
$ TEST_ACC_NAME=TestAccCloudDataSourceVPCRouter_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceVPCRouter_full
=== PAUSE TestAccCloudDataSourceVPCRouter_full
=== CONT  TestAccCloudDataSourceVPCRouter_full
--- PASS: TestAccCloudDataSourceVPCRouter_full (1.67s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	1.983s
$ TEST_ACC_NAME=TestAccCloudResourceVPCRouter_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceVPCRouter_full
=== PAUSE TestAccCloudResourceVPCRouter_full
=== CONT  TestAccCloudResourceVPCRouter_full
--- PASS: TestAccCloudResourceVPCRouter_full (7.73s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	8.049s
```

Part 1 of https://github.com/oxidecomputer/terraform-provider-oxide/issues/377