### PR TITLE
resource(instance): use floating ip id instead of ip pool id

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -1121,7 +1121,7 @@ func newAttachedExternalIPModel(ctx context.Context, client *oxide.Client, model
 			})
 		case oxide.ExternalIpKindFloating:
 			externalIPs = append(externalIPs, instanceResourceExternalIPModel{
-				ID:   types.StringValue(externalIP.IpPoolId),
+				ID:   types.StringValue(externalIP.Id),
 				Type: types.StringValue(string(externalIP.Kind)),
 			})
 		default:


### PR DESCRIPTION
Updated the `oxide_instance` resource to use the floating IP ID for floating external IPs instead of the IP pool ID. Without this change, Terraform will be unable to detach a floating IP from an instance since it will try to detach using the floating IP IP pool ID instead of the floating IP ID itself.