### PR TITLE
silo: use previous state for id attribute

### DIFF
--- a/internal/provider/resource_silo.go
+++ b/internal/provider/resource_silo.go
@@ -113,6 +113,9 @@ func (r *siloResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the silo.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
Added a plan modifier to the `id` attribute to prevent it from being marked as `(known after apply)` during a call to `Update`. This prevents downstream resources that rely on `id` in an interpolation from recomputing their state as well.

With this change, notice how the `id` attribute no longer is marked as `(known after apply`).

```
tls_private_key.self-signed: Refreshing state... [id=c622d58fe2be7f6933c9bea4acade2bed4e4d050]
tls_self_signed_cert.self-signed: Refreshing state... [id=215195527778788990587349674206992319739]
oxide_silo.example: Refreshing state... [id=aed4e113-5db7-4025-abd6-dbac748e38c1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # oxide_silo.example will be updated in-place
  ~ resource "oxide_silo" "example" {
        id                 = "aed4e113-5db7-4025-abd6-dbac748e38c1"
        name               = "example"
      ~ quotas             = {
          ~ cpus    = 2 -> 4
            # (2 unchanged attributes hidden)
        }
      ~ time_created       = "2025-09-24 20:15:42.838197 +0000 UTC" -> (known after apply)
      ~ time_modified      = "2025-09-24 20:15:42.838197 +0000 UTC" -> (known after apply)
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_silo.example: Modifying... [id=aed4e113-5db7-4025-abd6-dbac748e38c1]
oxide_silo.example: Modifications complete after 1s [id=aed4e113-5db7-4025-abd6-dbac748e38c1]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Closes https://github.com/oxidecomputer/terraform-provider-oxide/issues/528.