### PR TITLE
oxide_floating_ip: initial resource and data source

### DIFF
--- a/.changelog/0.9.0.toml
+++ b/.changelog/0.9.0.toml
@@ -3,8 +3,12 @@ title = ""
 description = ""
 
 [[features]]
-title = ""
-description = ""
+title = "New resource"
+description = "`oxide_floating_ip` [#427](https://github.com/oxidecomputer/terraform-provider-oxide/pull/427)."
+
+[[features]]
+title = "New data resource"
+description = "`oxide_floating_ip` [#427](https://github.com/oxidecomputer/terraform-provider-oxide/pull/427)."
 
 [[enhancements]]
 title = ""

--- a/docs/data-sources/oxide_floating_ip.md
+++ b/docs/data-sources/oxide_floating_ip.md
@@ -1,0 +1,46 @@
+---
+page_title: "oxide_floating_ip Data Source - terraform-provider-oxide"
+---
+
+# oxide_floating_ip (Data Source)
+
+Retrieve information about a specified floating IP.
+
+## Example Usage
+
+```hcl
+data "oxide_floating_ip" "example" {
+  project_name = "my-project"
+  name         = "app-ingress"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the floating IP.
+- `project_name` (String) Name of the project that contains the floating IP.
+
+### Optional
+
+- `timeouts` (Attribute, Optional) (see [below for nested schema](#nestedatt--timeouts))
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier for the floating IP.
+- `description` (String) Description for the floating IP.
+- `ip` (String) IP address for this floating IP.
+- `ip_pool_id` (String) ID of the IP pool where the floating IP was allocated from.
+- `instance_id` (String) Instance ID that this floating IP is attached to, if presently attached.
+- `time_created` (String) Timestamp of when the floating IP was created.
+- `time_modified` (String) Timestamp of when the floating IP was modified.
+- `timeouts` (Attribute, Optional) Timeouts for performing API operations. See [below for nested schema](#nestedatt--timeouts).
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `read` (String, Default `10m`)

--- a/docs/resources/oxide_floating_ip.md
+++ b/docs/resources/oxide_floating_ip.md
@@ -1,0 +1,74 @@
+---
+page_title: "oxide_floating_ip Resource - terraform-provider-oxide"
+---
+
+# oxide_floating_ip (Resource)
+
+This resource manages Oxide floating IPs.
+
+## Example Usage
+
+### Allocate a floating IP from the silo's default IP pool
+
+```hcl
+resource "oxide_floating_ip" "example" {
+  project_id  = "5476ccc9-464d-4dc4-bfc0-5154de1c986f"
+  name        = "app-ingress"
+  description = "Ingress for application."
+}
+```
+
+### Allocate a floating IP from the specified IP pool 
+
+```hcl
+resource "oxide_floating_ip" "example" {
+  project_id  = "5476ccc9-464d-4dc4-bfc0-5154de1c986f"
+  name        = "app-ingress"
+  description = "Ingress for application."
+  ip_pool_id  = "a4720b36-006b-49fc-a029-583528f18a4d"
+}
+```
+
+### Allocate a specific floating IP from the specified IP pool
+
+```hcl
+resource "oxide_floating_ip" "example" {
+  project_id  = "5476ccc9-464d-4dc4-bfc0-5154de1c986f"
+  name        = "app-ingress"
+  description = "Ingress for application."
+  ip_pool_id  = "a4720b36-006b-49fc-a029-583528f18a4d"
+  ip          = "172.21.252.128"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the floating IP.
+- `description` (String) Description for the floating IP.
+- `project_id` (String) ID of the project that will contain the floating IP.
+
+### Optional
+
+- `ip` (String) IP address for this floating IP. If unset, an IP address will be chosen from the given `ip_pool_id`, or the silo's default IP pool if the `ip_pool_id` attribute is unset.
+- `ip_pool_id` (String) ID of the IP pool where the floating IP will be allocated from. If unset, the silo's default IP pool is used.
+- `timeouts` (Attribute, Optional) Timeouts for performing API operations. See [below for nested schema](#nestedatt--timeouts).
+
+### Read-Only
+
+- `id` (String) Unique, immutable, system-controlled identifier for the floating IP.
+- `instance_id` (String) Instance ID that this floating IP is attached to, if presently attached.
+- `time_created` (String) Timestamp of when the floating IP was created.
+- `time_modified` (String) Timestamp of when the floating IP was modified.
+
+<a id="nestedatt--timeouts"></a>
+
+### Nested Schema for `timeouts`
+
+#### Optional
+
+- `create` (String, Default `10m`)
+- `delete` (String, Default `10m`)
+- `read` (String, Default `10m`)
+- `update` (String, Default `10m`)

--- a/internal/provider/data_source_floating_ip.go
+++ b/internal/provider/data_source_floating_ip.go
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// floatingIPDataSourceModel represents the Terraform configuration and state
+// for the Oxide floating IP resource.
+type floatingIPDataSourceModel struct {
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	Description  types.String   `tfsdk:"description"`
+	IP           types.String   `tfsdk:"ip"`
+	InstanceID   types.String   `tfsdk:"instance_id"`
+	IPPoolID     types.String   `tfsdk:"ip_pool_id"`
+	ProjectID    types.String   `tfsdk:"project_id"`
+	ProjectName  types.String   `tfsdk:"project_name"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Compile-time assertions to check that the floatingIPDataSource implements the
+// necessary Terraform data source interfaces.
+var (
+	_ datasource.DataSource              = (*floatingIPDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*floatingIPDataSource)(nil)
+)
+
+// floatingIPResource is the concrete type that implements the necessary
+// Terraform resource interfaces. It holds state to interact with the Oxide API.
+type floatingIPDataSource struct {
+	client *oxide.Client
+}
+
+// NewFloatingIPDataSource is a helper to easily construct a
+// floatingIPDataSource as a type that implements the Terraform data source
+// interface.
+func NewFloatingIPDataSource() datasource.DataSource {
+	return &floatingIPDataSource{}
+}
+
+// Metadata configures the Terraform data source name for the Oxide floating IP
+// data source.
+func (f *floatingIPDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "oxide_floating_ip"
+}
+
+// Configure sets up necessary data or clients needed by the floatingIPDataSource.
+func (f *floatingIPDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	f.client = req.ProviderData.(*oxide.Client)
+}
+
+// Schema defines the attributes for this Oxide floating IP data source.
+func (f *floatingIPDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier for the floating IP.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Unique, mutable, user-controlled identifier for the floating IP.",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Human-readable free-form text about the floating IP.",
+			},
+			"instance_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Instance ID that this floating IP is attached to, if presently attached.",
+			},
+			"ip": schema.StringAttribute{
+				Computed:    true,
+				Description: "IP address for this floating IP. If unset an IP address will be chosen from the given ip_pool_id.",
+			},
+			"ip_pool_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "IP pool ID to allocate this floating IP from. If unset the silo's default IP pool is used.",
+			},
+			"project_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Project ID where this floating IP is located.",
+			},
+			"project_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Project name where this floating IP is located.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when this floating IP was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when this floating IP was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Read: true,
+			}),
+		},
+	}
+}
+
+// Read fetches an Oxide floating IP from the Oxide API.
+func (f *floatingIPDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state floatingIPDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.FloatingIpViewParams{
+		FloatingIp: oxide.NameOrId(state.Name.ValueString()),
+		Project:    oxide.NameOrId(state.ProjectName.ValueString()),
+	}
+
+	floatingIP, err := f.client.FloatingIpView(ctx, params)
+	if err != nil {
+		if is404(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to read floating IP:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("read floating IP with ID: %v", floatingIP.Id), map[string]any{"success": true})
+
+	state.ID = types.StringValue(floatingIP.Id)
+	state.Name = types.StringValue(string(floatingIP.Name))
+	state.Description = types.StringValue(floatingIP.Description)
+	state.IP = types.StringValue(floatingIP.Ip)
+	state.InstanceID = types.StringValue(floatingIP.InstanceId)
+	state.IPPoolID = types.StringValue(floatingIP.IpPoolId)
+	state.ProjectID = types.StringValue(floatingIP.ProjectId)
+	state.TimeCreated = types.StringValue(floatingIP.TimeCreated.String())
+	state.TimeModified = types.StringValue(floatingIP.TimeModified.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/data_source_floating_ip_test.go
+++ b/internal/provider/data_source_floating_ip_test.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type dataSourceFloatingIPConfig struct {
+	BlockName         string
+	Name              string
+	SupportBlockName  string
+	SupportBlockName2 string
+}
+
+var dataSourceFloatingIPConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_floating_ip" "{{.SupportBlockName2}}" {
+  project_id  = data.oxide_project.{{.SupportBlockName}}.id
+  name        = "{{.Name}}"
+  description = "Floating IP."
+}
+
+data "oxide_floating_ip" "{{.BlockName}}" {
+  project_name = data.oxide_project.{{.SupportBlockName}}.name
+  name         = oxide_floating_ip.{{.SupportBlockName2}}.name
+  timeouts = {
+    read = "1m"
+  }
+}
+`
+
+func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
+	blockName := newBlockName("datasource-floating-ip")
+	resourceName := newResourceName()
+	config, err := parsedAccConfig(
+		dataSourceFloatingIPConfig{
+			BlockName:         blockName,
+			SupportBlockName:  newBlockName("support"),
+			SupportBlockName2: newBlockName("support"),
+			Name:              resourceName,
+		},
+		dataSourceFloatingIPConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkDataSourceFloatingIP(
+					fmt.Sprintf("data.oxide_floating_ip.%s", blockName),
+					resourceName,
+				),
+			},
+		},
+	})
+}
+
+func checkDataSourceFloatingIP(dataName, keyName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(dataName, "id"),
+		resource.TestCheckResourceAttr(dataName, "name", keyName),
+		resource.TestCheckResourceAttr(dataName, "description", "Floating IP."),
+		resource.TestCheckResourceAttrSet(dataName, "project_id"),
+		resource.TestCheckResourceAttrSet(dataName, "project_name"),
+		resource.TestCheckResourceAttrSet(dataName, "ip"),
+		resource.TestCheckResourceAttrSet(dataName, "ip_pool_id"),
+		resource.TestCheckResourceAttr(dataName, "instance_id", ""),
+		resource.TestCheckResourceAttrSet(dataName, "time_created"),
+		resource.TestCheckResourceAttrSet(dataName, "time_modified"),
+		resource.TestCheckResourceAttr(dataName, "timeouts.read", "1m"),
+	}...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -174,6 +174,7 @@ func (p *oxideProvider) DataSources(_ context.Context) []func() datasource.DataS
 		NewVPCInternetGatewayDataSource,
 		NewVPCRouterDataSource,
 		NewVPCSubnetDataSource,
+		NewFloatingIPDataSource,
 	}
 }
 
@@ -194,5 +195,6 @@ func (p *oxideProvider) Resources(_ context.Context) []func() resource.Resource 
 		NewVPCFirewallRulesResource,
 		NewVPCRouterResource,
 		NewVPCSubnetResource,
+		NewFloatingIPResource,
 	}
 }

--- a/internal/provider/resource_anti_affinity_group_test.go
+++ b/internal/provider/resource_anti_affinity_group_test.go
@@ -146,15 +146,15 @@ func testAccAntiAffinityGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		params := oxide.VpcViewParams{
-			Vpc: oxide.NameOrId(rs.Primary.Attributes["id"]),
+		params := oxide.AntiAffinityGroupViewParams{
+			AntiAffinityGroup: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
-		res, err := client.VpcView(ctx, params)
+		res, err := client.AntiAffinityGroupView(ctx, params)
 		if err != nil && is404(err) {
 			continue
 		}

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -1,0 +1,339 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// floatingIPResourceModel represents the Terraform configuration and state for
+// the Oxide floating IP resource.
+type floatingIPResourceModel struct {
+	ID           types.String   `tfsdk:"id"`
+	Name         types.String   `tfsdk:"name"`
+	Description  types.String   `tfsdk:"description"`
+	IP           types.String   `tfsdk:"ip"`
+	InstanceID   types.String   `tfsdk:"instance_id"`
+	IPPoolID     types.String   `tfsdk:"ip_pool_id"`
+	ProjectID    types.String   `tfsdk:"project_id"`
+	TimeCreated  types.String   `tfsdk:"time_created"`
+	TimeModified types.String   `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+}
+
+// Compile-time assertions to check that the floatingIPResource implements the
+// necessary Terraform resource interfaces.
+var (
+	_ resource.Resource                = (*floatingIPResource)(nil)
+	_ resource.ResourceWithConfigure   = (*floatingIPResource)(nil)
+	_ resource.ResourceWithImportState = (*floatingIPResource)(nil)
+)
+
+// floatingIPResource is the concrete type that implements the necessary
+// Terraform resource interfaces. It holds state to interact with the Oxide API.
+type floatingIPResource struct {
+	client *oxide.Client
+}
+
+// NewFloatingIPResource is a helper to easily construct a floatingIPResource as
+// a type that implements the Terraform resource interface.
+func NewFloatingIPResource() resource.Resource {
+	return &floatingIPResource{}
+}
+
+// Metadata configures the Terraform resource name for the Oxide floating IP
+// resource.
+func (f *floatingIPResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "oxide_floating_ip"
+}
+
+// Configure sets up necessary data or clients needed by the floatingIPResource.
+func (f *floatingIPResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	f.client = req.ProviderData.(*oxide.Client)
+}
+
+// ImportState imports an Oxide floating IP using its ID.
+func (f *floatingIPResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Schema defines the attributes for this Oxide floating IP resource.
+func (f *floatingIPResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier for the floating IP.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Unique, mutable, user-controlled identifier for the floating IP.",
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Human-readable free-form text about the floating IP.",
+			},
+			"instance_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Instance ID that this floating IP is attached to, if presently attached.",
+			},
+			"ip": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "IP address for this floating IP. If unset an IP address will be chosen from the given ip_pool_id.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"ip_pool_id": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "IP pool ID to allocate this floating IP from. If unset the silo's default IP pool is used.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Project ID where this floating IP is located.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when this floating IP was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when this floating IP was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+// Create creates an Oxide floating IP using the Oxide API.
+func (f *floatingIPResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan floatingIPResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	params := oxide.FloatingIpCreateParams{
+		Project: oxide.NameOrId(plan.ProjectID.ValueString()),
+		Body: &oxide.FloatingIpCreate{
+			Description: plan.Description.ValueString(),
+			Ip:          plan.IP.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+			Pool:        oxide.NameOrId(plan.IPPoolID.ValueString()),
+		},
+	}
+
+	floatingIP, err := f.client.FloatingIpCreate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating floating IP:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("created floating IP with ID: %v", floatingIP.Id), map[string]any{"success": true})
+
+	plan.ID = types.StringValue(floatingIP.Id)
+	plan.Name = types.StringValue(string(floatingIP.Name))
+	plan.Description = types.StringValue(floatingIP.Description)
+	plan.IP = types.StringValue(floatingIP.Ip)
+	plan.InstanceID = types.StringValue(floatingIP.InstanceId)
+	plan.IPPoolID = types.StringValue(floatingIP.IpPoolId)
+	plan.ProjectID = types.StringValue(floatingIP.ProjectId)
+	plan.TimeCreated = types.StringValue(floatingIP.TimeCreated.String())
+	plan.TimeModified = types.StringValue(floatingIP.TimeModified.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read fetches an Oxide floating IP from the Oxide API.
+func (f *floatingIPResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state floatingIPResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	params := oxide.FloatingIpViewParams{
+		FloatingIp: oxide.NameOrId(state.ID.ValueString()),
+	}
+
+	floatingIP, err := f.client.FloatingIpView(ctx, params)
+	if err != nil {
+		if is404(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to read floating IP:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("read floating IP with ID: %v", floatingIP.Id), map[string]any{"success": true})
+
+	state.ID = types.StringValue(floatingIP.Id)
+	state.Name = types.StringValue(string(floatingIP.Name))
+	state.Description = types.StringValue(floatingIP.Description)
+	state.IP = types.StringValue(floatingIP.Ip)
+	state.InstanceID = types.StringValue(floatingIP.InstanceId)
+	state.IPPoolID = types.StringValue(floatingIP.IpPoolId)
+	state.ProjectID = types.StringValue(floatingIP.ProjectId)
+	state.TimeCreated = types.StringValue(floatingIP.TimeCreated.String())
+	state.TimeModified = types.StringValue(floatingIP.TimeModified.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates an Oxide floating IP using the Oxide API. Not all attributes
+// can be updated. Refer to [Schema] and the floating_ip_update Oxide API
+// documentation for more information.
+func (f *floatingIPResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan floatingIPResourceModel
+	var state floatingIPResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateTimeout, diags := state.Timeouts.Update(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	params := oxide.FloatingIpUpdateParams{
+		FloatingIp: oxide.NameOrId(state.ID.ValueString()),
+		Body: &oxide.FloatingIpUpdate{
+			Description: plan.Description.ValueString(),
+			Name:        oxide.Name(plan.Name.ValueString()),
+		},
+	}
+
+	floatingIP, err := f.client.FloatingIpUpdate(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update floating IP:",
+			"API error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("updated floating IP with ID: %v", floatingIP.Id), map[string]any{"success": true})
+
+	plan.ID = types.StringValue(floatingIP.Id)
+	plan.Name = types.StringValue(string(floatingIP.Name))
+	plan.Description = types.StringValue(floatingIP.Description)
+	plan.IP = types.StringValue(floatingIP.Ip)
+	plan.InstanceID = types.StringValue(floatingIP.InstanceId)
+	plan.IPPoolID = types.StringValue(floatingIP.IpPoolId)
+	plan.ProjectID = types.StringValue(floatingIP.ProjectId)
+	plan.TimeCreated = types.StringValue(floatingIP.TimeCreated.String())
+	plan.TimeModified = types.StringValue(floatingIP.TimeModified.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes an Oxide floating IP using the Oxide API.
+func (f *floatingIPResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state floatingIPResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	params := oxide.FloatingIpDeleteParams{
+		FloatingIp: oxide.NameOrId(state.ID.ValueString()),
+	}
+
+	if err := f.client.FloatingIpDelete(ctx, params); err != nil {
+		if !is404(err) {
+			resp.Diagnostics.AddError(
+				"Unable to delete floating IP:",
+				"API error: "+err.Error(),
+			)
+			return
+		}
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("deleted floating IP with ID: %v", state.ID.ValueString()), map[string]any{"success": true})
+}

--- a/internal/provider/resource_floating_ip_test.go
+++ b/internal/provider/resource_floating_ip_test.go
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+type resourceFloatingIPConfig struct {
+	BlockName        string
+	SupportBlockName string
+	FloatingIPName   string
+}
+
+var resourceFloatingIPConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_floating_ip" "{{.BlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	name        = "{{.FloatingIPName}}"
+	description = "Floating IP."
+	timeouts = {
+		create = "1m"
+		read   = "2m"
+		update = "3m"
+		delete = "4m"
+	}
+}
+`
+
+var resourceFloatingIPUpdateConfigTpl = `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_floating_ip" "{{.BlockName}}" {
+	project_id  = data.oxide_project.{{.SupportBlockName}}.id
+	name        = "{{.FloatingIPName}}"
+	description = "Floating IP (updated)."
+  }
+`
+
+func TestAccCloudResourceFloatingIP_full(t *testing.T) {
+	floatingIPName := newResourceName()
+	blockName := newBlockName("floating_ip")
+	resourceName := fmt.Sprintf("oxide_floating_ip.%s", blockName)
+	supportBlockName := newBlockName("support")
+	config, err := parsedAccConfig(
+		resourceFloatingIPConfig{
+			BlockName:        blockName,
+			FloatingIPName:   floatingIPName,
+			SupportBlockName: supportBlockName,
+		},
+		resourceFloatingIPConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	floatingIPNameUpdated := floatingIPName + "-updated"
+	configUpdate, err := parsedAccConfig(
+		resourceFloatingIPConfig{
+			BlockName:        blockName,
+			FloatingIPName:   floatingIPNameUpdated,
+			SupportBlockName: supportBlockName,
+		},
+		resourceFloatingIPUpdateConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  checkResourceFloatingIP(resourceName, floatingIPName),
+			},
+			{
+				Config: configUpdate,
+				Check:  checkResourceFloatingIPUpdate(resourceName, floatingIPNameUpdated),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func checkResourceFloatingIP(resourceName, floatingIPName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "name", floatingIPName),
+		resource.TestCheckResourceAttr(resourceName, "description", "Floating IP."),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "ip"),
+		resource.TestCheckResourceAttrSet(resourceName, "ip_pool_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.create", "1m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.update", "3m"),
+		resource.TestCheckResourceAttr(resourceName, "timeouts.delete", "4m"),
+	}...)
+}
+
+func checkResourceFloatingIPUpdate(resourceName, floatingIPName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "name", floatingIPName),
+		resource.TestCheckResourceAttr(resourceName, "description", "Floating IP (updated)."),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "ip"),
+		resource.TestCheckResourceAttrSet(resourceName, "ip_pool_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func testAccFloatingIPDestroy(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oxide_floating_ip" {
+			continue
+		}
+
+		params := oxide.FloatingIpViewParams{
+			FloatingIp: oxide.NameOrId(rs.Primary.Attributes["id"]),
+		}
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+
+		res, err := client.FloatingIpView(ctx, params)
+		if err != nil && is404(err) {
+			continue
+		}
+
+		return fmt.Errorf("floating ip (%v) still exists", &res.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added the `oxide_floating_ip` resource and data source. This allows managing and reading an Oxide floating IP.

Closes #257.