### PR TITLE
test: fix IP pool tests

### DIFF
--- a/internal/provider/resource_external_subnet_test.go
+++ b/internal/provider/resource_external_subnet_test.go
@@ -7,6 +7,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -102,7 +103,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 		PoolName:         "terraform-acc-ext-subnet-pool",
 		PoolDescription:  "a subnet pool for external subnet tests",
 		PoolIPVersion:    "v4",
-		PoolMemberSubnet: "192.0.2.0/24",
+		PoolMemberSubnet: fmt.Sprintf("192.%d.%d.0/24", rand.IntN(255), rand.IntN(255)),
 		MaxPrefixLength:  30,
 		IsDefault:        true,
 		SubnetIPVersion:  "v4",

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -129,7 +129,7 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		CheckDestroy:             testAccIPPoolSiloLinkDestroy,

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -19,7 +19,7 @@ func TestAccResourceSubnetPoolSiloLink_full(t *testing.T) {
 	poolResourceName := "oxide_subnet_pool.test"
 	linkResourceName := "oxide_subnet_pool_silo_link.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Randomize subnet value and serialize tests cases that use `is_default = true` to avoid conflicts.

