### PR TITLE
In-place update for VPC firewall rules

### DIFF
--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -114,9 +113,6 @@ func (r *vpcFirewallRulesResource) Schema(ctx context.Context, _ resource.Schema
 			"rules": schema.SetNestedAttribute{
 				Required:    true,
 				Description: "Associated firewall rules.",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
-				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"action": schema.StringAttribute{


### PR DESCRIPTION
Taking a look at the resource docs they already say "Firewall rules defined by this resource are considered exhaustive and will overwrite any other firewall rules for the VPC once applied."

Not sure if this needs more clarification? WDYT @sudomateo?

Waiting on an API change to fully run acceptance tests

Fixes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/431
