### PR TITLE
Bump SDK version to c8be658

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
-	github.com/oxidecomputer/oxide.go v0.3.0
+	github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -70,5 +70,3 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/go.mod
+++ b/go.mod
@@ -70,3 +70,5 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.3.0 h1:I5l9njXo1lp1Tqp63y8HKw19HOpuEV8RRkJqpXoxcdQ=
-github.com/oxidecomputer/oxide.go v0.3.0/go.mod h1:FECb3qr0RSxGnHIiH6DsUGdkTcY/WeKN1evZCTQ3fy4=
+github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352 h1:C7+yo9PnkjVkS4UvhX0gMUQhzaBbS5L8WTsEraSdgyM=
+github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352/go.mod h1:yNLdQdroM42/yDIFlCsLAR9PawAdeJZDgHdAx+wcywg=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/internal/provider/data_source_images.go
+++ b/internal/provider/data_source_images.go
@@ -164,7 +164,7 @@ func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	// Seems unlikely anyone will have more than one billion images.
 	params := oxide.ImageListParams{
 		Project: oxide.NameOrId(state.ProjectID.ValueString()),
-		Limit:   1000000000,
+		Limit:   oxide.NewPointer(1000000000),
 		SortBy:  oxide.NameOrIdSortModeIdAscending,
 	}
 	images, err := d.client.ImageList(ctx, params)

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -115,7 +115,7 @@ func (d *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	// as there are in reality. For now I'll use the List method with a limit of 1,000,000,000 results.
 	// Seems unlikely anyone will have more than one billion projects.
 	params := oxide.ProjectListParams{
-		Limit:  1000000000,
+		Limit:  oxide.NewPointer(1000000000),
 		SortBy: oxide.NameOrIdSortModeNameDescending,
 	}
 	projects, err := d.client.ProjectList(ctx, params)

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -821,7 +821,7 @@ func newAttachedDisksSet(ctx context.Context, client *oxide.Client, instanceID s
 	var diags diag.Diagnostics
 
 	params := oxide.InstanceDiskListParams{
-		Limit:    1000000000,
+		Limit:    oxide.NewPointer(1000000000),
 		Instance: oxide.NameOrId(instanceID),
 	}
 	disks, err := client.InstanceDiskList(ctx, params)
@@ -851,7 +851,7 @@ func newAssociatedSSHKeysOnCreateSet(ctx context.Context, client *oxide.Client, 
 	var diags diag.Diagnostics
 
 	params := oxide.InstanceSshPublicKeyListParams{
-		Limit:    1000000000,
+		Limit:    oxide.NewPointer(1000000000),
 		Instance: oxide.NameOrId(instanceID),
 	}
 	keys, err := client.InstanceSshPublicKeyList(ctx, params)
@@ -919,7 +919,7 @@ func newAttachedNetworkInterfacesModel(ctx context.Context, client *oxide.Client
 
 	params := oxide.InstanceNetworkInterfaceListParams{
 		Instance: oxide.NameOrId(instanceID),
-		Limit:    1000000000,
+		Limit:    oxide.NewPointer(1000000000),
 	}
 	nics, err := client.InstanceNetworkInterfaceList(ctx, params)
 	if err != nil {

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -208,7 +208,7 @@ func (r *ipPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Append information about IP Pool ranges
 	listParams := oxide.IpPoolRangeListParams{
 		Pool:  oxide.NameOrId(ipPool.Id),
-		Limit: 1000000000,
+		Limit: oxide.NewPointer(1000000000),
 	}
 	ipPoolRanges, err := r.client.IpPoolRangeList(ctx, listParams)
 	if err != nil {
@@ -355,7 +355,7 @@ func (r *ipPoolResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		ctx,
 		oxide.IpPoolRangeListParams{
 			Pool:  oxide.NameOrId(state.ID.ValueString()),
-			Limit: 1000000000,
+			Limit: oxide.NewPointer(1000000000),
 		},
 	)
 	if err != nil {

--- a/internal/provider/resource_ip_pool_silo_link.go
+++ b/internal/provider/resource_ip_pool_silo_link.go
@@ -168,7 +168,7 @@ func (r *ipPoolSiloLinkResource) Read(ctx context.Context, req resource.ReadRequ
 
 	params := oxide.IpPoolSiloListParams{
 		Pool:   oxide.NameOrId(state.IPPoolID.ValueString()),
-		Limit:  1000000000,
+		Limit:  oxide.NewPointer(1000000000),
 		SortBy: oxide.IdSortModeIdAscending,
 	}
 

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -195,7 +195,7 @@ func testAccIPPoolSiloLinkDestroy(s *terraform.State) error {
 		siloID := rs.Primary.Attributes["silo_id"]
 		params := oxide.IpPoolSiloListParams{
 			Pool:   oxide.NameOrId(oxide.NameOrId(ipPoolID)),
-			Limit:  1000000000,
+			Limit:  oxide.NewPointer(1000000000),
 			SortBy: oxide.IdSortModeIdAscending,
 		}
 

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -504,20 +504,16 @@ func newVPCFirewallRulesUpdateBody(rules []vpcFirewallRulesResourceRuleModel) *o
 	}
 
 	for _, rule := range rules {
-		priority := rule.Priority.ValueInt64Pointer()
-		if priority == nil {
-			panic("TEMPORARY ERROR")
-		}
-
 		r := oxide.VpcFirewallRuleUpdate{
 			Action:      oxide.VpcFirewallRuleAction(rule.Action.ValueString()),
 			Description: rule.Description.ValueString(),
 			Direction:   oxide.VpcFirewallRuleDirection(rule.Direction.ValueString()),
 			Name:        oxide.Name(rule.Name.ValueString()),
-			Priority:    oxide.NewPointer(int(*priority)),
-			Status:      oxide.VpcFirewallRuleStatus(rule.Status.ValueString()),
-			Filters:     newFilterTypeFromModel(rule.Filters),
-			Targets:     newTargetTypeFromModel(rule.Targets),
+			// We can safely dereference rule.Priority as it's a required field
+			Priority: oxide.NewPointer(int(*rule.Priority.ValueInt64Pointer())),
+			Status:   oxide.VpcFirewallRuleStatus(rule.Status.ValueString()),
+			Filters:  newFilterTypeFromModel(rule.Filters),
+			Targets:  newTargetTypeFromModel(rule.Targets),
 		}
 
 		updateRules = append(updateRules, r)

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -504,12 +504,17 @@ func newVPCFirewallRulesUpdateBody(rules []vpcFirewallRulesResourceRuleModel) *o
 	}
 
 	for _, rule := range rules {
+		priority := rule.Priority.ValueInt64Pointer()
+		if priority == nil {
+			panic("TEMPORARY ERROR")
+		}
+
 		r := oxide.VpcFirewallRuleUpdate{
 			Action:      oxide.VpcFirewallRuleAction(rule.Action.ValueString()),
 			Description: rule.Description.ValueString(),
 			Direction:   oxide.VpcFirewallRuleDirection(rule.Direction.ValueString()),
 			Name:        oxide.Name(rule.Name.ValueString()),
-			Priority:    int(rule.Priority.ValueInt64()),
+			Priority:    oxide.NewPointer(int(*priority)),
 			Status:      oxide.VpcFirewallRuleStatus(rule.Status.ValueString()),
 			Filters:     newFilterTypeFromModel(rule.Filters),
 			Targets:     newTargetTypeFromModel(rule.Targets),
@@ -527,12 +532,13 @@ func newVPCFirewallRulesModel(rules []oxide.VpcFirewallRule) ([]vpcFirewallRules
 
 	for _, rule := range rules {
 		m := vpcFirewallRulesResourceRuleModel{
-			Action:       types.StringValue(string(rule.Action)),
-			Description:  types.StringValue(rule.Description),
-			Direction:    types.StringValue(string(rule.Direction)),
-			ID:           types.StringValue(rule.Id),
-			Name:         types.StringValue(string(rule.Name)),
-			Priority:     types.Int64Value(int64(rule.Priority)),
+			Action:      types.StringValue(string(rule.Action)),
+			Description: types.StringValue(rule.Description),
+			Direction:   types.StringValue(string(rule.Direction)),
+			ID:          types.StringValue(rule.Id),
+			Name:        types.StringValue(string(rule.Name)),
+			// We can safely dereference rule.Priority as it's a required field
+			Priority:     types.Int64Value(int64(*rule.Priority)),
 			Status:       types.StringValue(string(rule.Status)),
 			Targets:      newTargetsModelFromResponse(rule.Targets),
 			TimeCreated:  types.StringValue(rule.TimeCreated.String()),

--- a/internal/provider/resource_vpc_firewall_rules_test.go
+++ b/internal/provider/resource_vpc_firewall_rules_test.go
@@ -113,7 +113,7 @@ resource "oxide_vpc_firewall_rules" "{{.BlockName}}" {
 		 description = "custom deny"
 		 name = "custom-deny-http"
 		 direction = "inbound"
-		 priority = 50
+		 priority = 0
 		 status = "enabled"
 		 filters = {
 		   ports = ["8123"]
@@ -290,7 +290,7 @@ func checkResourceFirewallRulesUpdate(resourceName string) resource.TestCheckFun
 		resource.TestCheckResourceAttr(resourceName, "rules.0.filters.protocols.0", "ICMP"),
 		resource.TestCheckResourceAttrSet(resourceName, "rules.0.id"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.name", "custom-deny-http"),
-		resource.TestCheckResourceAttr(resourceName, "rules.0.priority", "50"),
+		resource.TestCheckResourceAttr(resourceName, "rules.0.priority", "0"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.status", "enabled"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.targets.0.type", "subnet"),
 		resource.TestCheckResourceAttr(resourceName, "rules.0.targets.0.value", "default"),


### PR DESCRIPTION
Depends on https://github.com/oxidecomputer/oxide.go/pull/274

Closes: #403 

Ran acceptance tests against the colo rack

```console
$ make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceImage_full
=== PAUSE TestAccCloudDataSourceImage_full
=== RUN   TestAccCloudDataSourceImages_project
=== PAUSE TestAccCloudDataSourceImages_project
=== RUN   TestAccCloudDataSourceImages_silo
=== PAUSE TestAccCloudDataSourceImages_silo
=== RUN   TestAccCloudDataSourceInstanceExternalIPs_full
=== PAUSE TestAccCloudDataSourceInstanceExternalIPs_full
=== RUN   TestAccCloudDataSourceProject_full
=== PAUSE TestAccCloudDataSourceProject_full
=== RUN   TestAccCloudDataSourceProjects_full
=== PAUSE TestAccCloudDataSourceProjects_full
=== RUN   TestAccCloudDataSourceSSHKey_full
=== PAUSE TestAccCloudDataSourceSSHKey_full
=== RUN   TestAccCloudDataSourceVPCInternetGateway_full
=== PAUSE TestAccCloudDataSourceVPCInternetGateway_full
=== RUN   TestAccCloudDataSourceVPCRouter_full
=== PAUSE TestAccCloudDataSourceVPCRouter_full
=== RUN   TestAccCloudDataSourceVPCSubnet_full
=== PAUSE TestAccCloudDataSourceVPCSubnet_full
=== RUN   TestAccCloudDataSourceVPC_full
=== PAUSE TestAccCloudDataSourceVPC_full
=== RUN   TestAccCloudResourceDisk_full
=== PAUSE TestAccCloudResourceDisk_full
=== RUN   TestAccCloudResourceImage_full
=== PAUSE TestAccCloudResourceImage_full
=== RUN   TestAccCloudResourceInstance_full
=== PAUSE TestAccCloudResourceInstance_full
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== RUN   TestAccCloudResourceInstance_sshKeys
=== PAUSE TestAccCloudResourceInstance_sshKeys
=== RUN   TestAccCloudResourceInstance_nic
=== PAUSE TestAccCloudResourceInstance_nic
=== RUN   TestAccCloudResourceInstance_disk
=== PAUSE TestAccCloudResourceInstance_disk
=== RUN   TestAccCloudResourceInstance_update
=== PAUSE TestAccCloudResourceInstance_update
=== RUN   TestAccCloudResourceProject_full
=== PAUSE TestAccCloudResourceProject_full
=== RUN   TestAccCloudResourceSnapshot_full
=== PAUSE TestAccCloudResourceSnapshot_full
=== RUN   TestAccCloudResourceSSHKey_full
=== PAUSE TestAccCloudResourceSSHKey_full
=== RUN   TestAccCloudResourceFirewallRules_full
=== PAUSE TestAccCloudResourceFirewallRules_full
=== RUN   TestAccCloudResourceVPCInternetGateway_full
=== PAUSE TestAccCloudResourceVPCInternetGateway_full
=== RUN   TestAccCloudResourceVPCRouter_full
=== PAUSE TestAccCloudResourceVPCRouter_full
=== RUN   TestAccCloudResourceVPCSubnet_full
=== PAUSE TestAccCloudResourceVPCSubnet_full
=== RUN   TestAccCloudResourceVPC_full
=== PAUSE TestAccCloudResourceVPC_full
=== CONT  TestAccCloudDataSourceImage_full
=== CONT  TestAccCloudResourceSSHKey_full
=== CONT  TestAccCloudResourceInstance_full
=== CONT  TestAccCloudResourceImage_full
=== CONT  TestAccCloudResourceDisk_full
=== CONT  TestAccCloudResourceInstance_extIPs
--- PASS: TestAccCloudResourceSSHKey_full (0.94s)
=== CONT  TestAccCloudDataSourceVPC_full
--- PASS: TestAccCloudDataSourceImage_full (1.08s)
=== CONT  TestAccCloudDataSourceVPCSubnet_full
--- PASS: TestAccCloudDataSourceVPC_full (0.48s)
=== CONT  TestAccCloudDataSourceVPCRouter_full
--- PASS: TestAccCloudDataSourceVPCSubnet_full (0.47s)
=== CONT  TestAccCloudDataSourceVPCInternetGateway_full
--- PASS: TestAccCloudDataSourceVPCRouter_full (0.52s)
=== CONT  TestAccCloudDataSourceSSHKey_full
--- PASS: TestAccCloudDataSourceVPCInternetGateway_full (0.51s)
=== CONT  TestAccCloudResourceSnapshot_full
--- PASS: TestAccCloudDataSourceSSHKey_full (1.85s)
=== CONT  TestAccCloudDataSourceProjects_full
--- PASS: TestAccCloudDataSourceProjects_full (0.51s)
=== CONT  TestAccCloudResourceProject_full
--- PASS: TestAccCloudResourceDisk_full (6.42s)
=== CONT  TestAccCloudDataSourceProject_full
--- PASS: TestAccCloudResourceProject_full (2.56s)
=== CONT  TestAccCloudResourceInstance_update
--- PASS: TestAccCloudDataSourceProject_full (0.58s)
=== CONT  TestAccCloudDataSourceInstanceExternalIPs_full
--- PASS: TestAccCloudResourceInstance_extIPs (8.09s)
=== CONT  TestAccCloudResourceInstance_disk
--- PASS: TestAccCloudResourceImage_full (17.70s)
=== CONT  TestAccCloudDataSourceImages_silo
--- PASS: TestAccCloudResourceSnapshot_full (15.65s)
=== CONT  TestAccCloudResourceInstance_nic
--- PASS: TestAccCloudDataSourceInstanceExternalIPs_full (12.57s)
=== CONT  TestAccCloudDataSourceImages_project
--- PASS: TestAccCloudDataSourceImages_silo (1.98s)
=== CONT  TestAccCloudResourceInstance_sshKeys
--- PASS: TestAccCloudDataSourceImages_project (0.91s)
=== CONT  TestAccCloudResourceVPCRouter_full
--- PASS: TestAccCloudResourceVPCRouter_full (4.31s)
=== CONT  TestAccCloudResourceVPCInternetGateway_full
--- PASS: TestAccCloudResourceInstance_sshKeys (7.07s)
=== CONT  TestAccCloudResourceVPC_full
--- PASS: TestAccCloudResourceVPCInternetGateway_full (6.50s)
=== CONT  TestAccCloudResourceFirewallRules_full
--- PASS: TestAccCloudResourceInstance_full (32.14s)
=== CONT  TestAccCloudResourceVPCSubnet_full
--- PASS: TestAccCloudResourceVPC_full (6.67s)
--- PASS: TestAccCloudResourceFirewallRules_full (4.36s)
--- PASS: TestAccCloudResourceVPCSubnet_full (3.87s)
--- PASS: TestAccCloudResourceInstance_nic (41.29s)
--- PASS: TestAccCloudResourceInstance_disk (60.11s)
--- PASS: TestAccCloudResourceInstance_update (66.88s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	74.057s
```