### PR TITLE
ci: investigate slow cleanup times.

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -16,9 +16,16 @@ jobs:
       # hosted Github Actions runners don't offer much space. Clean up unused
       # dependencies so that we don't run out of disk. Borrowed from
       # https://carlosbecker.com/posts/github-actions-disk-space.
+      #
+      # Note: deleting these directories can be very slow, so we only remove
+      # enough to allow the build to complete. We'll drop this workaround and
+      # get better build times once we switch to self-hosted runners with
+      # persistent storage and more disk.
       - name: "cleanup"
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          time sudo rm -rf /usr/share/dotnet
+          time sudo rm -rf /opt/hostedtoolcache/CodeQL
+
           sudo docker image prune --all --force
           sudo docker builder prune -a
       - uses: actions/checkout@v6


### PR DESCRIPTION
* Vendor the latest omicron config to fix tests.
* Speed up the cleanup step by a few minutes.