### PR TITLE
misc(subnet_pool_silo_link): change read logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/oxidecomputer/oxide.go v0.7.1-0.20260206035828-b5d31ae54de1
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -621,10 +621,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260203205921-06dacbeebae7 h1:taKDndmbieTpMvuE/ojkVtfAjXQ8dlLmjx44Z8s6KJs=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260203205921-06dacbeebae7/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260206035828-b5d31ae54de1 h1:arJbgudVNdJnfEeZVcl+NXDSZyWo9uV7f7Jd2pO5vbU=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260206035828-b5d31ae54de1/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b h1:KDUeTr6i0kGdMhs1JB/H1nM0mmd3ZZ9ww2GNpop51hc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
Updated the `Read` method to use a different Oxide API call to read subnet links for a specific silo.

Relates to SSE-141.
