### PR TITLE
docs: import documentation

### DIFF
--- a/docs/resources/anti_affinity_group.md
+++ b/docs/resources/anti_affinity_group.md
@@ -57,3 +57,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_anti_affinity_group.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -76,3 +76,13 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_disk.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/floating_ip.md
+++ b/docs/resources/floating_ip.md
@@ -69,3 +69,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_floating_ip.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -70,3 +70,13 @@ Read-Only:
 
 - `type` (String) Digest type.
 - `value` (String) Digest type value.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_image.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/ip_pool.md
+++ b/docs/resources/ip_pool.md
@@ -68,3 +68,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_ip_pool.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/ip_pool_silo_link.md
+++ b/docs/resources/ip_pool_silo_link.md
@@ -52,3 +52,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_ip_pool_silo_link.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -52,3 +52,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_project.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/silo.md
+++ b/docs/resources/silo.md
@@ -102,3 +102,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_silo.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -59,3 +59,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_snapshot.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -52,3 +52,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_ssh_key.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -59,3 +59,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc_firewall_rules.md
+++ b/docs/resources/vpc_firewall_rules.md
@@ -282,3 +282,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc_firewall_rules.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc_internet_gateway.md
+++ b/docs/resources/vpc_internet_gateway.md
@@ -55,3 +55,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc_internet_gateway.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc_router.md
+++ b/docs/resources/vpc_router.md
@@ -55,3 +55,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc_router.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc_router_route.md
+++ b/docs/resources/vpc_router_route.md
@@ -95,3 +95,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc_router_route.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -58,3 +58,13 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_vpc_subnet.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90
+```

--- a/examples/resources/oxide_anti_affinity_group/import.sh
+++ b/examples/resources/oxide_anti_affinity_group/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_anti_affinity_group.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_disk/import.sh
+++ b/examples/resources/oxide_disk/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_disk.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_floating_ip/import.sh
+++ b/examples/resources/oxide_floating_ip/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_floating_ip.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_image/import.sh
+++ b/examples/resources/oxide_image/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_image.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_ip_pool/import.sh
+++ b/examples/resources/oxide_ip_pool/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_ip_pool.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_ip_pool_silo_link/import.sh
+++ b/examples/resources/oxide_ip_pool_silo_link/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_ip_pool_silo_link.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_project/import.sh
+++ b/examples/resources/oxide_project/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_project.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_silo/import.sh
+++ b/examples/resources/oxide_silo/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_silo.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_snapshot/import.sh
+++ b/examples/resources/oxide_snapshot/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_snapshot.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_ssh_key/import.sh
+++ b/examples/resources/oxide_ssh_key/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_ssh_key.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc/import.sh
+++ b/examples/resources/oxide_vpc/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc_firewall_rules/import.sh
+++ b/examples/resources/oxide_vpc_firewall_rules/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc_firewall_rules.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc_internet_gateway/import.sh
+++ b/examples/resources/oxide_vpc_internet_gateway/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc_internet_gateway.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc_router/import.sh
+++ b/examples/resources/oxide_vpc_router/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc_router.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc_router_route/import.sh
+++ b/examples/resources/oxide_vpc_router_route/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc_router_route.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90

--- a/examples/resources/oxide_vpc_subnet/import.sh
+++ b/examples/resources/oxide_vpc_subnet/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_vpc_subnet.example 3e2c6e84-bed8-4c94-afc3-1032082d6a90


### PR DESCRIPTION
Added import documentation for all resources according to the method required by `terraform-plugin-docs`.

Amp-Thread: https://ampcode.com/threads/T-019b395c-a6e2-71df-bf52-5b24b674a2dc
