### PR TITLE
Refactor and cache docker image for faster builds.

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -3,10 +3,9 @@ name: "simulator acceptance tests"
 on:
   workflow_call:
     inputs:
-      omicron-branch:
+      omicron-sha:
         type: "string"
         required: true
-        default: "main"
 
 jobs:
   acceptance:
@@ -17,15 +16,6 @@ jobs:
           - terraform
           - opentofu
     steps:
-      # Simulated omicron takes up a meaningful amount of disk space, and the
-      # hosted Github Actions runners don't offer much space. Clean up unused
-      # dependencies so that we don't run out of disk. Borrowed from
-      # https://carlosbecker.com/posts/github-actions-disk-space.
-      - name: "cleanup"
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          sudo docker builder prune -a
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         if: matrix.tf-binary == 'terraform'
@@ -45,8 +35,10 @@ jobs:
       # always use the latest oxide.rs version corresponding to the relevant omicron version.
       - name: resolve oxide cli version
         id: oxide-cli
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          commit=$(./acctest/oxide-cli-version.sh '${{ inputs.omicron-branch }}')
+          commit=$(./acctest/oxide-cli-version.sh '${{ inputs.omicron-sha }}')
           echo "commit=${commit}" >> $GITHUB_OUTPUT
       - name: cache oxide cli
         uses: actions/cache@v4
@@ -66,11 +58,21 @@ jobs:
           ~/.cargo/bin/oxide version
           echo ~/.cargo/bin >> $GITHUB_PATH
       # Run simulated omicron in the background with docker compose.
-      # TODO(jmcarp): publish this image for faster builds.
-      - name: omicron-dev
-        working-directory: acctest
+      # The image is pre-built and pushed by the publish-image job in build-test.yml.
+      - name: pull omicron-dev image
+        env:
+          IMAGE_REPO: ${{ github.repository }}
+          OMICRON_SHA: ${{ inputs.omicron-sha }}
         run: |
-          docker compose build --build-arg 'OMICRON_BRANCH=${{ inputs.omicron-branch }}'
+          REMOTE_IMAGE="ghcr.io/${IMAGE_REPO}/acctest-omicron-dev:${OMICRON_SHA}"
+          LOCAL_IMAGE="acctest-omicron-dev:${OMICRON_SHA}"
+          docker pull "${REMOTE_IMAGE}"
+          docker tag "${REMOTE_IMAGE}" "${LOCAL_IMAGE}"
+      - name: start omicron-dev
+        working-directory: acctest
+        env:
+          TEST_ACC_DOCKER_TAG: ${{ inputs.omicron-sha }}
+        run: |
           if ! docker compose up --wait --wait-timeout 1500; then
             docker compose logs
             exit 1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,13 @@ on:
       - 'rel/v*'
   pull_request:
   schedule:
+    # Cron jobs test against omicron main to catch breaking changes early.
     - cron: "25 7 * * *"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/acctest-omicron-dev
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -22,7 +28,87 @@ jobs:
         run: make test
       - name: lint
         run: make lint
+
+  # Choose the appropriate omicron version for acceptance tests. For cron jobs, use `main`, since
+  # our goal is to detect breaking changes in omicron. Otherwise, look up the omicron version from
+  # the VERSION_OMICRON file in oxide.go, checking the expected version of oxide.go from go.mod.
+  #
+  # Note: we use the omicron commit hash throughout for tagging and fetching the docker image, so
+  # it has to be a complete SHA, not a branch name or partial SHA.
+  omicron-version:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.version.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_SCHEDULE: ${{ github.event_name == 'schedule' }}
+        run: |
+          if [[ "${IS_SCHEDULE}" == "true" ]]; then
+            OMICRON_SHA=$(./acctest/omicron-version.sh main)
+          else
+            OMICRON_SHA=$(./acctest/omicron-version.sh)
+          fi
+          echo "sha=${OMICRON_SHA}" >> $GITHUB_OUTPUT
+
+  # Build and push the acctest docker image before running acceptance tests.
+  # This ensures the image is available in the registry for acceptance tests to pull.
+  #
+  # Note: images are cached by omicron SHA only. If you change acctest/Dockerfile, manually delete
+  # the cached image from ghcr.io/oxidecomputer/terraform-provider-oxide/acctest-omicron-dev.
+  publish-image:
+    needs: omicron-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if image exists
+        id: check
+        run: |
+          if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.omicron-version.outputs.sha }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Clean up disk space
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: acctest
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            OMICRON_SHA=${{ needs.omicron-version.outputs.sha }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.omicron-version.outputs.sha }}
+
   acceptance:
+    needs: [omicron-version, publish-image]
     uses: "./.github/workflows/acceptance-sim.yml"
     with:
-      omicron-branch: "main"
+      omicron-sha: ${{ needs.omicron-version.outputs.sha }}

--- a/acctest/Dockerfile
+++ b/acctest/Dockerfile
@@ -1,12 +1,45 @@
-FROM rust
+# Builder image
+FROM rust:bookworm AS builder
 
-ARG OMICRON_BRANCH="main"
+ARG OMICRON_SHA
 
-RUN /bin/bash -c "git clone https://github.com/oxidecomputer/omicron.git --branch '${OMICRON_BRANCH}' --depth 1 && \
-  cd omicron && \
-  source env.sh && \
-  ./tools/install_builder_prerequisites.sh -y -s"
+RUN curl -sL "https://github.com/oxidecomputer/omicron/archive/${OMICRON_SHA}.tar.gz" | tar xz && \
+    mv omicron-* omicron
 
-RUN sed -i 's/bind_address = "127.0.0.1:12220"/bind_address = "0.0.0.0:12220"/' omicron/nexus/examples/config.toml
+WORKDIR /omicron
 
-WORKDIR omicron
+RUN bash -c "source env.sh && ./tools/install_builder_prerequisites.sh -y -s"
+
+RUN bash -c "source env.sh && cargo build -p omicron-dev"
+
+# Runtime image
+FROM debian:bookworm-slim
+
+COPY --from=builder /omicron/tools/install_runner_prerequisites.sh /tmp/
+RUN apt-get update && \
+    /tmp/install_runner_prerequisites.sh -y -s && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/* /tmp/install_runner_prerequisites.sh
+
+# Copy binaries and config files from the builder image.
+COPY --from=builder /omicron/target/debug/omicron-dev /usr/local/bin/
+COPY --from=builder /omicron/out/clickhouse /omicron/out/clickhouse
+COPY --from=builder /omicron/out/cockroachdb /omicron/out/cockroachdb
+COPY --from=builder /omicron/out/dendrite-stub /omicron/out/dendrite-stub
+COPY --from=builder /omicron/out/mgd /omicron/out/mgd
+
+COPY --from=builder /omicron/nexus/examples /omicron/nexus/examples
+COPY --from=builder /omicron/gateway-test-utils/configs /omicron/gateway-test-utils/configs
+COPY --from=builder /omicron/smf /omicron/smf
+
+RUN sed -i 's/bind_address = "127.0.0.1:12220"/bind_address = "0.0.0.0:12220"/' \
+    /omicron/nexus/examples/config.toml
+
+# Add test paths required by omicron-dev.
+RUN mkdir -p /omicron/test-utils /omicron/nexus/test-utils
+
+ENV PATH="/omicron/out/cockroachdb/bin:/omicron/out/clickhouse:/omicron/out/dendrite-stub/bin:/omicron/out/mgd/root/opt/oxide/mgd/bin:${PATH}"
+
+WORKDIR /omicron
+
+CMD ["omicron-dev", "run-all"]

--- a/acctest/docker-compose.yaml
+++ b/acctest/docker-compose.yaml
@@ -3,7 +3,11 @@ services:
     build: "."
     image: "acctest-omicron-dev:${TEST_ACC_DOCKER_TAG:-latest}"
     platform: "linux/amd64"
-    command: "/bin/bash -c 'source env.sh && cargo xtask omicron-dev run-all'"
+    command:
+      - "omicron-dev"
+      - "run-all"
+      - "--nexus-config=/omicron/nexus/examples/config.toml"
+      - "--gateway-config=/omicron/gateway-test-utils/configs/sp_sim_config.test.toml"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:12220"]
       interval: "5s"

--- a/acctest/omicron-version.sh
+++ b/acctest/omicron-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Output the omicron commit SHA to use for acceptance tests.
+#
+# Usage:
+#   ./omicron-version.sh [VERSION]
+#
+# If VERSION is provided (branch name or SHA), resolve it to a full SHA.
+# Otherwise, look up the version from oxide.go's VERSION_OMICRON file.
+
+set -euo pipefail
+
+OMICRON_VERSION="${1:-}"
+
+if [[ -z "${OMICRON_VERSION}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+    OXIDE_COMMIT=$(cd "${REPO_ROOT}" && go list -m -json github.com/oxidecomputer/oxide.go | jq -r '.Version | split("-") | .[-1]')
+    if [[ -z "${OXIDE_COMMIT}" ]]; then
+        echo "Error: Could not extract oxide.go commit from go.mod" >&2
+        exit 1
+    fi
+
+    OMICRON_VERSION=$(curl -sL "https://raw.githubusercontent.com/oxidecomputer/oxide.go/${OXIDE_COMMIT}/VERSION_OMICRON")
+    if [[ -z "${OMICRON_VERSION}" ]]; then
+        echo "Error: Could not fetch VERSION_OMICRON from oxide.go" >&2
+        exit 1
+    fi
+fi
+
+gh api "repos/oxidecomputer/omicron/commits/${OMICRON_VERSION}" --jq '.sha'

--- a/acctest/oxide-cli-version.sh
+++ b/acctest/oxide-cli-version.sh
@@ -26,8 +26,7 @@ if [[ -z "${API_VERSION}" || "${API_VERSION}" == "null" ]]; then
 fi
 echo "Nexus API version: ${API_VERSION}" >&2
 
-# Search oxide.rs commits for matching version.
-COMMITS=$(curl -sL "https://api.github.com/repos/oxidecomputer/oxide.rs/commits?path=oxide.json&per_page=50" | jq -r '.[].sha')
+COMMITS=$(gh api "repos/oxidecomputer/oxide.rs/commits?path=oxide.json&per_page=50" --jq '.[].sha')
 for sha in ${COMMITS}; do
     version=$(curl -sL "https://raw.githubusercontent.com/oxidecomputer/oxide.rs/${sha}/oxide.json" | jq -r '.info.version' 2>/dev/null || echo "")
     if [[ "${version}" == "${API_VERSION}" ]]; then


### PR DESCRIPTION
* Use a builder image to build the relevant binaries, then copy to the output image. This will avoid compiling rust binaries on every run.
* Check for cached images based on VERSION_OMICRON if available, other than the cron task, which always uses omicron main.