### PR TITLE
Configure disk type.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,6 @@ jobs:
       matrix:
         omicron-branch:
           - "main"
-          - "rel/v17.1/rc0"
     uses: "./.github/workflows/acceptance-sim.yml"
     with:
       omicron-branch: ${{ matrix.omicron-branch }}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
-	github.com/oxidecomputer/oxide.go v0.7.0
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/oxidecomputer/oxide.go v0.7.0 h1:ZRxH3vSgwZys/dsQthphW4o57xp0BivUCkND18b5nr4=
-github.com/oxidecomputer/oxide.go v0.7.0/go.mod h1:e/Azkl4nFUrsdsJ113siW/ZNUQkiG539e4i7a6GEcD8=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94 h1:2lY3Z+2KqsNcoiitDRQGIswlvqc1h2ICTKT5UUaHpHc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94/go.mod h1:e/Azkl4nFUrsdsJ113siW/ZNUQkiG539e4i7a6GEcD8=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/resource_disk.go
+++ b/internal/provider/resource_disk.go
@@ -209,6 +209,15 @@ func (r *diskResource) Create(ctx context.Context, req resource.CreateRequest, r
 			Description: plan.Description.ValueString(),
 			Name:        oxide.Name(plan.Name.ValueString()),
 			Size:        oxide.ByteCount(plan.Size.ValueInt64()),
+			DiskBackend: oxide.DiskBackend{
+				// As of r18, disk type must be specified as
+				// "distributed" (the only option in prior
+				// releases) or "local". For now, always set
+				// disk type to distributed. We'll support
+				// local disks as well once r18 is available
+				// for testing.
+				Type: oxide.DiskBackendTypeDistributed,
+			},
 		},
 	}
 
@@ -223,7 +232,7 @@ func (r *diskResource) Create(ctx context.Context, req resource.CreateRequest, r
 		ds.BlockSize = oxide.BlockSize(plan.BlockSize.ValueInt64())
 		ds.Type = oxide.DiskSourceTypeBlank
 	}
-	params.Body.DiskSource = ds
+	params.Body.DiskBackend.DiskSource = ds
 
 	disk, err := r.client.DiskCreate(ctx, params)
 	if err != nil {


### PR DESCRIPTION
As of r18, we'll support both distributed disks (currently the only option) and local disks. To fix acceptance tests against omicron's main branch this patch sets the now-required disk type option to distributed. Once r18 lands on a test rack, we'll also add support for local disks.

Part of #566.
Closes SSE-128.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
