### PR TITLE
ci: update acceptance test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,8 @@ on:
       - '[0-9].[0-9]+'
       - 'rel/v*'
   pull_request:
+  schedule:
+    - cron: "25 7 * * *"
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -21,11 +23,6 @@ jobs:
       - name: lint
         run: make lint
   acceptance:
-    strategy:
-      fail-fast: false
-      matrix:
-        omicron-branch:
-          - "main"
     uses: "./.github/workflows/acceptance-sim.yml"
     with:
-      omicron-branch: ${{ matrix.omicron-branch }}
+      omicron-branch: "main"


### PR DESCRIPTION
Remove test matrix since each release branch currently only targets one Omicron branch. Also runs acceptance tests in a cron schedule to help detect breaking changes earlier.

The 7:25 UTC cron time was picked somewhat at random. The criteria I used was to avoid common "rush" hours for CI/CD systems (like 0:00 and anything at 00 minutes) and also something outside regular work hours.

There's currently no reporting in case of error, except for the badge status added to the README, but I think that's probably good enough for now.