### PR TITLE
deps: update Go SDK with latest changes for R18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20260112183619-ab2936d45bb5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94 h1:2lY3Z+2KqsNcoiitDRQGIswlvqc1h2ICTKT5UUaHpHc=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20251209192830-04fa236fbf94/go.mod h1:e/Azkl4nFUrsdsJ113siW/ZNUQkiG539e4i7a6GEcD8=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260112183619-ab2936d45bb5 h1:EPky8QBORFsgOcwIBTMgsfOm1BnGphQe+zKNTgPKVLM=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260112183619-ab2936d45bb5/go.mod h1:eYMtxTV8TtcQtcO5ed55vECnC/LCPEf3LFtZDial8sM=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/data_source_instance_external_ips_test.go
+++ b/internal/provider/data_source_instance_external_ips_test.go
@@ -23,6 +23,12 @@ data "oxide_project" "{{.SupportBlockName}}" {
 	name = "tf-acc-test"
 }
 
+data "oxide_vpc_subnet" "default" {
+  project_name = data.oxide_project.{{.SupportBlockName}}.name
+  vpc_name     = "default"
+  name         = "default"
+}
+
 resource "oxide_instance" "{{.InstanceBlockName}}" {
   project_id      = data.oxide_project.{{.SupportBlockName}}.id
   description     = "a test instance"
@@ -35,6 +41,14 @@ resource "oxide_instance" "{{.InstanceBlockName}}" {
 	{
 	  type = "ephemeral"
 	}
+  ]
+  network_interfaces = [
+    {
+      name        = "net0"
+      description = "net0"
+      subnet_id   = data.oxide_vpc_subnet.default.id
+      vpc_id      = data.oxide_vpc_subnet.default.vpc_id
+    }
   ]
 }
 

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -225,6 +225,12 @@ data "oxide_project" "{{.SupportBlockName}}" {
 	name = "tf-acc-test"
 }
 
+data "oxide_vpc_subnet" "default" {
+  project_name = data.oxide_project.{{.SupportBlockName}}.name
+  vpc_name     = "default"
+  name         = "default"
+}
+
 data "oxide_ip_pool" "{{.IPPoolBlockName}}" {
 	name = "{{.IPPoolName}}"
 }
@@ -243,12 +249,26 @@ resource "oxide_instance" "{{.BlockName}}" {
 	  id   = data.oxide_ip_pool.{{.IPPoolBlockName}}.id
 	}
   ]
+  network_interfaces = [
+    {
+      name        = "net0"
+      description = "net0"
+      subnet_id   = data.oxide_vpc_subnet.default.id
+      vpc_id      = data.oxide_vpc_subnet.default.vpc_id
+    }
+  ]
 }
 `
 
 	resourceInstanceExternalIPConfigUpdate1Tpl := `
 data "oxide_project" "{{.SupportBlockName}}" {
 	name = "tf-acc-test"
+}
+
+data "oxide_vpc_subnet" "default" {
+  project_name = data.oxide_project.{{.SupportBlockName}}.name
+  vpc_name     = "default"
+  name         = "default"
 }
 
 resource "oxide_instance" "{{.BlockName}}" {
@@ -263,6 +283,14 @@ resource "oxide_instance" "{{.BlockName}}" {
 	{
 	  type = "ephemeral"
 	}
+  ]
+  network_interfaces = [
+    {
+      name        = "net0"
+      description = "net0"
+      subnet_id   = data.oxide_vpc_subnet.default.id
+      vpc_id      = data.oxide_vpc_subnet.default.vpc_id
+    }
   ]
 }
 `

--- a/scripts/acc-test-setup.sh
+++ b/scripts/acc-test-setup.sh
@@ -29,6 +29,10 @@ if ! oxide ip-pool view --pool default > /dev/null; then
     oxide ip-pool create --name default --description default
     oxide ip-pool silo link --pool default --silo $SILO_NAME --is-default true
     oxide ip-pool range add --first 10.0.1.0 --last 10.0.1.255 --pool default
+
+    oxide ip-pool create --name default-ipv6 --description 'default IPv6' --ip-version v6
+    oxide ip-pool silo link --pool default-ipv6 --silo $SILO_NAME --is-default true
+    oxide ip-pool range add --first fc00:: --last fc00:ffff:: --pool default-ipv6
 fi
 
 # The acceptance tests expect both at least a single project-scoped image and a


### PR DESCRIPTION
This PR is the first of a series intended to add support for release R18 features.

This initial work just updates the SDK version and adapts the internal logic to the new API structure. It does not add new feature and does not modify any resource schema.

Most importantly, this PR does not add support for IPv6. Network cards with IPv6 are ignored and it's not possible to create IPv6 network interfaces or external IPs.

Relates to SSE-141