### PR TITLE
ci: fix backport permissions

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -25,6 +25,9 @@ jobs:
         with:
           app-id: "${{ vars.BACKPORT_PR_APP_ID }}"
           private-key: "${{ secrets.BACKPORT_PR_APP_KEY }}"
+          permission-contents: "write"
+          permission-pull-requests: "write"
+          permission-workflows: "write"
       - uses: "oxidecomputer/backport-pr-action@v0"
         with:
           pr: "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
GitHub has an undocumented permission called `workflows` that is required to allow modifying workflow files.

`actions/create-github-app-token` is documented to import the GitHub App permissions by default, but from my tests it doesn't seem to import `workflows`, so permissions need to be set explicitly.