### PR TITLE
resource(instance): fix snat external ip compatibility

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -1124,11 +1124,9 @@ func newAttachedExternalIPModel(ctx context.Context, client *oxide.Client, model
 				ID:   types.StringValue(externalIP.Id),
 				Type: types.StringValue(string(externalIP.Kind)),
 			})
+		// Skipped until the schema is updated to support SNAT external IPs.
 		case oxide.ExternalIpKindSnat:
-			externalIPs = append(externalIPs, instanceResourceExternalIPModel{
-				ID:   types.StringValue(externalIP.IpPoolId),
-				Type: types.StringValue(string(externalIP.Kind)),
-			})
+			continue
 		default:
 			diags.AddError(
 				"Invalid external IP kind:",
@@ -1413,6 +1411,9 @@ func detachExternalIPs(ctx context.Context, client *oxide.Client, externalIPs []
 
 				return diags
 			}
+		// It's not possible to detach an SNAT external IP. Skip it.
+		case oxide.ExternalIpKindSnat:
+			continue
 		default:
 			diags.AddError(
 				fmt.Sprintf("Cannot detach invalid external IP type %q", externalIPType.ValueString()),


### PR DESCRIPTION
Updated the provider to maintain compatibility with SNAT external IPs but removed them from the Terraform state.

Previously, SNAT IPs would be read into the `external_ips` attribute upon `Read`, but a subsequent plan would immediately try to remove them since SNAT external IPs cannot be present in the Terraform configuration. Additionally, during `Update`, the SNAT external IP would attempt to be detached from the instance, throwing an error since SNAT external IPs cannot be detached from an instance.

The `external_ips` attribute is user configurable. We cannot both accept user configuration and write additional computed state into the attribute. Otherwise, Terraform will either produce an inconsistent plan (e.g., planned for 1 external IP but received 2 during create) or attempt to remove the SNAT IP during a subsequent plan as described above.

I opted to ignore SNAT IPs in the interest of time so that the Terraform provider is compatible with Oxide release 16. A future change can introduce a new `attached_external_ips` attribute into the schema that contains all of the computed external IPs, irrespective of the `external_ips` attribute.