### PR TITLE
Validate subnet cidrs.

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -186,10 +186,6 @@ Optional:
 - `ip_version` (String) IP version to use when multiple default pools exist. Conflicts with `pool_id`.
 - `pool_id` (String) ID of the IP pool to allocate from. Conflicts with `ip_version`.
 
-Read-Only:
-
-- `ip` (String) The external ephemeral IP attached to the instance.
-
 
 <a id="nestedatt--external_ips--floating"></a>
 ### Nested Schema for `external_ips.floating`
@@ -197,11 +193,6 @@ Read-Only:
 Required:
 
 - `id` (String) The external floating IP ID.
-
-Read-Only:
-
-- `ip` (String) The external floating IP attached to the instance.
-- `name` (String) The name of the external floating IP attached to the instance.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ tool (
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.17.0
+	github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/hashicorp/terraform-plugin-docs v0.24.0 h1:YNZYd+8cpYclQyXbl1EEngbld8
 github.com/hashicorp/terraform-plugin-docs v0.24.0/go.mod h1:YLg+7LEwVmRuJc0EuCw0SPLxuQXw5mW8iJ5ml/kvi+o=
 github.com/hashicorp/terraform-plugin-framework v1.17.0 h1:JdX50CFrYcYFY31gkmitAEAzLKoBgsK+iaJjDC8OexY=
 github.com/hashicorp/terraform-plugin-framework v1.17.0/go.mod h1:4OUXKdHNosX+ys6rLgVlgklfxN3WHR5VHSOABeS/BM0=
+github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0 h1:cEiRvdFAhFnivRm9JI/8l2g8oruzkioUAwItkEM7bmU=
+github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0/go.mod h1:SDIm7W2x3Bs9otNC0ysbaSQ7H4H/EPimoACTy+7Z9rU=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 h1:jblRy1PkLfPm5hb5XeMa3tezusnMRziUGqtT5epSYoI=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0/go.mod h1:5jm2XK8uqrdiSRfD5O47OoxyGMCnwTcl8eoiDgSa+tc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=

--- a/internal/provider/resource_external_subnet.go
+++ b/internal/provider/resource_external_subnet.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
@@ -43,19 +44,19 @@ type externalSubnetResource struct {
 }
 
 type externalSubnetResourceModel struct {
-	ID                 types.String   `tfsdk:"id"`
-	Name               types.String   `tfsdk:"name"`
-	Description        types.String   `tfsdk:"description"`
-	ProjectID          types.String   `tfsdk:"project_id"`
-	Subnet             types.String   `tfsdk:"subnet"`
-	PrefixLen          types.Int64    `tfsdk:"prefix_len"`
-	SubnetPoolID       types.String   `tfsdk:"subnet_pool_id"`
-	IPVersion          types.String   `tfsdk:"ip_version"`
-	SubnetPoolMemberID types.String   `tfsdk:"subnet_pool_member_id"`
-	InstanceID         types.String   `tfsdk:"instance_id"`
-	TimeCreated        types.String   `tfsdk:"time_created"`
-	TimeModified       types.String   `tfsdk:"time_modified"`
-	Timeouts           timeouts.Value `tfsdk:"timeouts"`
+	ID                 types.String       `tfsdk:"id"`
+	Name               types.String       `tfsdk:"name"`
+	Description        types.String       `tfsdk:"description"`
+	ProjectID          types.String       `tfsdk:"project_id"`
+	Subnet             cidrtypes.IPPrefix `tfsdk:"subnet"`
+	PrefixLen          types.Int64        `tfsdk:"prefix_len"`
+	SubnetPoolID       types.String       `tfsdk:"subnet_pool_id"`
+	IPVersion          types.String       `tfsdk:"ip_version"`
+	SubnetPoolMemberID types.String       `tfsdk:"subnet_pool_member_id"`
+	InstanceID         types.String       `tfsdk:"instance_id"`
+	TimeCreated        types.String       `tfsdk:"time_created"`
+	TimeModified       types.String       `tfsdk:"time_modified"`
+	Timeouts           timeouts.Value     `tfsdk:"timeouts"`
 }
 
 // Metadata returns the resource type name.
@@ -133,6 +134,7 @@ func (r *externalSubnetResource) Schema(
 			"subnet": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
+				CustomType:          cidrtypes.IPPrefixType{},
 				MarkdownDescription: "The subnet CIDR to reserve. Must be available in the pool. Conflicts with `prefix_len`. If unset, a subnet will be automatically allocated with the specified `prefix_len`.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
@@ -297,7 +299,7 @@ func (r *externalSubnetResource) Create(
 	plan.Name = types.StringValue(string(externalSubnet.Name))
 	plan.Description = types.StringValue(externalSubnet.Description)
 	plan.ProjectID = types.StringValue(externalSubnet.ProjectId)
-	plan.Subnet = types.StringValue(externalSubnet.Subnet.String())
+	plan.Subnet = cidrtypes.NewIPPrefixValue(externalSubnet.Subnet.String())
 	plan.SubnetPoolID = types.StringValue(externalSubnet.SubnetPoolId)
 	plan.SubnetPoolMemberID = types.StringValue(externalSubnet.SubnetPoolMemberId)
 	plan.InstanceID = types.StringValue(externalSubnet.InstanceId)
@@ -360,7 +362,7 @@ func (r *externalSubnetResource) Read(
 	state.Name = types.StringValue(string(externalSubnet.Name))
 	state.Description = types.StringValue(externalSubnet.Description)
 	state.ProjectID = types.StringValue(externalSubnet.ProjectId)
-	state.Subnet = types.StringValue(externalSubnet.Subnet.String())
+	state.Subnet = cidrtypes.NewIPPrefixValue(externalSubnet.Subnet.String())
 	state.SubnetPoolID = types.StringValue(externalSubnet.SubnetPoolId)
 	state.SubnetPoolMemberID = types.StringValue(externalSubnet.SubnetPoolMemberId)
 	state.InstanceID = types.StringValue(externalSubnet.InstanceId)
@@ -428,7 +430,7 @@ func (r *externalSubnetResource) Update(
 	plan.Name = types.StringValue(string(externalSubnet.Name))
 	plan.Description = types.StringValue(externalSubnet.Description)
 	plan.ProjectID = types.StringValue(externalSubnet.ProjectId)
-	plan.Subnet = types.StringValue(externalSubnet.Subnet.String())
+	plan.Subnet = cidrtypes.NewIPPrefixValue(externalSubnet.Subnet.String())
 	plan.SubnetPoolID = types.StringValue(externalSubnet.SubnetPoolId)
 	plan.SubnetPoolMemberID = types.StringValue(externalSubnet.SubnetPoolMemberId)
 	plan.InstanceID = types.StringValue(externalSubnet.InstanceId)

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/iptypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -25,17 +26,17 @@ import (
 // floatingIPResourceModel represents the Terraform configuration and state for
 // the Oxide floating IP resource.
 type floatingIPResourceModel struct {
-	ID           types.String   `tfsdk:"id"`
-	Name         types.String   `tfsdk:"name"`
-	Description  types.String   `tfsdk:"description"`
-	IP           types.String   `tfsdk:"ip"`
-	InstanceID   types.String   `tfsdk:"instance_id"`
-	IPPoolID     types.String   `tfsdk:"ip_pool_id"`
-	IPVersion    types.String   `tfsdk:"ip_version"`
-	ProjectID    types.String   `tfsdk:"project_id"`
-	TimeCreated  types.String   `tfsdk:"time_created"`
-	TimeModified types.String   `tfsdk:"time_modified"`
-	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+	ID           types.String      `tfsdk:"id"`
+	Name         types.String      `tfsdk:"name"`
+	Description  types.String      `tfsdk:"description"`
+	IP           iptypes.IPAddress `tfsdk:"ip"`
+	InstanceID   types.String      `tfsdk:"instance_id"`
+	IPPoolID     types.String      `tfsdk:"ip_pool_id"`
+	IPVersion    types.String      `tfsdk:"ip_version"`
+	ProjectID    types.String      `tfsdk:"project_id"`
+	TimeCreated  types.String      `tfsdk:"time_created"`
+	TimeModified types.String      `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value    `tfsdk:"timeouts"`
 }
 
 // Compile-time assertions to check that the floatingIPResource implements the
@@ -123,6 +124,7 @@ This resource manages Oxide floating IPs.
 			"ip": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
+				CustomType:          iptypes.IPAddressType{},
 				MarkdownDescription: "IP address for this floating IP. If unset an IP address will be chosen from the given `ip_pool_id`.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
@@ -260,7 +262,7 @@ func (f *floatingIPResource) Create(
 	plan.ID = types.StringValue(floatingIP.Id)
 	plan.Name = types.StringValue(string(floatingIP.Name))
 	plan.Description = types.StringValue(floatingIP.Description)
-	plan.IP = types.StringValue(floatingIP.Ip)
+	plan.IP = iptypes.NewIPAddressValue(floatingIP.Ip)
 	plan.InstanceID = types.StringValue(floatingIP.InstanceId)
 	plan.IPPoolID = types.StringValue(floatingIP.IpPoolId)
 	plan.ProjectID = types.StringValue(floatingIP.ProjectId)
@@ -321,7 +323,7 @@ func (f *floatingIPResource) Read(
 	state.ID = types.StringValue(floatingIP.Id)
 	state.Name = types.StringValue(string(floatingIP.Name))
 	state.Description = types.StringValue(floatingIP.Description)
-	state.IP = types.StringValue(floatingIP.Ip)
+	state.IP = iptypes.NewIPAddressValue(floatingIP.Ip)
 	state.InstanceID = types.StringValue(floatingIP.InstanceId)
 	state.IPPoolID = types.StringValue(floatingIP.IpPoolId)
 	state.ProjectID = types.StringValue(floatingIP.ProjectId)
@@ -390,7 +392,7 @@ func (f *floatingIPResource) Update(
 	plan.ID = types.StringValue(floatingIP.Id)
 	plan.Name = types.StringValue(string(floatingIP.Name))
 	plan.Description = types.StringValue(floatingIP.Description)
-	plan.IP = types.StringValue(floatingIP.Ip)
+	plan.IP = iptypes.NewIPAddressValue(floatingIP.Ip)
 	plan.InstanceID = types.StringValue(floatingIP.InstanceId)
 	plan.IPPoolID = types.StringValue(floatingIP.IpPoolId)
 	plan.ProjectID = types.StringValue(floatingIP.ProjectId)

--- a/internal/provider/resource_subnet_pool_member.go
+++ b/internal/provider/resource_subnet_pool_member.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -39,13 +40,13 @@ type subnetPoolMemberResource struct {
 }
 
 type subnetPoolMemberResourceModel struct {
-	ID              types.String   `tfsdk:"id"`
-	SubnetPoolID    types.String   `tfsdk:"subnet_pool_id"`
-	Subnet          types.String   `tfsdk:"subnet"`
-	MinPrefixLength types.Int64    `tfsdk:"min_prefix_length"`
-	MaxPrefixLength types.Int64    `tfsdk:"max_prefix_length"`
-	TimeCreated     types.String   `tfsdk:"time_created"`
-	Timeouts        timeouts.Value `tfsdk:"timeouts"`
+	ID              types.String       `tfsdk:"id"`
+	SubnetPoolID    types.String       `tfsdk:"subnet_pool_id"`
+	Subnet          cidrtypes.IPPrefix `tfsdk:"subnet"`
+	MinPrefixLength types.Int64        `tfsdk:"min_prefix_length"`
+	MaxPrefixLength types.Int64        `tfsdk:"max_prefix_length"`
+	TimeCreated     types.String       `tfsdk:"time_created"`
+	Timeouts        timeouts.Value     `tfsdk:"timeouts"`
 }
 
 // Metadata returns the resource type name.
@@ -107,6 +108,7 @@ func (r *subnetPoolMemberResource) Schema(
 			},
 			"subnet": schema.StringAttribute{
 				Required:    true,
+				CustomType:  cidrtypes.IPPrefixType{},
 				Description: "The subnet CIDR to add to the pool (e.g., '10.0.0.0/16').",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -292,7 +294,7 @@ func (r *subnetPoolMemberResource) Read(
 	)
 
 	state.ID = types.StringValue(foundMember.Id)
-	state.Subnet = types.StringValue(foundMember.Subnet.String())
+	state.Subnet = cidrtypes.NewIPPrefixValue(foundMember.Subnet.String())
 	state.MinPrefixLength = types.Int64Value(int64(*foundMember.MinPrefixLength))
 	state.MaxPrefixLength = types.Int64Value(int64(*foundMember.MaxPrefixLength))
 	state.TimeCreated = types.StringValue(foundMember.TimeCreated.String())


### PR DESCRIPTION
* Add a subnet cidr validator, which optionally accepts an address type.
* Move existing ip config validator to utils and backfill tests.

Note: this isn't an attempt to validate all ip address and cidr fields in the provider. If we find these validators useful, we can expand validation coverage in a separate patch.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
