### PR TITLE
oxide_instance: add validation to ssh_public_keys attribute

### DIFF
--- a/.changelog/0.10.0.toml
+++ b/.changelog/0.10.0.toml
@@ -14,6 +14,10 @@ description = "`oxide_vpc_router_route` [#423](https://github.com/oxidecomputer/
 title = "VPC firewall rules resource"
 description = "In place updates are now supported [#432](https://github.com/oxidecomputer/terraform-provider-oxide/pull/432)"
 
+[[enhancements]]
+title = "`oxide_instance` attribute validation"
+description = "Added validation to the `ssh_public_keys` attribute on the `oxide_instance` resource. [#443](https://github.com/oxidecomputer/terraform-provider-oxide/pull/443)"
+
 [[bugs]]
 title = ""
 description = ""

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -177,6 +178,12 @@ func (r *instanceResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.Set{
+					setvalidator.NoNullValues(),
+					setvalidator.ValueStringsAre(
+						stringvalidator.NoneOf(""),
+					),
 				},
 			},
 			"network_interfaces": schema.SetNestedAttribute{


### PR DESCRIPTION
Add validation to the `ssh_public_keys` attribute to validate that it contains no empty or null values. A customer pointed out that the following Terraform configuration resulted in an unclear error message.

```hcl
resource "oxide_instance" "example" {
  ssh_public_keys = ["4db0f0d3-8e82-491a-beff-39764be1c529", null]
}
```

Even worse, the error message didn't occur until apply time.

```
oxide_instance.example: Creating...
╷
│ Error: Error retrieving name or ID information
│
│   with oxide_instance.example,
│   on main.tf line 22, in resource "oxide_instance" "example":
│   22: resource "oxide_instance" "example" {
│
│ name or ID parse error: invalid syntax
╵
```

With this change, the error message occurs at plan time and is much more clear.

```
> terraform apply
╷
│ Error: Null Set Value
│
│   with oxide_instance.example,
│   on main.tf line 31, in resource "oxide_instance" "example":
│   31:   ssh_public_keys  = ["4db0f0d3-8e82-491a-beff-39764be1c529", null]
│
│ This attribute contains a null value.
╵
```