### PR TITLE
Anti-affinity groups on instance create

### DIFF
--- a/.changelog/0.8.0.toml
+++ b/.changelog/0.8.0.toml
@@ -3,8 +3,8 @@ title = ""
 description = ""
 
 [[features]]
-title = ""
-description = ""
+title = "New instance argument"
+description = "It is now possible to manage anti-affinity group assigments on instance resources. [#414](https://github.com/oxidecomputer/terraform-provider-oxide/pull/414)."
 
 [[enhancements]]
 title = ""

--- a/docs/resources/oxide_instance.md
+++ b/docs/resources/oxide_instance.md
@@ -6,7 +6,7 @@ page_title: "oxide_instance Resource - terraform-provider-oxide"
 
 This resource manages instances.
 
--> Updates will stop and reboot the instance.
+!> Updates will stop and start the instance.
 
 -> When setting a boot disk using `boot_disk_id`, the boot disk ID must also be
 present in `disk_attachments`.
@@ -27,19 +27,20 @@ resource "oxide_instance" "example" {
 }
 ```
 
-### Instance with user data and an SSH public key
+### Instance with user data and an SSH public key and anti-affinity group
 
 ```hcl
 resource "oxide_instance" "example" {
-  project_id       = "c1dee930-a8e4-11ed-afa1-0242ac120002"
-  description      = "Example instance."
-  name             = "myinstance"
-  host_name        = "myhostname"
-  memory           = 10737418240
-  ncpus            = 1
-  disk_attachments = ["611bb17d-6883-45be-b3aa-8a186fdeafe8"]
-  ssh_public_keys  = ["066cab1b-c550-4aea-8a80-8422fd3bfc40"]
-  user_data        = filebase64("path/to/init.sh")
+  project_id           = "c1dee930-a8e4-11ed-afa1-0242ac120002"
+  description          = "Example instance."
+  name                 = "myinstance"
+  host_name            = "myhostname"
+  memory               = 10737418240
+  ncpus                = 1
+  anti_affinity_groups = ["9b9f9be1-96bf-44ad-864a-0dedae3b3999"]
+  disk_attachments     = ["611bb17d-6883-45be-b3aa-8a186fdeafe8"]
+  ssh_public_keys      = ["066cab1b-c550-4aea-8a80-8422fd3bfc40"]
+  user_data            = filebase64("path/to/init.sh")
 }
 ```
 
@@ -107,6 +108,7 @@ resource "oxide_instance" "example" {
 
 ### Optional
 
+- `anti_affinity_groups` (Set of String, Optional) The IDs of the anti-affinity groups this instance should belong to.
 - `boot_disk_id` (String, Optional) ID of the disk to boot the instance from. When provided, this ID must also be present in `disk_attachments`.
 - `disk_attachments` (Set of String, Optional) IDs of the disks to be attached to the instance. When multiple disk IDs are provided, set `book_disk_id` to specify the boot disk for the instance. Otherwise, a boot disk will be chosen randomly.
 - `external_ips` (Set of Object, Optional) External IP addresses associated with the instance. See [below for nested schema](#nestedatt--ips).

--- a/go.mod
+++ b/go.mod
@@ -70,3 +70,5 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/go.mod
+++ b/go.mod
@@ -70,5 +70,3 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -191,6 +192,36 @@ func Test_sliceDiff_model(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sliceDiff(tt.args.a, tt.args.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_newNameOrIdList(t *testing.T) {
+	tests := []struct {
+		name string
+		args []attr.Value
+		want []oxide.NameOrId
+	}{
+		{
+			name: "success double quote",
+			args: []attr.Value{types.StringValue("d72b0406-dd16-4373-ba2e-b7016ede6c3c"), types.StringValue("bob")},
+			want: []oxide.NameOrId{"d72b0406-dd16-4373-ba2e-b7016ede6c3c", "bob"},
+		},
+		{
+			name: "success backtick",
+			args: []attr.Value{types.StringValue(`d72b0406-dd16-4373-ba2e-b7016ede6c3c`), types.StringValue(`bob`)},
+			want: []oxide.NameOrId{"d72b0406-dd16-4373-ba2e-b7016ede6c3c", "bob"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := types.SetValueMust(types.StringType, tt.args)
+			got, diags := newNameOrIdList(set)
+			if diags.HasError() {
+				// We know diags can only contain a single error in this function
+				t.Errorf("unexpected error: %s: %s ", diags[0].Summary(), diags[0].Detail())
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
Depends on https://github.com/oxidecomputer/oxide.go/pull/276

Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/411

Tested against dogfood rack

```console
$ TEST_ACC_NAME=TestAccCloudResourceInstance make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceInstance_full
=== PAUSE TestAccCloudResourceInstance_full
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== RUN   TestAccCloudResourceInstance_sshKeys
=== PAUSE TestAccCloudResourceInstance_sshKeys
=== RUN   TestAccCloudResourceInstance_nic
=== PAUSE TestAccCloudResourceInstance_nic
=== RUN   TestAccCloudResourceInstance_disk
=== PAUSE TestAccCloudResourceInstance_disk
=== RUN   TestAccCloudResourceInstance_update
=== PAUSE TestAccCloudResourceInstance_update
=== RUN   TestAccCloudResourceInstance_antiAffinityGroups
=== PAUSE TestAccCloudResourceInstance_antiAffinityGroups
=== CONT  TestAccCloudResourceInstance_full
=== CONT  TestAccCloudResourceInstance_disk
=== CONT  TestAccCloudResourceInstance_antiAffinityGroups
=== CONT  TestAccCloudResourceInstance_sshKeys
=== CONT  TestAccCloudResourceInstance_extIPs
=== CONT  TestAccCloudResourceInstance_nic
--- PASS: TestAccCloudResourceInstance_extIPs (9.82s)
=== CONT  TestAccCloudResourceInstance_update
--- PASS: TestAccCloudResourceInstance_sshKeys (9.87s)
--- PASS: TestAccCloudResourceInstance_full (39.50s)
--- PASS: TestAccCloudResourceInstance_antiAffinityGroups (44.39s)
--- PASS: TestAccCloudResourceInstance_nic (45.10s)
--- PASS: TestAccCloudResourceInstance_disk (58.12s)
--- PASS: TestAccCloudResourceInstance_update (67.77s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	77.921s
```
