### PR TITLE
silo_saml_identity_provider: update documentation

### DIFF
--- a/docs/resources/oxide_silo_saml_identity_provider.md
+++ b/docs/resources/oxide_silo_saml_identity_provider.md
@@ -50,12 +50,12 @@ resource "oxide_silo_saml_identity_provider" "example" {
 
   idp_metadata_source = {
     type = "base64_encoded_xml"
-    data = base64encode(file("${path.module}/idp-metadata.xml"))
+    data = filebase64("${path.module}/idp-metadata.xml")
   }
 
   signing_keypair = {
-    private_key = base64encode(file("${path.module}/saml-key.pem"))
-    public_cert = base64encode(file("${path.module}/saml-cert.pem"))
+    private_key = filebase64("${path.module}/saml-key.der")
+    public_cert = filebase64("${path.module}/saml-cert.der")
   }
 }
 ```
@@ -103,8 +103,8 @@ Optional:
 
 Required:
 
-- `private_key` (String, Sensitive) RSA private key (base64 encoded).
-- `public_cert` (String) Public certificate (base64 encoded).
+- `private_key` (String, Sensitive) Request signing RSA private key in PKCS#1 DER format (base64 encoded).
+- `public_cert` (String) Request signing public certificate in DER format (base64 encoded).
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`


### PR DESCRIPTION
Updated the documentation for `oxide_silo_saml_identity_provider` to note that the SAML signing certificate and private key should be in DER format before base64 encoding it.

Otherwise, users might get errors like the following when trying to use this resource.

```
╷
│ Error: Error creating SAML identity provider
│
│   with oxide_silo_saml_identity_provider.example,
│   on main.tf line 109, in resource "oxide_silo_saml_identity_provider" "example":
│  109: resource "oxide_silo_saml_identity_provider" "example" {
│
│ API error: POST https://oxide.sys.r3.oxide-preview.com/v1/system/identity-providers/saml?silo=9236e3bc-8f50-4ff9-beac-388f318bd0f1
│ ----------- RESPONSE -----------
│ Status: 400
│ Message: unable to parse JSON body: signing_keypair.private_key: private_key is not recognized as a RSA private key: error:068000A8:asn1 encoding
│ routines:asn1_check_tlen:wrong tag:crypto/asn1/tasn_dec.c:1188:, error:0688010A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1
│ error:crypto/asn1/tasn_dec.c:349:Type=RSAPrivateKey at line 1 column 4876
│ RequestID: fd5b67db-f61e-4ecb-9e87-bdf29525030f
│ ------- RESPONSE HEADERS -------
│ Content-Type: [application/json]
│ X-Request-Id: [fd5b67db-f61e-4ecb-9e87-bdf29525030f]
│ Date: [Mon, 08 Sep 2025 21:42:39 GMT]
│ Content-Length: [420]
│
```

```
╷
│ Error: Error creating SAML identity provider
│
│   with oxide_silo_saml_identity_provider.example,
│   on main.tf line 109, in resource "oxide_silo_saml_identity_provider" "example":
│  109: resource "oxide_silo_saml_identity_provider" "example" {
│
│ API error: POST https://oxide.sys.r3.oxide-preview.com/v1/system/identity-providers/saml?silo=9236e3bc-8f50-4ff9-beac-388f318bd0f1
│ ----------- RESPONSE -----------
│ Status: 400
│ Message: unable to parse JSON body: signing_keypair.public_cert: public_cert is not recognized as a X509 certificate: error:068000A8:asn1 encoding
│ routines:asn1_check_tlen:wrong tag:crypto/asn1/tasn_dec.c:1188:, error:0688010A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1
│ error:crypto/asn1/tasn_dec.c:349:Type=X509 at line 1 column 7701
│ RequestID: dca9d46b-2da2-4b7f-95f3-93863fa21ccc
│ ------- RESPONSE HEADERS -------
│ Content-Type: [application/json]
│ X-Request-Id: [dca9d46b-2da2-4b7f-95f3-93863fa21ccc]
│ Date: [Mon, 08 Sep 2025 22:13:59 GMT]
│ Content-Length: [412]
│
╵
```