### PR TITLE
test: remove optional fields from oxide_images

### DIFF
--- a/internal/provider/data_source_images_test.go
+++ b/internal/provider/data_source_images_test.go
@@ -112,12 +112,10 @@ func checkDataSourceSiloImages(dataName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(dataName, "id"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.block_size"),
-		resource.TestCheckResourceAttrSet(dataName, "images.0.os"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.id"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.name"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.size"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.time_created"),
 		resource.TestCheckResourceAttrSet(dataName, "images.0.time_modified"),
-		resource.TestCheckResourceAttrSet(dataName, "images.0.version"),
 	}...)
 }


### PR DESCRIPTION
OS and version are optional fields, so the test can fail if the silo has images without them. Checking that these fields are properly set is covered by `TestAccCloudDataSourceImages_project`, where we have more control over the list of images.