### PR TITLE
Update to Go SDK v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.1
-	github.com/oxidecomputer/oxide.go v0.4.1-0.20250530023940-ecfa72d833e0
+	github.com/oxidecomputer/oxide.go v0.5.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.4.1-0.20250530023940-ecfa72d833e0 h1:P/pU75YLSgM9vIbdTyAc92H9k+yuXYWLTzaMk71QubA=
-github.com/oxidecomputer/oxide.go v0.4.1-0.20250530023940-ecfa72d833e0/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
+github.com/oxidecomputer/oxide.go v0.5.0 h1:bT5FPUmczVcS84NCLdJZ5PAWHMhINz99QQVLImnd5Sc=
+github.com/oxidecomputer/oxide.go v0.5.0/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
I tested all of the cloud endpoints against the dogfood rack and everything is working as expected

```console
$ make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudDataSourceAntiAffinityGroup_full
=== PAUSE TestAccCloudDataSourceAntiAffinityGroup_full
=== RUN   TestAccCloudDataSourceFloatingIP_full
=== PAUSE TestAccCloudDataSourceFloatingIP_full
=== RUN   TestAccCloudDataSourceImage_full
=== PAUSE TestAccCloudDataSourceImage_full
=== RUN   TestAccCloudDataSourceImages_project
=== PAUSE TestAccCloudDataSourceImages_project
=== RUN   TestAccCloudDataSourceImages_silo
=== PAUSE TestAccCloudDataSourceImages_silo
=== RUN   TestAccCloudDataSourceInstanceExternalIPs_full
=== PAUSE TestAccCloudDataSourceInstanceExternalIPs_full
=== RUN   TestAccCloudDataSourceProject_full
=== PAUSE TestAccCloudDataSourceProject_full
=== RUN   TestAccCloudDataSourceProjects_full
=== PAUSE TestAccCloudDataSourceProjects_full
=== RUN   TestAccCloudDataSourceSSHKey_full
=== PAUSE TestAccCloudDataSourceSSHKey_full
=== RUN   TestAccCloudDataSourceVPCInternetGateway_full
=== PAUSE TestAccCloudDataSourceVPCInternetGateway_full
=== RUN   TestAccCloudDataSourceVPCRouterRoute_full
=== PAUSE TestAccCloudDataSourceVPCRouterRoute_full
=== RUN   TestAccCloudDataSourceVPCRouter_full
=== PAUSE TestAccCloudDataSourceVPCRouter_full
=== RUN   TestAccCloudDataSourceVPCSubnet_full
=== PAUSE TestAccCloudDataSourceVPCSubnet_full
=== RUN   TestAccCloudDataSourceVPC_full
=== PAUSE TestAccCloudDataSourceVPC_full
=== RUN   TestAccCloudResourceAntiAffinityGroup_full
=== PAUSE TestAccCloudResourceAntiAffinityGroup_full
=== RUN   TestAccCloudResourceDisk_full
=== PAUSE TestAccCloudResourceDisk_full
=== RUN   TestAccCloudResourceFloatingIP_full
=== PAUSE TestAccCloudResourceFloatingIP_full
=== RUN   TestAccCloudResourceImage_full
=== PAUSE TestAccCloudResourceImage_full
=== RUN   TestAccCloudResourceInstance_full
=== PAUSE TestAccCloudResourceInstance_full
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== RUN   TestAccCloudResourceInstance_sshKeys
=== PAUSE TestAccCloudResourceInstance_sshKeys
=== RUN   TestAccCloudResourceInstance_nic
=== PAUSE TestAccCloudResourceInstance_nic
=== RUN   TestAccCloudResourceInstance_disk
=== PAUSE TestAccCloudResourceInstance_disk
=== RUN   TestAccCloudResourceInstance_update
=== PAUSE TestAccCloudResourceInstance_update
=== RUN   TestAccCloudResourceInstance_antiAffinityGroups
=== PAUSE TestAccCloudResourceInstance_antiAffinityGroups
=== RUN   TestAccCloudResourceProject_full
=== PAUSE TestAccCloudResourceProject_full
=== RUN   TestAccCloudResourceSnapshot_full
=== PAUSE TestAccCloudResourceSnapshot_full
=== RUN   TestAccCloudResourceSSHKey_full
=== PAUSE TestAccCloudResourceSSHKey_full
=== RUN   TestAccCloudResourceFirewallRules_full
=== PAUSE TestAccCloudResourceFirewallRules_full
=== RUN   TestAccCloudResourceVPCInternetGateway_full
=== PAUSE TestAccCloudResourceVPCInternetGateway_full
=== RUN   TestAccCloudResourceVPCRouterRoute_full
=== PAUSE TestAccCloudResourceVPCRouterRoute_full
=== RUN   TestAccCloudResourceVPCRouter_full
=== PAUSE TestAccCloudResourceVPCRouter_full
=== RUN   TestAccCloudResourceVPCSubnet_full
=== PAUSE TestAccCloudResourceVPCSubnet_full
=== RUN   TestAccCloudResourceVPC_full
=== PAUSE TestAccCloudResourceVPC_full
=== CONT  TestAccCloudDataSourceAntiAffinityGroup_full
=== CONT  TestAccCloudResourceImage_full
=== CONT  TestAccCloudDataSourceVPCInternetGateway_full
=== CONT  TestAccCloudDataSourceInstanceExternalIPs_full
=== CONT  TestAccCloudDataSourceProject_full
=== CONT  TestAccCloudDataSourceImages_silo
=== CONT  TestAccCloudDataSourceProjects_full
--- PASS: TestAccCloudDataSourceProject_full (2.02s)
=== CONT  TestAccCloudDataSourceImages_project
--- PASS: TestAccCloudDataSourceVPCInternetGateway_full (2.02s)
=== CONT  TestAccCloudDataSourceImage_full
--- PASS: TestAccCloudDataSourceProjects_full (1.08s)
=== CONT  TestAccCloudDataSourceFloatingIP_full
=== CONT  TestAccCloudDataSourceVPCSubnet_full
=== CONT  TestAccCloudResourceFloatingIP_full
--- PASS: TestAccCloudDataSourceVPCSubnet_full (1.59s)
=== CONT  TestAccCloudResourceDisk_full
--- PASS: TestAccCloudDataSourceAntiAffinityGroup_full (4.94s)
=== CONT  TestAccCloudResourceAntiAffinityGroup_full
--- PASS: TestAccCloudDataSourceFloatingIP_full (3.92s)
=== CONT  TestAccCloudDataSourceSSHKey_full
--- PASS: TestAccCloudDataSourceSSHKey_full (3.05s)
=== CONT  TestAccCloudDataSourceVPCRouterRoute_full
--- PASS: TestAccCloudResourceFloatingIP_full (8.24s)
=== CONT  TestAccCloudDataSourceVPC_full
--- PASS: TestAccCloudDataSourceVPCRouterRoute_full (2.43s)
=== CONT  TestAccCloudDataSourceVPCRouter_full
--- PASS: TestAccCloudResourceDisk_full (7.32s)
=== CONT  TestAccCloudResourceSnapshot_full
--- PASS: TestAccCloudResourceAntiAffinityGroup_full (7.04s)
=== CONT  TestAccCloudResourceInstance_disk
--- PASS: TestAccCloudDataSourceInstanceExternalIPs_full (11.99s)
=== CONT  TestAccCloudResourceProject_full
--- PASS: TestAccCloudDataSourceVPC_full (2.15s)
=== CONT  TestAccCloudResourceVPC_full
--- PASS: TestAccCloudDataSourceVPCRouter_full (2.07s)
=== CONT  TestAccCloudResourceVPCSubnet_full
--- PASS: TestAccCloudResourceProject_full (6.35s)
=== CONT  TestAccCloudResourceVPCRouter_full
--- PASS: TestAccCloudResourceImage_full (27.32s)
=== CONT  TestAccCloudResourceInstance_antiAffinityGroups
--- PASS: TestAccCloudResourceVPC_full (14.16s)
=== CONT  TestAccCloudResourceVPCRouterRoute_full
--- PASS: TestAccCloudResourceSnapshot_full (17.44s)
=== CONT  TestAccCloudResourceVPCInternetGateway_full
--- PASS: TestAccCloudResourceVPCSubnet_full (15.63s)
=== CONT  TestAccCloudResourceFirewallRules_full
--- PASS: TestAccCloudResourceVPCRouter_full (11.65s)
=== CONT  TestAccCloudResourceSSHKey_full
--- PASS: TestAccCloudResourceSSHKey_full (2.35s)
=== CONT  TestAccCloudResourceInstance_sshKeys
--- PASS: TestAccCloudResourceVPCInternetGateway_full (9.84s)
=== CONT  TestAccCloudResourceInstance_nic
--- PASS: TestAccCloudResourceInstance_sshKeys (17.68s)
=== CONT  TestAccCloudResourceInstance_update
--- PASS: TestAccCloudResourceVPCRouterRoute_full (22.98s)
=== CONT  TestAccCloudResourceInstance_extIPs
--- PASS: TestAccCloudResourceFirewallRules_full (22.34s)
=== CONT  TestAccCloudResourceInstance_full
--- PASS: TestAccCloudResourceInstance_antiAffinityGroups (58.21s)
--- PASS: TestAccCloudResourceInstance_disk (76.63s)
--- PASS: TestAccCloudResourceInstance_nic (60.05s)
--- PASS: TestAccCloudResourceInstance_full (48.75s)
--- PASS: TestAccCloudResourceInstance_extIPs (51.50s)
--- PASS: TestAccCloudResourceInstance_update (71.27s)
```