### PR TITLE
silo: do not allow negative cpu quotas

### DIFF
--- a/.changelog/0.14.0.toml
+++ b/.changelog/0.14.0.toml
@@ -13,3 +13,7 @@ description = ""
 [[bugs]]
 title = "`oxide_vpc_firewall_rules`"
 description = "Fixed the `Failed to decode resource from state` error when upgrading the provider to v0.13.0. [#501](https://github.com/oxidecomputer/terraform-provider-oxide/pull/501)"
+
+[[bugs]]
+title = "`oxide_silo`"
+description = "The `quotas.cpus` attribute no longer accepts negative values. [#506](https://github.com/oxidecomputer/terraform-provider-oxide/pull/506)"

--- a/internal/provider/resource_silo.go
+++ b/internal/provider/resource_silo.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -141,6 +142,9 @@ func (r *siloResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 					"cpus": schema.Int64Attribute{
 						Required:    true,
 						Description: "Amount of virtual CPUs available for running instances in the silo.",
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"memory": schema.Int64Attribute{
 						Required:    true,


### PR DESCRIPTION
Related to https://github.com/oxidecomputer/omicron/issues/8973.

The `oxide_silo` resource no longer accepts negative values for `quotas.cpus`. When a negative value is given, Terraform errors with the following.

```
╷
│ Error: Invalid Attribute Value
│
│   with oxide_silo.example,
│   on main.tf line 39, in resource "oxide_silo" "example":
│   39: resource "oxide_silo" "example" {
│
│ Attribute quotas.cpus value must be at least 0, got: -2
╵
```