### PR TITLE
resource(oxide_instance): fix inconsistent result after apply

### DIFF
--- a/.changelog/0.12.0.toml
+++ b/.changelog/0.12.0.toml
@@ -11,5 +11,5 @@ title = ""
 description = ""
 
 [[bugs]]
-title = ""
-description = ""
+title = "`oxide_instance`"
+description = "Fixed the `inconsistent result after apply` error when applying a subsequent plan where the `external_ips` attribute contained an ephemeral IP with a non-empty ID. [#460](https://github.com/oxidecomputer/terraform-provider-oxide/pull/460)"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -18,4 +18,5 @@ jobs:
         env:
           OXIDE_TOKEN: ${{ secrets.COLO_OXIDE_TOKEN }}
           OXIDE_HOST: ${{ secrets.COLO_OXIDE_HOST }}
+          OXIDE_TEST_IP_POOL_NAME: private
           TEST_ACC_NAME: TestAccCloud


### PR DESCRIPTION
Updated the `oxide_instance` resource to fix the issue documented in https://github.com/oxidecomputer/terraform-provider-oxide/issues/459 where the provider would produce an inconsistent result after apply.

The changes here do the following.

1. Use the ephemeral external IP pool ID from the plan since the upstream Oxide API does not provide that.

1. Use the `.IpPoolId` field for floating external IPs rather than the incorrect `.Id` field.

Creating an acceptance test for this proved to be difficult since it required either using an existing IP pool for the external IP or creating and linking an IP pool on the fly. I opted to assume an IP pool named `default` exists in the silo and allowing the user to override that IP pool name via the `OXIDE_TEST_IP_POOL_NAME` environment variable.

```
> TEST_ACC_NAME=TestAccCloudResourceInstance_extIPs OXIDE_TEST_IP_POOL_NAME=private make testacc
-> Running terraform acceptance tests
=== RUN   TestAccCloudResourceInstance_extIPs
=== PAUSE TestAccCloudResourceInstance_extIPs
=== CONT  TestAccCloudResourceInstance_extIPs
--- PASS: TestAccCloudResourceInstance_extIPs (59.90s)
PASS
ok      github.com/oxidecomputer/terraform-provider-oxide/internal/provider     59.912s
```