### PR TITLE
Support local disks.

### DIFF
--- a/.changelog/0.18.0.toml
+++ b/.changelog/0.18.0.toml
@@ -15,8 +15,12 @@ title = "Support `OXIDE_PROFILE`"
 description = "Added support for the `OXIDE_PROFILE` environment variable within the provider configuration. [#589](https://github.com/oxidecomputer/terraform-provider-oxide/pull/589)."
 
 [[features]]
-type = "Support `config_dir` and `insecure_skip_verify`"
+title = "Support `config_dir` and `insecure_skip_verify`"
 description = "Added support for the `config_dir` and `insecure_skip_verify` provider configuration. [#595](https://github.com/oxidecomputer/terraform-provider-oxide/pull/595)."
+
+[[features]]
+title = "Support `disk_type` in disk resource."
+description = "Added support for the `disk_type` attribute for the `oxide_disk` resource. [#587](https://github.com/oxidecomputer/terraform-provider-oxide/pull/587)."
 
 [[enhancements]]
 title = "`oxide_instance` attribute deprecation"

--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -57,6 +57,7 @@ resource "oxide_disk" "example2" {
 ### Optional
 
 - `block_size` (Number) Size of blocks in bytes.
+- `disk_type` (String) Type of disk. Must be one of "distributed" or "local". Defaults to "distributed".
 - `source_image_id` (String) Image ID of the disk source if applicable.
 - `source_snapshot_id` (String) Snapshot ID of the disk source if applicable.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))


### PR DESCRIPTION
In preparation for r18, allow users to configure disk types in the disk resource (distributed, local).

Part of #566.



-----

### Pull request checklist

- [x] Add changelog entry for this change.
