### PR TITLE
backport: ci: update acceptance test workflow (#585)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,21 +23,6 @@ jobs:
       - name: lint
         run: make lint
   acceptance:
-<<<<<<< HEAD
-    strategy:
-      fail-fast: false
-      matrix:
-        omicron-branch:
-          - "main"
-          - "rel/v17.1/rc0"
-||||||| parent of 83859fc (ci: update acceptance test workflow (#585))
-    strategy:
-      fail-fast: false
-      matrix:
-        omicron-branch:
-          - "main"
-=======
->>>>>>> 83859fc (ci: update acceptance test workflow (#585))
     uses: "./.github/workflows/acceptance-sim.yml"
     with:
-      omicron-branch: "main"
+      omicron-branch: "rel/v17"


### PR DESCRIPTION
Remove test matrix since each release branch currently only targets one Omicron branch. Also runs acceptance tests in a cron schedule to help detect breaking changes earlier.

The 7:25 UTC cron time was picked somewhat at random. The criteria I used was to avoid common "rush" hours for CI/CD systems (like 0:00 and anything at 00 minutes) and also something outside regular work hours.

There's currently no reporting in case of error, except for the badge status added to the README, but I think that's probably good enough for now.

Oxide-backport-of: oxidecomputer/terraform-provider-oxide#585
