### PR TITLE
release: prepare for v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/examples/demo/demo.tf
+++ b/examples/demo/demo.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/examples/disk_resource/disk.tf
+++ b/examples/disk_resource/disk.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/examples/instance_resource/instance.tf
+++ b/examples/instance_resource/instance.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/examples/vpc_resource/vpc.tf
+++ b/examples/vpc_resource/vpc.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oxide = {
       source  = "oxidecomputer/oxide"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/oxidecomputer/oxide.go v0.5.1-0.20250804182320-d8df86da3154
+	github.com/oxidecomputer/oxide.go v0.6.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oxidecomputer/oxide.go v0.5.1-0.20250804182320-d8df86da3154 h1:qftdu0QhJq6PKHX+AQBjG8wTBpUP4PeY7QHfldRbJ1o=
-github.com/oxidecomputer/oxide.go v0.5.1-0.20250804182320-d8df86da3154/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
+github.com/oxidecomputer/oxide.go v0.6.0 h1:H9vf6na1CzhNmLzT7fZV0nf0azaRVBILXSlA9hHWShM=
+github.com/oxidecomputer/oxide.go v0.6.0/go.mod h1:4gfHlxdBQLs/34UbChPvINd+pGNAnGlASRGEd4xIz1Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
Updated the version constraints and Go SDK to prepare for v0.13.0 release.