### PR TITLE
Cache oxide.rs by version.

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -40,15 +40,31 @@ jobs:
           go-version-file: 'go.mod'
       - uses: docker/setup-compose-action@v1
       - uses: astral-sh/setup-uv@v7
+      # Look up the version of oxide.rs corresponding to the requested omicron version. We'll cache
+      # the resulting binary, so that we only build the CLI for a given oxide.rs commit once, and
+      # always use the latest oxide.rs version corresponding to the relevant omicron version.
+      - name: resolve oxide cli version
+        id: oxide-cli
+        run: |
+          commit=$(./acctest/oxide-cli-version.sh '${{ inputs.omicron-branch }}')
+          echo "commit=${commit}" >> $GITHUB_OUTPUT
+      - name: cache oxide cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/oxide
+          key: oxide-cli-${{ steps.oxide-cli.outputs.commit }}
       - name: install oxide cli
         run: |
-          cargo install \
-            --git https://github.com/oxidecomputer/oxide.rs \
-            --branch '${{ inputs.omicron-branch }}' \
-            --root . \
-            oxide-cli
-          ./bin/oxide version
-          echo "$(pwd)/bin" >> $GITHUB_PATH
+          if [[ -x ~/.cargo/bin/oxide ]]; then
+            echo "using cached oxide cli"
+          else
+            cargo install \
+              --git https://github.com/oxidecomputer/oxide.rs \
+              --rev '${{ steps.oxide-cli.outputs.commit }}' \
+              oxide-cli
+          fi
+          ~/.cargo/bin/oxide version
+          echo ~/.cargo/bin >> $GITHUB_PATH
       # Run simulated omicron in the background with docker compose.
       # TODO(jmcarp): publish this image for faster builds.
       - name: omicron-dev

--- a/acctest/oxide-cli-version.sh
+++ b/acctest/oxide-cli-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Get the relevant commit of oxide.rs that best corresponds to a given omicron version. First look
+# up the OpenAPI spec version corresponding to the omicron ref. Then find the most recent commit to
+# oxide.rs@main that uses the expected spec version. If no match is found, use the latest commit to
+# oxide.rs@main.
+
+set -euo pipefail
+
+OMICRON_VERSION="${1:?Usage: oxide-cli-version.sh OMICRON_VERSION}"
+
+echo "Omicron version: ${OMICRON_VERSION}" >&2
+
+# Look up the openapi spec version from the omicron version.
+NEXUS_LATEST=$(curl -sL "https://raw.githubusercontent.com/oxidecomputer/omicron/${OMICRON_VERSION}/openapi/nexus/nexus-latest.json")
+if [[ -z "${NEXUS_LATEST}" ]]; then
+    echo "Error: Could not fetch nexus-latest.json" >&2
+    exit 1
+fi
+SPEC_URL="https://raw.githubusercontent.com/oxidecomputer/omicron/${OMICRON_VERSION}/openapi/nexus/${NEXUS_LATEST}"
+API_VERSION=$(curl -sL "${SPEC_URL}" | jq -r '.info.version')
+
+if [[ -z "${API_VERSION}" || "${API_VERSION}" == "null" ]]; then
+    echo "Error: Could not extract API version from ${SPEC_URL}" >&2
+    exit 1
+fi
+echo "Nexus API version: ${API_VERSION}" >&2
+
+# Search oxide.rs commits for matching version.
+COMMITS=$(curl -sL "https://api.github.com/repos/oxidecomputer/oxide.rs/commits?path=oxide.json&per_page=50" | jq -r '.[].sha')
+for sha in ${COMMITS}; do
+    version=$(curl -sL "https://raw.githubusercontent.com/oxidecomputer/oxide.rs/${sha}/oxide.json" | jq -r '.info.version' 2>/dev/null || echo "")
+    if [[ "${version}" == "${API_VERSION}" ]]; then
+        echo "Found oxide.rs commit ${sha} with API version ${version}" >&2
+        echo "${sha}"
+        exit 0
+    fi
+done
+
+# If no exact match, default to `main`. We're probably using omicron main in
+# this case, so the latest oxide.rs is a reasonable default.
+MAIN_SHA=$(git ls-remote https://github.com/oxidecomputer/oxide.rs refs/heads/main | cut -f1)
+echo "No exact match for API version ${API_VERSION}. Defaulting to oxide.rs main (${MAIN_SHA})." >&2
+echo "${MAIN_SHA}"


### PR DESCRIPTION
* Look up the correct version of oxide.rs for the current VERSION_OMICRON. We can't assume that the `main` branch of this repo always corresponds to oxide.rs@main, so we look up the expected version of the openapi spec and page through oxide.rs commits until we find one with a matching version in its oxide.json.
* Cache the oxide.rs binary by its commit hash. Building from source can take 4-5 minutes on shared workers, so we save a meaningful amount of time by caching.

Extracting from #604 for easier review.