### PR TITLE
vpc_firewall_rules: fix incorrect example

### DIFF
--- a/docs/resources/oxide_vpc_firewall_rules.md
+++ b/docs/resources/oxide_vpc_firewall_rules.md
@@ -36,7 +36,7 @@ resource "oxide_vpc_firewall_rules" "example" {
           }
         ]
         ports     = ["443"]
-        protocols = ["tcp"]
+        protocols = [{ type = "tcp" }]
       },
       targets = [
         {


### PR DESCRIPTION
The example was using the wrong schema for `rules.filters.protocols`. Fixed that.