### PR TITLE
feat(provider): support `OXIDE_PROFILE`

### DIFF
--- a/.changelog/0.18.0.toml
+++ b/.changelog/0.18.0.toml
@@ -10,6 +10,10 @@ description = "`oxide_address_lot` [#489](https://github.com/oxidecomputer/terra
 title = "New data source"
 description = "`oxide_address_lot` [#489](https://github.com/oxidecomputer/terraform-provider-oxide/pull/489)."
 
+[[features]]
+title = "Support `OXIDE_PROFILE`"
+description = "Added support for the `OXIDE_PROFILE` environment variable within the provider configuration. [#589](https://github.com/oxidecomputer/terraform-provider-oxide/pull/589)."
+
 [[enhancements]]
 title = "`oxide_instance` attribute deprecation"
 description = "The `host_name` attribute on the `oxide_instance` resource has been deprecated in favor of `hostname`. The `host_name` attribute will be removed in the next minor version of the provider. [#577](https://github.com/oxidecomputer/terraform-provider-oxide/pulls/577)."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,9 @@ There is a make target to run the linters. All that's needed is `make lint`.
 
 ## Running acceptance tests
 
-To run the acceptance testing suite, you need to make sure to have either the `$OXIDE_HOST` and `$OXIDE_TOKEN` environment variables, or `$OXIDE_TEST_HOST` and `$OXIDE_TEST_TOKEN`. If you wish to use the later for a testing environment, make sure you have unset the previous first.
+To run the acceptance testing suite, you need to make sure to have either the
+`OXIDE_HOST` and `OXIDE_TOKEN`, or the `OXIDE_PROFILE` environment variables
+exported.
 
 Until all resources have been added you'll need to make sure your testing environment has the following:
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 ## Using the provider
 
-As a preferred method of authentication, export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables with their corresponding values.
+As a preferred method of authentication, export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables, or the `OXIDE_PROFILE` environment variable, with their corresponding values.
 
-Alternatively, it is possible to authenticate via the optional `host` and `token` arguments. In most cases this method of authentication is not recommended. It is generally preferable to keep credential information out of the configuration.
+Alternatively, it is possible to authenticate via the optional `host` and `token` or `profile` arguments. In most cases this method of authentication is not recommended. It is generally preferable to keep credential information out of the configuration.
 
 To generate a token, follow these steps:
 
@@ -39,10 +39,12 @@ terraform {
 }
 
 provider "oxide" {
-  # The provider will default to use $OXIDE_HOST and $OXIDE_TOKEN.
+  # The provider will default to use $OXIDE_HOST and $OXIDE_TOKEN,
+  # or $OXIDE_PROFILE.
   # If necessary they can be set explicitly (not recommended).
   # host = "<host address>"
   # token = "<token value>"
+  # profile = "<profile name>"
 }
 
 # Create a blank disk

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,9 @@ resource "oxide_instance" "example" {
 
 ### Environment Variables
 
-Export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables. This is the
-recommended authentication method.
+Export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables, or the
+`OXIDE_PROFILE` environment variable. This is the recommended authentication
+method.
 
 ```terraform
 provider "oxide" {}
@@ -39,7 +40,9 @@ provider "oxide" {}
 
 ### Profile
 
-Use a profile from the credentials file created via `oxide auth login`.
+Use a profile from the credentials file created via `oxide auth login`. This
+can be set using the `OXIDE_PROFILE` environment variable or the `profile`
+argument in the provider configuration.
 
 ```terraform
 provider "oxide" {

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -118,7 +118,7 @@ resource "oxide_instance" "example" {
 - `boot_disk_id` (String) ID of the disk the instance should be booted from. When provided, this ID must also be present in `disk_attachments`.
 - `disk_attachments` (Set of String) IDs of the disks to be attached to the instance. When multiple disk IDs are provided, set `boot_disk_id` to specify the boot disk for the instance. Otherwise, a boot disk will be chosen randomly.
 - `external_ips` (Attributes Set) External IP addresses provided to this instance. (see [below for nested schema](#nestedatt--external_ips))
-- `host_name` (String, Deprecated) Host name of the instance.
+- `host_name` (String, Deprecated) Hostname of the instance.
 - `hostname` (String) Hostname of the instance.
 - `network_interfaces` (Attributes Set) Network interface devices attached to the instance. (see [below for nested schema](#nestedatt--network_interfaces))
 - `ssh_public_keys` (Set of String) An allowlist of IDs of the SSH public keys to be transferred to the instance via cloud-init during instance creation.

--- a/internal/provider/testutils.go
+++ b/internal/provider/testutils.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -24,20 +23,14 @@ func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServ
 }
 
 func testAccPreCheck(t *testing.T) {
-	host, token := setAccFromEnvVar()
-
-	if host == "" || token == "" {
-		t.Fatal("Both host and token need to be set to execute acceptance tests")
+	if _, err := newTestClient(); err != nil {
+		t.Fatalf("failed to create oxide client for acceptance tests: %v", err)
 	}
 }
 
 func newTestClient() (*oxide.Client, error) {
-	host, token := setAccFromEnvVar()
-
 	config := oxide.Config{
-		Token:     token,
-		UserAgent: "terraform-provider-oxide-test",
-		Host:      host,
+		UserAgent: fmt.Sprintf("terraform-provider-oxide/%s", Version),
 	}
 	client, err := oxide.NewClient(&config)
 	if err != nil {
@@ -57,28 +50,6 @@ func parsedAccConfig(config any, tpl string) (string, error) {
 	}
 
 	return buf.String(), nil
-}
-
-func setAccFromEnvVar() (string, string) {
-	// TODO: Unsure if I should only keep the tests tokens,
-	// but will leave like this for now
-	var host, token string
-
-	if k := os.Getenv("OXIDE_HOST"); k != "" {
-		host = k
-	}
-	if k := os.Getenv("OXIDE_TEST_HOST"); k != "" {
-		host = k
-	}
-
-	if k := os.Getenv("OXIDE_TOKEN"); k != "" {
-		token = k
-	}
-	if k := os.Getenv("OXIDE_TEST_TOKEN"); k != "" {
-		token = k
-	}
-
-	return host, token
 }
 
 func newResourceName() string {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,14 +17,17 @@ description: |-
 
 ### Environment Variables
 
-Export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables. This is the
-recommended authentication method.
+Export the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables, or the
+`OXIDE_PROFILE` environment variable. This is the recommended authentication
+method.
 
 {{ tffile "examples/provider/provider-auth-env.tf" }}
 
 ### Profile
 
-Use a profile from the credentials file created via `oxide auth login`.
+Use a profile from the credentials file created via `oxide auth login`. This
+can be set using the `OXIDE_PROFILE` environment variable or the `profile`
+argument in the provider configuration.
 
 {{ tffile "examples/provider/provider-auth-profile.tf" }}
 


### PR DESCRIPTION
Add support for the `OXIDE_PROFILE` environment variable to allow users to authenticate using a profile from the Oxide credentials file.

Closes SSE-136.

Amp-Thread: https://ampcode.com/threads/T-019b96cb-2cec-73af-b286-47a7b920e558
