### PR TITLE
chore: make acctest setup idempotent.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,6 @@ To override when testing against a different environment, set the
 
 Run `make testacc`.
 
-Eventually we'll have a GitHub action to create a Nexus server and run these tests, but for now testing will have to be run manually.
-
 ## Releasing a new version
 
 Remember to update the changelog before releasing.


### PR DESCRIPTION
Running the acceptance test setup script more than once currently fails, as it will attempt to create resources that already exist. This patch updates the script to be approximately idempotent, so that it can be run multiple times if necessary.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
