### PR TITLE
resource(vpc_firewall_rules): support new api changes

### DIFF
--- a/.changelog/0.13.0.toml
+++ b/.changelog/0.13.0.toml
@@ -1,6 +1,6 @@
 [[breaking]]
-title = ""
-description = ""
+title = "`oxide_vpc_firewall_rules`"
+description = "Updated the schema for the `protocols` attribute to allow for more control over ICMP traffic. [#474](https://github.com/oxidecomputer/terraform-provider-oxide/pull/474)"
 
 [[features]]
 title = ""

--- a/docs/resources/oxide_vpc_firewall_rules.md
+++ b/docs/resources/oxide_vpc_firewall_rules.md
@@ -15,6 +15,8 @@ rules when updating this resource.
 
 ## Example Usage
 
+### Basic Example
+
 ```hcl
 resource "oxide_vpc_firewall_rules" "example" {
   vpc_id = "6556fc6a-63c0-420b-bb23-c3205410f5cc"
@@ -34,7 +36,50 @@ resource "oxide_vpc_firewall_rules" "example" {
           }
         ]
         ports     = ["443"]
-        protocols = ["TCP"]
+        protocols = ["tcp"]
+      },
+      targets = [
+        {
+          type  = "subnet"
+          value = "default"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### ICMP Example
+
+```hcl
+resource "oxide_vpc_firewall_rules" "example" {
+  vpc_id = "6556fc6a-63c0-420b-bb23-c3205410f5cc"
+  rules = [
+    {
+      action      = "allow"
+      description = "Allow ICMP"
+      name        = "allow-icmp"
+      direction   = "inbound"
+      priority    = 50
+      status      = "enabled"
+      filters = {
+        protocols = [
+          # All ICMP.
+          {
+            type = "icmp",
+          },
+          # Echo Reply types.
+          {
+            type = "icmp",
+            icmp_type = 0
+          },
+          # Echo Reply types with codes 1-3.
+          {
+            type = "icmp",
+            icmp_type = 0
+            icmp_code = "1-3"
+          },
+        ]
       },
       targets = [
         {
@@ -86,7 +131,7 @@ Required:
 Optional:
 
 - `hosts` (Set) If present, the sources (if incoming) or destinations (if outgoing) this rule applies to. (see [below for nested schema](#nestedatt--hosts))
-- `protocols` (Array of Strings) If present, the networking protocols this rule applies to. Possible values are: TCP, UDP and ICMP.
+- `protocols` (Set) If present, the networking protocols this rule applies to. (see [below for nested schema](#nestedatt--protocols))
 - `ports` (Array of Strings) If present, the destination ports this rule applies to. Can be a mix of single ports (e.g., `"443"`) and port ranges (e.g., `"30000-32768"`).
 
 <a id="nestedatt--hosts"></a>
@@ -102,6 +147,19 @@ Required:
 	- For type instance: Name of the instance
 	- For type ip: IP address
 	- For type ip_net: IPv4 or IPv6 subnet
+
+<a id="nestedatt--protocols"></a>
+
+### Nested Schema for `protocols`
+
+Required:
+
+- `type` (String) The protocol type. Must be one of `tcp`, `udp`, or `icmp`.
+
+Optional:
+
+- `icmp_type` (Number) ICMP type (e.g., 0 for Echo Reply). Only valid when `type` is `icmp`.
+- `icmp_code` (String) ICMP code (e.g., 0) or range (e.g., 1-3). Omit to filter all traffic of the specified `icmp_type`. Only valid when type is `icmp` and `icmp_type` is provided.
 
 <a id="nestedatt--targets"></a>
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/oxidecomputer/oxide.go v0.5.0
+	github.com/oxidecomputer/oxide.go v0.5.1-0.20250719004549-7255536641a1
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.5.0 h1:bT5FPUmczVcS84NCLdJZ5PAWHMhINz99QQVLImnd5Sc=
-github.com/oxidecomputer/oxide.go v0.5.0/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
+github.com/oxidecomputer/oxide.go v0.5.1-0.20250719004549-7255536641a1 h1:fdKQaoRt2FDN3OYWT4pJGgDqqmfb2eq5KYYigN+HDIw=
+github.com/oxidecomputer/oxide.go v0.5.1-0.20250719004549-7255536641a1/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
Pulled in the Go SDK changes from
https://github.com/oxidecomputer/oxide.go/pull/304 which contained changes to the VPC firewall rules APIs.

Updated the `oxide_vpc_firewall_rules` resource to account for these changes.