### PR TITLE
Bump oxide.go to latest.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/oxidecomputer/oxide.go v0.7.1-0.20260127143929-a6e47816d4f4
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20260127220329-e1ba7effd833
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -623,6 +623,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/oxidecomputer/oxide.go v0.7.1-0.20260127143929-a6e47816d4f4 h1:Dkktvmc6O++01SQBjjjKYcsIYC2AW8dVvkF63gZt5Sk=
 github.com/oxidecomputer/oxide.go v0.7.1-0.20260127143929-a6e47816d4f4/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260127220329-e1ba7effd833 h1:Gx1sq1gGDQ2Mf/R0lXlW8TV6tPM8tcA0tDoXyuovYAQ=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260127220329-e1ba7effd833/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -192,15 +192,15 @@ func (f *floatingIPResource) Create(
 	if ip != "" {
 		// Explicit IP, and explicit pool if set, otherwise uses silo's default
 		// pool for the IP version being used.
-		params.Body.AddressSelector = oxide.AddressSelector{
-			Type: oxide.AddressSelectorTypeExplicit,
-			Ip:   ip,
-			Pool: oxide.NameOrId(pool),
+		params.Body.AddressAllocator = oxide.AddressAllocator{
+			Type:         oxide.AddressAllocatorTypeExplicit,
+			Ip:           ip,
+			PoolSelector: oxide.PoolSelector{Pool: oxide.NameOrId(pool)},
 		}
 	} else if pool != "" {
 		// Auto IP with explicit pool.
-		params.Body.AddressSelector = oxide.AddressSelector{
-			Type: oxide.AddressSelectorTypeAuto,
+		params.Body.AddressAllocator = oxide.AddressAllocator{
+			Type: oxide.AddressAllocatorTypeAuto,
 			PoolSelector: oxide.PoolSelector{
 				Type: oxide.PoolSelectorTypeExplicit,
 				Pool: oxide.NameOrId(pool),
@@ -208,8 +208,8 @@ func (f *floatingIPResource) Create(
 		}
 	} else {
 		// Auto IP with auto IPv4 pool.
-		params.Body.AddressSelector = oxide.AddressSelector{
-			Type: oxide.AddressSelectorTypeAuto,
+		params.Body.AddressAllocator = oxide.AddressAllocator{
+			Type: oxide.AddressAllocatorTypeAuto,
 			PoolSelector: oxide.PoolSelector{
 				Type:      oxide.PoolSelectorTypeAuto,
 				IpVersion: oxide.IpVersionV4,


### PR DESCRIPTION
Pull in a small breaking change from oxide.go. I'd like to get this in so that future PRs based on oxide.go don't include noise from this change in the diffs.