### PR TITLE
This filters the boot disk out of attachments

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -406,12 +406,14 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 	}
 	params.Body.AntiAffinityGroups = antiAffinityGroupIDs
 
+	// The control plane API counts the BootDisk and the Disk attachments when it calculates the limit on disk attachments.
+	// If bootdisk is set explicitly, we don't want it to be in the API call, but we need it in the state entry.
 	disks, diags := newDiskAttachmentsOnCreate(ctx, r.client, plan.DiskAttachments)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	params.Body.Disks = disks
+	params.Body.Disks = filterBootDiskFromDisks(disks, params.Body.BootDisk)
 
 	externalIPs := newExternalIPsOnCreate(plan.ExternalIPs)
 	params.Body.ExternalIps = externalIPs
@@ -1176,6 +1178,17 @@ func newDiskAttachmentsOnCreate(ctx context.Context, client *oxide.Client, diskI
 	}
 
 	return disks, diags
+}
+
+func filterBootDiskFromDisks(disks []oxide.InstanceDiskAttachment, boot_disk *oxide.InstanceDiskAttachment) []oxide.InstanceDiskAttachment {
+	var filtered_disks = []oxide.InstanceDiskAttachment{}
+	for _, disk := range disks {
+		if disk == *boot_disk {
+			continue
+		}
+		filtered_disks = append(filtered_disks, disk)
+	}
+	return filtered_disks
 }
 
 func newExternalIPsOnCreate(externalIPs []instanceResourceExternalIPModel) []oxide.ExternalIpCreate {


### PR DESCRIPTION
- Filter boot_disk out of the instance creation call. This keeps the local state file entry complete with the boot disk but the control plane will count a boot disk + all attachments against the 8 disk limit.