### PR TITLE
New anti-affinity group resource and datasource

### DIFF
--- a/.changelog/0.8.0.toml
+++ b/.changelog/0.8.0.toml
@@ -6,6 +6,10 @@ description = ""
 title = ""
 description = ""
 
+[[features]]
+title = "New resource"
+description = "`oxide_anti_affinity_group` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+
 [[enhancements]]
 title = ""
 description = ""

--- a/.changelog/0.8.0.toml
+++ b/.changelog/0.8.0.toml
@@ -10,6 +10,10 @@ description = ""
 title = "New resource"
 description = "`oxide_anti_affinity_group` [#415](https://github.com/oxidecomputer/terraform-provider-oxide/pull/415)."
 
+[[features]]
+title = "New data source"
+description = "`oxide_anti_affinity_group` [#415](https://github.com/oxidecomputer/terraform-provider-oxide/pull/415)."
+
 [[enhancements]]
 title = ""
 description = ""

--- a/.changelog/0.8.0.toml
+++ b/.changelog/0.8.0.toml
@@ -8,7 +8,7 @@ description = ""
 
 [[features]]
 title = "New resource"
-description = "`oxide_anti_affinity_group` [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)."
+description = "`oxide_anti_affinity_group` [#415](https://github.com/oxidecomputer/terraform-provider-oxide/pull/415)."
 
 [[enhancements]]
 title = ""

--- a/docs/data-sources/oxide_anti_affinity_group.md
+++ b/docs/data-sources/oxide_anti_affinity_group.md
@@ -1,0 +1,57 @@
+---
+page_title: "oxide_anti_affinity_group Data Source - terraform-provider-oxide"
+---
+
+# oxide_anti_affinity_group (Data Source)
+
+Retrieve information about a specified anti-affinity group.
+
+## Example Usage
+
+```hcl
+data "oxide_anti_affinity_group" "example" {
+  project_name = "my-project"
+  name         = "my-group"
+  timeouts = {
+    read = "1m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the anti-affinity group.
+- `project_name` (String) Name of the project that contains the anti-affinity group.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `description` (String) Description of the anti-affinity group.
+- `failure_domain` (String) Describes the scope of affinity for the purposes of co-location.
+- `id` (String) Unique, immutable, system-controlled identifier for the anti-affinity group.
+- `policy` (String) Affinity policy used to describe what to do when a request cannot be satisfied.
+- `project_id` (String) ID of the project that contains the anti-affinity group.
+- `time_created` (String) Timestamp of when this anti-affinity group was created.
+- `time_modified` (String) Timestamp of when this anti-affinity group was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `read` (String, Default `10m`)
+
+<a id="nestedobject--digest"></a>
+
+### Nested Schema for `digest`
+
+Read-Only:
+
+- `type` (String) Digest type.
+- `value` (String) Digest type value.

--- a/docs/resources/oxide_anti_affinity_group.md
+++ b/docs/resources/oxide_anti_affinity_group.md
@@ -29,7 +29,7 @@ resource "oxide_anti_affinity_group" "example" {
 
 - `description` (String) Description for the anti-affinity group.
 - `name` (String) Name of the anti-affinity group.
-- `policy` (String) Affinity policy used to describe what to do when a request cannot be satisfied.
+- `policy` (String) Affinity policy used to describe what to do when a request cannot be satisfied. Possible values are: `allow` or `fail`.
 - `project_id` (String) ID of the project that will contain the anti-affinity group.
 
 ### Optional

--- a/docs/resources/oxide_anti_affinity_group.md
+++ b/docs/resources/oxide_anti_affinity_group.md
@@ -1,0 +1,55 @@
+---
+page_title: "oxide_anti_affinity_group Resource - terraform-provider-oxide"
+---
+
+# oxide_anti_affinity_group (Resource)
+
+This resource manages anti-affinity groups.
+
+## Example Usage
+
+```hcl
+resource "oxide_anti_affinity_group" "example" {
+  project_id  = "c1dee930-a8e4-11ed-afa1-0242ac120002"
+  description = "a test anti-affinity group"
+  name        = "my-anti-affinty-group"
+  policy      = "allow"
+  timeouts = {
+    read   = "1m"
+    create = "3m"
+    delete = "2m"
+    update = "2m"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `description` (String) Description for the anti-affinity group.
+- `name` (String) Name of the anti-affinity group.
+- `policy` (String) Affinity policy used to describe what to do when a request cannot be satisfied.
+- `project_id` (String) ID of the project that will contain the anti-affinity group.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier of the anti-affinity group.
+- `failure_domain` (String) Describes the scope of affinity for the purposes of co-location.
+- `time_created` (String) Timestamp of when this anti-affinity group was created.
+- `time_modified` (String) Timestamp of when this anti-affinity group was last modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String, Default `10m`)
+- `delete` (String, Default `10m`)
+- `read` (String, Default `10m`)
+- `update` (String, Default `10m`)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
-	github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352
+	github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -70,5 +70,3 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/go.mod
+++ b/go.mod
@@ -70,3 +70,5 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/oxidecomputer/oxide.go => ../oxide.go

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352 h1:C7+yo9PnkjVkS4UvhX0gMUQhzaBbS5L8WTsEraSdgyM=
-github.com/oxidecomputer/oxide.go v0.3.1-0.20250328231836-c8be65844352/go.mod h1:yNLdQdroM42/yDIFlCsLAR9PawAdeJZDgHdAx+wcywg=
+github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a h1:Zn3udDHSZA6zqrxm9m2gx1oRFpEBa44nM1U+FiYZbjY=
+github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a/go.mod h1:yNLdQdroM42/yDIFlCsLAR9PawAdeJZDgHdAx+wcywg=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/internal/provider/data_source_anti_affinity_group.go
+++ b/internal/provider/data_source_anti_affinity_group.go
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var (
+	_ datasource.DataSource              = (*antiAffinityGroupDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*antiAffinityGroupDataSource)(nil)
+)
+
+// NewAntiAffinityGroupDataSource initialises an anti-affinity group datasource
+func NewAntiAffinityGroupDataSource() datasource.DataSource {
+	return &antiAffinityGroupDataSource{}
+}
+
+type antiAffinityGroupDataSource struct {
+	client *oxide.Client
+}
+
+type antiAffinityGroupDataSourceModel struct {
+	Description   types.String   `tfsdk:"description"`
+	FailureDomain types.String   `tfsdk:"failure_domain"`
+	ID            types.String   `tfsdk:"id"`
+	Name          types.String   `tfsdk:"name"`
+	Policy        types.String   `tfsdk:"policy"`
+	ProjectID     types.String   `tfsdk:"project_id"`
+	TimeCreated   types.String   `tfsdk:"time_created"`
+	TimeModified  types.String   `tfsdk:"time_modified"`
+	Timeouts      timeouts.Value `tfsdk:"timeouts"`
+	ProjectName   types.String   `tfsdk:"project_name"`
+}
+
+func (d *antiAffinityGroupDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "oxide_anti_affinity_group"
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *antiAffinityGroupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.client = req.ProviderData.(*oxide.Client)
+}
+
+func (d *antiAffinityGroupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the project that contains the anti-affinity group.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the anti-affinity group.",
+			},
+			"project_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the project that contains the anti-affinity group.",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Description for the anti-affinity group.",
+			},
+			"policy": schema.StringAttribute{
+				Computed:    true,
+				Description: "Affinity policy used to describe what to do when a request cannot be satisfied.",
+			},
+			"failure_domain": schema.StringAttribute{
+				Computed:    true,
+				Description: "Describes the scope of affinity for the purposes of co-location.",
+			},
+			"timeouts": timeouts.Attributes(ctx),
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the anti-affinity group.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this anti-affinity group was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this anti-affinity group was last modified.",
+			},
+		},
+	}
+}
+
+func (d *antiAffinityGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state antiAffinityGroupDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.AntiAffinityGroupViewParams{
+		AntiAffinityGroup: oxide.NameOrId(state.Name.ValueString()),
+		Project:           oxide.NameOrId(state.ProjectName.ValueString()),
+	}
+	antiAffinityGroup, err := d.client.AntiAffinityGroupView(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read anti-affinity group:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read anti-affinity group with ID: %v", antiAffinityGroup.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(antiAffinityGroup.Description)
+	state.FailureDomain = types.StringValue(string(antiAffinityGroup.FailureDomain))
+	state.ID = types.StringValue(antiAffinityGroup.Id)
+	state.Name = types.StringValue(string(antiAffinityGroup.Name))
+	state.Policy = types.StringValue(string(antiAffinityGroup.Policy))
+	state.ProjectID = types.StringValue(antiAffinityGroup.ProjectId)
+	state.TimeCreated = types.StringValue(antiAffinityGroup.TimeCreated.String())
+	state.TimeModified = types.StringValue(antiAffinityGroup.TimeModified.String())
+
+	// Save state into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/data_source_anti_affinity_group_test.go
+++ b/internal/provider/data_source_anti_affinity_group_test.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type dataSourceAntiAffinityGroupConfig struct {
+	BlockName         string
+	Name              string
+	SupportBlockName  string
+	SupportBlockName2 string
+}
+
+var dataSourceAntiAffinityGroupConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_anti_affinity_group" "{{.SupportBlockName2}}" {
+  project_id  = data.oxide_project.{{.SupportBlockName}}.id
+  name        = "{{.Name}}"
+  description = "a group"
+  policy      = "allow"
+}
+
+data "oxide_anti_affinity_group" "{{.BlockName}}" {
+  project_name = "tf-acc-test"
+  name         = oxide_anti_affinity_group.{{.SupportBlockName2}}.name
+  timeouts = {
+    read = "1m"
+  }
+}
+`
+
+func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
+	blockName := newBlockName("datasource-anti-affinity-group")
+	resourceName := newResourceName()
+	config, err := parsedAccConfig(
+		dataSourceAntiAffinityGroupConfig{
+			BlockName:         blockName,
+			SupportBlockName:  newBlockName("support"),
+			SupportBlockName2: newBlockName("support"),
+			Name:              resourceName,
+		},
+		dataSourceAntiAffinityGroupConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkDataSourceAntiAffinityGroup(
+					fmt.Sprintf("data.oxide_anti_affinity_group.%s", blockName),
+					resourceName,
+				),
+			},
+		},
+	})
+}
+
+func checkDataSourceAntiAffinityGroup(dataName, keyName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(dataName, "id"),
+		resource.TestCheckResourceAttr(dataName, "name", keyName),
+		resource.TestCheckResourceAttr(dataName, "description", "a group"),
+		resource.TestCheckResourceAttr(dataName, "policy", "allow"),
+		resource.TestCheckResourceAttr(dataName, "failure_domain", "sled"),
+		resource.TestCheckResourceAttrSet(dataName, "project_id"),
+		resource.TestCheckResourceAttrSet(dataName, "time_created"),
+		resource.TestCheckResourceAttrSet(dataName, "time_modified"),
+		resource.TestCheckResourceAttr(dataName, "timeouts.read", "1m"),
+	}...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -179,6 +179,7 @@ func (p *oxideProvider) DataSources(_ context.Context) []func() datasource.DataS
 // Resources defines the resources implemented in the provider.
 func (p *oxideProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewAntiAffinityGroupResource,
 		NewDiskResource,
 		NewImageResource,
 		NewInstanceResource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,6 +161,7 @@ func (p *oxideProvider) Configure(ctx context.Context, req provider.ConfigureReq
 // DataSources defines the data sources implemented in the provider.
 func (p *oxideProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewAntiAffinityGroupDataSource,
 		NewImageDataSource,
 		NewImagesDataSource,
 		NewInstanceExternalIPsDataSource,

--- a/internal/provider/resource_anti_affinity_group.go
+++ b/internal/provider/resource_anti_affinity_group.go
@@ -1,0 +1,321 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource              = (*antiAffinityGroupResource)(nil)
+	_ resource.ResourceWithConfigure = (*antiAffinityGroupResource)(nil)
+)
+
+// NewAntiAffinityGroupResource is a helper function to simplify the provider implementation.
+func NewAntiAffinityGroupResource() resource.Resource {
+	return &antiAffinityGroupResource{}
+}
+
+// antiAffinityGroupResource is the resource implementation.
+type antiAffinityGroupResource struct {
+	client *oxide.Client
+}
+
+type antiAffinityGroupResourceModel struct {
+	Description   types.String   `tfsdk:"description"`
+	FailureDomain types.String   `tfsdk:"failure_domain"`
+	ID            types.String   `tfsdk:"id"`
+	Name          types.String   `tfsdk:"name"`
+	Policy        types.String   `tfsdk:"policy"`
+	ProjectID     types.String   `tfsdk:"project_id"`
+	TimeCreated   types.String   `tfsdk:"time_created"`
+	TimeModified  types.String   `tfsdk:"time_modified"`
+	Timeouts      timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Metadata returns the resource type name.
+func (r *antiAffinityGroupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "oxide_anti_affinity_group"
+}
+
+// Configure adds the provider configured client to the data source.
+func (r *antiAffinityGroupResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*oxide.Client)
+}
+
+func (r *antiAffinityGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Schema defines the schema for the resource.
+func (r *antiAffinityGroupResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the project that will contain the anti-affinity group.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the anti-affinity group.",
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Description for the anti-affinity group.",
+			},
+			"policy": schema.StringAttribute{
+				Required:    true,
+				Description: "Affinity policy used to describe what to do when a request cannot be satisfied",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(oxide.AffinityPolicyAllow),
+						string(oxide.AffinityPolicyFail),
+					),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the anti-affinity group.",
+			},
+			"failure_domain": schema.StringAttribute{
+				// For now this will remain as a computed attribute as there is
+				// only a single option: "sled".
+				Computed:    true,
+				Description: "Describes the scope of affinity for the purposes of co-location.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this anti-affinity group was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this anti-affinity group was last modified.",
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *antiAffinityGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan antiAffinityGroupResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	params := oxide.AntiAffinityGroupCreateParams{
+		Project: oxide.NameOrId(plan.ProjectID.ValueString()),
+		Body: &oxide.AntiAffinityGroupCreate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+			// TODO: For now, the only option is "sled", change this into
+			// an attribute when there are more options.
+			FailureDomain: oxide.FailureDomainSled,
+			Policy:        oxide.AffinityPolicy(plan.Policy.ValueString()),
+		},
+	}
+	antiAffinityGroup, err := r.client.AntiAffinityGroupCreate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating AntiAffinityGroup",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("created AntiAffinityGroup with ID: %v", antiAffinityGroup.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(antiAffinityGroup.Id)
+	plan.FailureDomain = types.StringValue(string(antiAffinityGroup.FailureDomain))
+	plan.TimeCreated = types.StringValue(antiAffinityGroup.TimeCreated.String())
+	plan.TimeModified = types.StringValue(antiAffinityGroup.TimeModified.String())
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *antiAffinityGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state antiAffinityGroupResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.AntiAffinityGroupViewParams{
+		AntiAffinityGroup: oxide.NameOrId(state.ID.ValueString()),
+	}
+	antiAffinityGroup, err := r.client.AntiAffinityGroupView(ctx, params)
+	if err != nil {
+		if is404(err) {
+			// Remove resource from state during a refresh
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to read anti-affinity group:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read anti-affinity group with ID: %v", antiAffinityGroup.Id), map[string]any{"success": true})
+
+	state.Description = types.StringValue(antiAffinityGroup.Description)
+	state.FailureDomain = types.StringValue(string(antiAffinityGroup.FailureDomain))
+	state.ID = types.StringValue(antiAffinityGroup.Id)
+	state.Policy = types.StringValue(string(antiAffinityGroup.Policy))
+	state.Name = types.StringValue(string(antiAffinityGroup.Name))
+	state.ProjectID = types.StringValue(antiAffinityGroup.ProjectId)
+	state.TimeCreated = types.StringValue(antiAffinityGroup.TimeCreated.String())
+	state.TimeModified = types.StringValue(antiAffinityGroup.TimeModified.String())
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *antiAffinityGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan antiAffinityGroupResourceModel
+	var state antiAffinityGroupResourceModel
+
+	// Read Terraform plan data into the plan model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Read Terraform prior state data into the state model to retrieve ID
+	// which is a computed attribute, so it won't show up in the plan.
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	params := oxide.AntiAffinityGroupUpdateParams{
+		AntiAffinityGroup: oxide.NameOrId(state.ID.ValueString()),
+		Body: &oxide.AntiAffinityGroupUpdate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+		},
+	}
+	antiAffinityGroup, err := r.client.AntiAffinityGroupUpdate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating anti-affinity group",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("updated anti-affinity group with ID: %v", antiAffinityGroup.Id), map[string]any{"success": true})
+
+	// Map response body to schema and populate Computed attribute values
+	plan.ID = types.StringValue(antiAffinityGroup.Id)
+	plan.FailureDomain = types.StringValue(string(antiAffinityGroup.FailureDomain))
+	plan.TimeCreated = types.StringValue(antiAffinityGroup.TimeCreated.String())
+	plan.TimeModified = types.StringValue(antiAffinityGroup.TimeModified.String())
+
+	// Save plan into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *antiAffinityGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state antiAffinityGroupResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	params := oxide.AntiAffinityGroupDeleteParams{
+		AntiAffinityGroup: oxide.NameOrId(state.ID.ValueString()),
+	}
+	if err := r.client.AntiAffinityGroupDelete(ctx, params); err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Error deleting AntiAffinityGroup:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted AntiAffinityGroup with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+}

--- a/internal/provider/resource_anti_affinity_group_test.go
+++ b/internal/provider/resource_anti_affinity_group_test.go
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+type resourceAntiAffinityGroupConfig struct {
+	BlockName             string
+	SupportBlockName      string
+	AntiAffinityGroupName string
+}
+
+var resourceAntiAffinityGroupConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_anti_affinity_group" "{{.BlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	description = "a test anti-affinity group"
+	name        = "{{.AntiAffinityGroupName}}"
+	policy      = "allow"
+	timeouts = {
+		read   = "1m"
+		create = "3m"
+		delete = "2m"
+		update = "4m"
+	}
+  }
+`
+
+var resourceAntiAffinityGroupUpdateConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_anti_affinity_group" "{{.BlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	description = "a test updated"
+	name        = "{{.AntiAffinityGroupName}}"
+	policy      = "allow"
+  }
+`
+
+func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
+	antiAffinityGroupName := newResourceName()
+	blockName := newBlockName("anti_affinity_group")
+	resourceName := fmt.Sprintf("oxide_anti_affinity_group.%s", blockName)
+	supportBlockName := newBlockName("support")
+	config, err := parsedAccConfig(
+		resourceAntiAffinityGroupConfig{
+			BlockName:             blockName,
+			AntiAffinityGroupName: antiAffinityGroupName,
+			SupportBlockName:      supportBlockName,
+		},
+		resourceAntiAffinityGroupConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	antiAffinityGroupNameUpdated := antiAffinityGroupName + "-updated"
+	configUpdate, err := parsedAccConfig(
+		resourceAntiAffinityGroupConfig{
+			BlockName:             blockName,
+			AntiAffinityGroupName: antiAffinityGroupNameUpdated,
+			SupportBlockName:      supportBlockName,
+		},
+		resourceAntiAffinityGroupUpdateConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccAntiAffinityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  checkResourceAntiAffinityGroup(resourceName, antiAffinityGroupName),
+			},
+			{
+				Config: configUpdate,
+				Check:  checkResourceAntiAffinityGroupUpdate(resourceName, antiAffinityGroupNameUpdated),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func checkResourceAntiAffinityGroup(resourceName, antiAffinityGroupName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test anti-affinity group"),
+		resource.TestCheckResourceAttr(resourceName, "name", antiAffinityGroupName),
+		resource.TestCheckResourceAttr(resourceName, "failure_domain", "sled"),
+		resource.TestCheckResourceAttr(resourceName, "policy", "allow"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "1m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "2m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "3m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "4m"),
+	}...)
+}
+
+func checkResourceAntiAffinityGroupUpdate(resourceName, antiAffinityGroupName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test updated"),
+		resource.TestCheckResourceAttr(resourceName, "name", antiAffinityGroupName),
+		resource.TestCheckResourceAttr(resourceName, "failure_domain", "sled"),
+		resource.TestCheckResourceAttr(resourceName, "policy", "allow"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccAntiAffinityGroupDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_anti_affinity_group" {
+			continue
+		}
+
+		params := oxide.VpcViewParams{
+			Vpc: oxide.NameOrId(rs.Primary.Attributes["id"]),
+		}
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+
+		res, err := client.VpcView(ctx, params)
+		if err != nil && is404(err) {
+			continue
+		}
+
+		return fmt.Errorf("anti-affinity group (%v) still exists", &res.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Depends on https://github.com/oxidecomputer/oxide.go/pull/276

Closes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/416

Tested against the dogfood rack

```console
$ TEST_ACC_NAME=TestAccCloudResourceAntiAffinityGroup_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceAntiAffinityGroup_full
=== PAUSE TestAccCloudResourceAntiAffinityGroup_full
=== CONT  TestAccCloudResourceAntiAffinityGroup_full
--- PASS: TestAccCloudResourceAntiAffinityGroup_full (4.44s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	4.771s
```

```console
$ TEST_ACC_NAME=TestAccCloudDataSourceAntiAffinityGroup_full make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceAntiAffinityGroup_full
=== PAUSE TestAccCloudDataSourceAntiAffinityGroup_full
=== CONT  TestAccCloudDataSourceAntiAffinityGroup_full
--- PASS: TestAccCloudDataSourceAntiAffinityGroup_full (2.13s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	2.454s
```