### PR TITLE
provider: use previous state for id attribute

### DIFF
--- a/acctest/nexus-config.toml
+++ b/acctest/nexus-config.toml
@@ -98,13 +98,16 @@ metrics_producer_gc.period_secs = 60
 external_endpoints.period_secs = 60
 nat_cleanup.period_secs = 30
 bfd_manager.period_secs = 30
+# How frequently to check for a new inventory collection (made by any Nexus).
+# This is cheap, so we should check frequently.
+inventory.period_secs_load = 15
 # How frequently to collect hardware/software inventory from the whole system
 # (even if we don't have reason to believe anything has changed).
-inventory.period_secs = 600
+inventory.period_secs_collect = 600
 # Maximum number of past collections to keep in the database
 inventory.nkeep = 5
 # Disable inventory collection altogether (for emergencies)
-inventory.disable = false
+inventory.disable_collect = false
 phantom_disks.period_secs = 30
 physical_disk_adoption.period_secs = 30
 support_bundle_collector.period_secs = 30
@@ -162,3 +165,8 @@ type = "random"
 # setting `seed` to a fixed value will make dataset selection ordering use the
 # same shuffling order for every region allocation.
 # seed = 0
+
+[omdb]
+# In production omdb is shipped alongside Nexus in its zone; this doesn't happen
+# (and isn't needed) in simulated environments.
+bin_path = "/cannot/fetch/omdb/in/simulated/environments"

--- a/internal/provider/resource_anti_affinity_group.go
+++ b/internal/provider/resource_anti_affinity_group.go
@@ -111,6 +111,9 @@ This resource manages anti-affinity groups.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the anti-affinity group.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"failure_domain": schema.StringAttribute{
 				// For now this will remain as a computed attribute as there is

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -84,6 +84,9 @@ This resource manages Oxide floating IPs.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier for the floating IP.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -328,6 +328,9 @@ Maximum 32 KiB unencoded data.`,
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the instance.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -107,7 +109,10 @@ This resource manages IP pools.
 			}),
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "Unique, immutable, system-controlled identifier of the IP pool.",
+				Description: "Unique, immutable, system-controlled identifier of the IP Pool.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_ip_pool_silo_link.go
+++ b/internal/provider/resource_ip_pool_silo_link.go
@@ -97,6 +97,9 @@ This resource manages IP pool to silo links.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the IP pool silo link.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
@@ -84,6 +86,9 @@ This resource manages projects.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the project.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_vpc.go
+++ b/internal/provider/resource_vpc.go
@@ -109,6 +109,9 @@ This resource manages VPCs.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the VPC.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"system_router_id": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -333,6 +333,9 @@ Depending on the type, it will be one of the following:
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the firewall rules. Specific only to Terraform.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_vpc_router.go
+++ b/internal/provider/resource_vpc_router.go
@@ -89,6 +89,9 @@ This resource manages VPC routers.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the VPC router.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"kind": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_vpc_router_route.go
+++ b/internal/provider/resource_vpc_router_route.go
@@ -162,6 +162,9 @@ Depending on the type, it will be one of the following:
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the VPC router route.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"kind": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_vpc_subnet.go
+++ b/internal/provider/resource_vpc_subnet.go
@@ -117,6 +117,9 @@ This resource manages VPC subnets.
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique, immutable, system-controlled identifier of the VPC.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"time_created": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
Updated resources to use the previous state for their `id` attribute if the resource has an `Update` method that can mutate the resource without changing the underlying Oxide ID.