### PR TITLE
Add build status badges per branch. (#574)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,17 +4,8 @@ on:
     branches:
       - main
       - '[0-9].[0-9]+'
-    paths:
-      - "**.go"
-      - .github/workflows/build-test.yml
-      - "go.mod"
-      - "go.sum"
-      - "docs/**"
-      - "examples/**"
+      - 'rel/v*'
   pull_request:
-    branches:
-      - main
-      - '[0-9].[0-9]+'
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Terraform Provider Oxide
 
+## Build status
+
+| Branch      | Status |
+| ----------- | ------ |
+| `main`      | [![main](https://github.com/oxidecomputer/terraform-provider-oxide/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/oxidecomputer/terraform-provider-oxide/actions/workflows/build-test.yml?query=branch%3Amain) |
+| `rel/v0.17` | [![0.17](https://github.com/oxidecomputer/terraform-provider-oxide/actions/workflows/build-test.yml/badge.svg?branch=rel%2Fv0.17)](https://github.com/oxidecomputer/terraform-provider-oxide/actions/workflows/build-test.yml?query=branch%3Arel%2Fv0.17) |
+
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads) 1.11.x and above, we recommend using the latest stable release whenever possible. When installing on an Illumos machine use the Solaris binary.


### PR DESCRIPTION
Manual backport of #574 because, for some reason, the automated attempts were still failing (https://github.com/oxidecomputer/terraform-provider-oxide/actions/runs/20578736991). 

I think this run was using old code that doesn't contain https://github.com/oxidecomputer/terraform-provider-oxide/pull/575, but I will investigate it further.