### PR TITLE
Update SDK to v0.4.0 and doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/examples/demo/demo.tf
+++ b/examples/demo/demo.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/examples/disk_resource/disk.tf
+++ b/examples/disk_resource/disk.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/examples/instance_resource/instance.tf
+++ b/examples/instance_resource/instance.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/examples/vpc_resource/vpc.tf
+++ b/examples/vpc_resource/vpc.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.7.0"
+      version = "0.8.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
-	github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a
+	github.com/oxidecomputer/oxide.go v0.4.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a h1:Zn3udDHSZA6zqrxm9m2gx1oRFpEBa44nM1U+FiYZbjY=
-github.com/oxidecomputer/oxide.go v0.3.1-0.20250403205243-894605d0e70a/go.mod h1:yNLdQdroM42/yDIFlCsLAR9PawAdeJZDgHdAx+wcywg=
+github.com/oxidecomputer/oxide.go v0.4.0 h1:Y15OPFd1TsUtYp5ivK1ROEkRH+WVHOuy0kJxVs9+dkM=
+github.com/oxidecomputer/oxide.go v0.4.0/go.mod h1:yNLdQdroM42/yDIFlCsLAR9PawAdeJZDgHdAx+wcywg=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=


### PR DESCRIPTION
Tested against the colo rack

```console
make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceAntiAffinityGroup_full
=== PAUSE TestAccCloudDataSourceAntiAffinityGroup_full
=== RUN   TestAccCloudDataSourceImage_full
=== PAUSE TestAccCloudDataSourceImage_full
=== RUN   TestAccCloudDataSourceImages_project
=== PAUSE TestAccCloudDataSourceImages_project
=== RUN   TestAccCloudDataSourceImages_silo
=== PAUSE TestAccCloudDataSourceImages_silo
=== RUN   TestAccCloudDataSourceInstanceExternalIPs_full
=== PAUSE TestAccCloudDataSourceInstanceExternalIPs_full
=== RUN   TestAccCloudDataSourceProject_full
=== PAUSE TestAccCloudDataSourceProject_full
=== RUN   TestAccCloudDataSourceProjects_full
=== PAUSE TestAccCloudDataSourceProjects_full
=== RUN   TestAccCloudDataSourceSSHKey_full
=== PAUSE TestAccCloudDataSourceSSHKey_full
=== RUN   TestAccCloudDataSourceVPCInternetGateway_full
=== PAUSE TestAccCloudDataSourceVPCInternetGateway_full
=== RUN   TestAccCloudDataSourceVPCRouter_full
=== PAUSE TestAccCloudDataSourceVPCRouter_full
=== RUN   TestAccCloudDataSourceVPCSubnet_full
=== PAUSE TestAccCloudDataSourceVPCSubnet_full
=== RUN   TestAccCloudDataSourceVPC_full
=== PAUSE TestAccCloudDataSourceVPC_full
=== RUN   TestAccCloudResourceAntiAffinityGroup_full
=== PAUSE TestAccCloudResourceAntiAffinityGroup_full
=== RUN   TestAccCloudResourceDisk_full
=== PAUSE TestAccCloudResourceDisk_full
=== RUN   TestAccCloudResourceImage_full
=== PAUSE TestAccCloudResourceImage_full
=== RUN   TestAccCloudResourceInstance_full
=== PAUSE TestAccCloudResourceInstance_full
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== RUN   TestAccCloudResourceInstance_sshKeys
=== PAUSE TestAccCloudResourceInstance_sshKeys
=== RUN   TestAccCloudResourceInstance_nic
=== PAUSE TestAccCloudResourceInstance_nic
=== RUN   TestAccCloudResourceInstance_disk
=== PAUSE TestAccCloudResourceInstance_disk
=== RUN   TestAccCloudResourceInstance_update
=== PAUSE TestAccCloudResourceInstance_update
=== RUN   TestAccCloudResourceInstance_antiAffinityGroups
=== PAUSE TestAccCloudResourceInstance_antiAffinityGroups
=== RUN   TestAccCloudResourceProject_full
=== PAUSE TestAccCloudResourceProject_full
=== RUN   TestAccCloudResourceSnapshot_full
=== PAUSE TestAccCloudResourceSnapshot_full
=== RUN   TestAccCloudResourceSSHKey_full
=== PAUSE TestAccCloudResourceSSHKey_full
=== RUN   TestAccCloudResourceFirewallRules_full
=== PAUSE TestAccCloudResourceFirewallRules_full
=== RUN   TestAccCloudResourceVPCInternetGateway_full
=== PAUSE TestAccCloudResourceVPCInternetGateway_full
=== RUN   TestAccCloudResourceVPCRouter_full
=== PAUSE TestAccCloudResourceVPCRouter_full
=== RUN   TestAccCloudResourceVPCSubnet_full
=== PAUSE TestAccCloudResourceVPCSubnet_full
=== RUN   TestAccCloudResourceVPC_full
=== PAUSE TestAccCloudResourceVPC_full
=== CONT  TestAccCloudDataSourceAntiAffinityGroup_full
=== CONT  TestAccCloudResourceInstance_full
=== CONT  TestAccCloudResourceImage_full
=== CONT  TestAccCloudResourceSnapshot_full
=== CONT  TestAccCloudResourceVPCRouter_full
=== CONT  TestAccCloudResourceVPC_full
--- PASS: TestAccCloudDataSourceAntiAffinityGroup_full (5.55s)
=== CONT  TestAccCloudResourceVPCSubnet_full
--- PASS: TestAccCloudResourceVPCRouter_full (13.90s)
=== CONT  TestAccCloudResourceVPCInternetGateway_full
--- PASS: TestAccCloudResourceVPC_full (15.60s)
=== CONT  TestAccCloudResourceSSHKey_full
--- PASS: TestAccCloudResourceSSHKey_full (3.73s)
=== CONT  TestAccCloudDataSourceSSHKey_full
--- PASS: TestAccCloudResourceVPCSubnet_full (15.42s)
=== CONT  TestAccCloudResourceDisk_full
--- PASS: TestAccCloudDataSourceSSHKey_full (2.32s)
=== CONT  TestAccCloudResourceInstance_disk
--- PASS: TestAccCloudResourceSnapshot_full (23.81s)
=== CONT  TestAccCloudResourceAntiAffinityGroup_full
--- PASS: TestAccCloudResourceImage_full (23.95s)
=== CONT  TestAccCloudResourceProject_full
--- PASS: TestAccCloudResourceVPCInternetGateway_full (10.20s)
=== CONT  TestAccCloudDataSourceVPC_full
--- PASS: TestAccCloudDataSourceVPC_full (3.53s)
=== CONT  TestAccCloudResourceInstance_antiAffinityGroups
=== CONT  TestAccCloudDataSourceVPCSubnet_full
--- PASS: TestAccCloudResourceProject_full (7.56s)
--- PASS: TestAccCloudResourceAntiAffinityGroup_full (7.85s)
=== CONT  TestAccCloudResourceInstance_update
--- PASS: TestAccCloudDataSourceVPCSubnet_full (1.16s)
=== CONT  TestAccCloudDataSourceVPCRouter_full
--- PASS: TestAccCloudResourceDisk_full (11.97s)
=== CONT  TestAccCloudDataSourceVPCInternetGateway_full
--- PASS: TestAccCloudDataSourceVPCInternetGateway_full (2.18s)
=== CONT  TestAccCloudResourceInstance_sshKeys
--- PASS: TestAccCloudDataSourceVPCRouter_full (2.45s)
=== CONT  TestAccCloudResourceInstance_extIPs
--- PASS: TestAccCloudResourceInstance_full (45.36s)
=== CONT  TestAccCloudResourceInstance_nic
--- PASS: TestAccCloudResourceInstance_extIPs (11.28s)
=== CONT  TestAccCloudDataSourceInstanceExternalIPs_full
--- PASS: TestAccCloudResourceInstance_sshKeys (11.57s)
=== CONT  TestAccCloudDataSourceImages_project
--- PASS: TestAccCloudDataSourceImages_project (2.22s)
=== CONT  TestAccCloudDataSourceProjects_full
--- PASS: TestAccCloudDataSourceProjects_full (3.01s)
=== CONT  TestAccCloudDataSourceImages_silo
--- PASS: TestAccCloudDataSourceImages_silo (1.16s)
=== CONT  TestAccCloudDataSourceProject_full
--- PASS: TestAccCloudDataSourceProject_full (0.99s)
=== CONT  TestAccCloudDataSourceImage_full
--- PASS: TestAccCloudDataSourceInstanceExternalIPs_full (10.69s)
=== CONT  TestAccCloudResourceFirewallRules_full
--- PASS: TestAccCloudDataSourceImage_full (4.93s)
--- PASS: TestAccCloudResourceFirewallRules_full (19.99s)
--- PASS: TestAccCloudResourceInstance_antiAffinityGroups (50.76s)
--- PASS: TestAccCloudResourceInstance_disk (72.91s)
--- PASS: TestAccCloudResourceInstance_nic (52.85s)
--- PASS: TestAccCloudResourceInstance_update (70.36s)
PASS
ok  	github.com/oxidecomputer/terraform-provider-oxide/internal/provider	102.438s
```