### PR TITLE
Ignore 404 when removing instance membership from anti-affinity group

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -1460,7 +1460,7 @@ func addAntiAffinityGroups(
 		id, err := strconv.Unquote(v.String())
 		if err != nil {
 			diags.AddError(
-				"Error adding anti-affinity group",
+				"Error adding anti-affinity group to instance",
 				"anti-affinity group ID parse error: "+err.Error(),
 			)
 			return diags
@@ -1473,12 +1473,12 @@ func addAntiAffinityGroups(
 		_, err = client.AntiAffinityGroupMemberInstanceAdd(ctx, params)
 		if err != nil {
 			diags.AddError(
-				"Error adding anti-affinity group",
+				"Error adding anti-affinity group to instance",
 				"API error: "+err.Error(),
 			)
 			return diags
 		}
-		tflog.Trace(ctx, fmt.Sprintf("added anti-affinity group with ID: %v", v), map[string]any{"success": true})
+		tflog.Trace(ctx, fmt.Sprintf("added anti-affinity group with ID: %v to instance with ID: %v", id, instanceID), map[string]any{"success": true})
 	}
 
 	return nil
@@ -1492,7 +1492,7 @@ func removeAntiAffinityGroups(
 		id, err := strconv.Unquote(v.String())
 		if err != nil {
 			diags.AddError(
-				"Error removing anti-affinity group",
+				"Error removing anti-affinity group from instance",
 				"anti-affinity group ID parse error: "+err.Error(),
 			)
 			return diags
@@ -1504,13 +1504,18 @@ func removeAntiAffinityGroups(
 		}
 		err = client.AntiAffinityGroupMemberInstanceDelete(ctx, params)
 		if err != nil {
+			// If the anti-affinity group doesn't exist anymore, it means
+			// the instance isn't part of it. We can just return.
+			if is404(err) {
+				return nil
+			}
 			diags.AddError(
-				"Error removing anti-affinity group",
+				"Error removing anti-affinity group from instance",
 				"API error: "+err.Error(),
 			)
 			return diags
 		}
-		tflog.Trace(ctx, fmt.Sprintf("removed anit-affinity group with ID: %v", v), map[string]any{"success": true})
+		tflog.Trace(ctx, fmt.Sprintf("removed anti-affinity group with ID %v to instance with ID %v", id, instanceID), map[string]any{"success": true})
 	}
 
 	return nil


### PR DESCRIPTION
If the anti-affinity group has already been removed, the instance resource shouldn't care about a 404 when removing membership from it.

Also, this commit changes the error messages to make it clearer that we're not actually trying to delete the anti-affinity group. Just removing the instance's membership.

Tested against the colo rack with @askfongjojo's HCL config from https://github.com/oxidecomputer/terraform-provider-oxide/issues/446.

Applying first:

```hcl
resource "oxide_anti_affinity_group" "peers" {
  project_id  = data.oxide_project.proj.id
  description = "another anti-affinity group"
  name        = "related-peers"
  policy      = "allow"
}

resource "oxide_instance" "test" {
  project_id      = data.oxide_project.proj.id
  description     = "a test instance"
  name            = "test"
  host_name       = "terraform-acc-myhost"
  memory          = 1073741824
  ncpus           = 1
  start_on_create = true
  anti_affinity_groups = [
    oxide_anti_affinity_group.peers.id
  ]
}
```

And then:

```hcl
#resource "oxide_anti_affinity_group" "peers" {
#  project_id  = data.oxide_project.proj.id
#  description = "another anti-affinity group"
#  name        = "related-peers"
#  policy      = "allow"
#}

resource "oxide_instance" "test" {
  project_id      = data.oxide_project.proj.id
  description     = "a test instance"
  name            = "test"
  host_name       = "terraform-acc-myhost"
  memory          = 1073741824
  ncpus           = 1
  start_on_create = true
  #anti_affinity_groups = [
  #  oxide_anti_affinity_group.peers.id
  #]
}
```

Results:

```console
$ terraform init && terraform apply
Initializing the backend...
Initializing provider plugins...
<...>
data.oxide_project.proj: Reading...
data.oxide_project.proj: Read complete after 1s [id=5f9eebcc-19de-4e91-9bd9-92cac61b446c]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_anti_affinity_group.peers will be created
  + resource "oxide_anti_affinity_group" "peers" {
      + description    = "another anti-affinity group"
      + failure_domain = (known after apply)
      + id             = (known after apply)
      + name           = "related-peers"
      + policy         = "allow"
      + project_id     = "5f9eebcc-19de-4e91-9bd9-92cac61b446c"
      + time_created   = (known after apply)
      + time_modified  = (known after apply)
    }

  # oxide_instance.test will be created
  + resource "oxide_instance" "test" {
      + anti_affinity_groups = [
          + (known after apply),
        ]
      + description          = "a test instance"
      + host_name            = "terraform-acc-myhost"
      + id                   = (known after apply)
      + memory               = 1073741824
      + name                 = "test"
      + ncpus                = 1
      + project_id           = "5f9eebcc-19de-4e91-9bd9-92cac61b446c"
      + start_on_create      = true
      + time_created         = (known after apply)
      + time_modified        = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_anti_affinity_group.peers: Creating...
oxide_anti_affinity_group.peers: Creation complete after 4s [id=aea02b00-c2f2-470e-924f-4c85a3b5b0e9]
oxide_instance.test: Creating...
oxide_instance.test: Creation complete after 4s [id=be2b9d99-8492-435b-ba1f-97acce7cdca8]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

$ terraform apply
data.oxide_project.proj: Reading...
oxide_anti_affinity_group.peers: Refreshing state... [id=aea02b00-c2f2-470e-924f-4c85a3b5b0e9]
data.oxide_project.proj: Read complete after 1s [id=5f9eebcc-19de-4e91-9bd9-92cac61b446c]
oxide_instance.test: Refreshing state... [id=be2b9d99-8492-435b-ba1f-97acce7cdca8]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # oxide_anti_affinity_group.peers will be destroyed
  # (because oxide_anti_affinity_group.peers is not in configuration)
  - resource "oxide_anti_affinity_group" "peers" {
      - description    = "another anti-affinity group" -> null
      - failure_domain = "sled" -> null
      - id             = "aea02b00-c2f2-470e-924f-4c85a3b5b0e9" -> null
      - name           = "related-peers" -> null
      - policy         = "allow" -> null
      - project_id     = "5f9eebcc-19de-4e91-9bd9-92cac61b446c" -> null
      - time_created   = "2025-06-11 06:37:37.535487 +0000 UTC" -> null
      - time_modified  = "2025-06-11 06:37:37.535487 +0000 UTC" -> null
    }

  # oxide_instance.test will be updated in-place
  ~ resource "oxide_instance" "test" {
      - anti_affinity_groups = [
          - "aea02b00-c2f2-470e-924f-4c85a3b5b0e9",
        ] -> null
      ~ id                   = "be2b9d99-8492-435b-ba1f-97acce7cdca8" -> (known after apply)
        name                 = "test"
      ~ time_created         = "2025-06-11 06:37:37.996253 +0000 UTC" -> (known after apply)
      ~ time_modified        = "2025-06-11 06:37:37.996253 +0000 UTC" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_anti_affinity_group.peers: Destroying... [id=aea02b00-c2f2-470e-924f-4c85a3b5b0e9]
oxide_anti_affinity_group.peers: Destruction complete after 1s
oxide_instance.test: Modifying... [id=be2b9d99-8492-435b-ba1f-97acce7cdca8]
oxide_instance.test: Modifications complete after 8s [id=be2b9d99-8492-435b-ba1f-97acce7cdca8]

Apply complete! Resources: 0 added, 1 changed, 1 destroyed.
```

Fixes: https://github.com/oxidecomputer/terraform-provider-oxide/issues/446 