### PR TITLE
Clean up test environment.

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -90,8 +90,7 @@ jobs:
         env:
           OXIDE_HOST: http://localhost:12220
           OXIDE_TOKEN: ${{ steps.auth-token.outputs.OXIDE_TOKEN }}
-          OXIDE_TEST_IP_POOL_NAME: default
-          OXIDE_SILO_DNS_NAME: "*.sys.oxide-dev.test"
+          TF_ACC_SIM: "1"
       - name: test opentofu
         id: test-tofu
         if: matrix.tf-binary == 'opentofu'
@@ -102,8 +101,7 @@ jobs:
           TF_ACC_PROVIDER_NAMESPACE: oxidecomputer
           OXIDE_HOST: http://localhost:12220
           OXIDE_TOKEN: ${{ steps.auth-token.outputs.OXIDE_TOKEN }}
-          OXIDE_TEST_IP_POOL_NAME: default
-          OXIDE_SILO_DNS_NAME: "*.sys.oxide-dev.test"
+          TF_ACC_SIM: "1"
       - name: print omicron logs
         if: always()
         continue-on-error: true

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,5 +19,5 @@ jobs:
           OXIDE_TOKEN: ${{ secrets.COLO_OXIDE_TOKEN }}
           OXIDE_HOST: ${{ secrets.COLO_OXIDE_HOST }}
           OXIDE_TEST_IP_POOL_NAME: private
-          OXIDE_SILO_DNS_NAME: "*.oxide-preview.com"
+          OXIDE_TEST_SILO_DNS_NAME: "*.oxide-preview.com"
           TEST_ACC_NAME: TestAccCloud

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ to use for it. We default to the \*.sys.oxide-dev.test wildcard used by
 the [simulated omicron
 environment](https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc).
 To override when testing against a different environment, set the
-`$OXIDE_SILO_DNS_NAME` environment variable to the relevant DNS name.
+`$OXIDE_TEST_SILO_DNS_NAME` environment variable to the relevant DNS name.
 
 Run `make testacc`.
 

--- a/internal/provider/data_source_silo_test.go
+++ b/internal/provider/data_source_silo_test.go
@@ -6,7 +6,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -87,10 +86,7 @@ data "oxide_silo" "{{.BlockName}}" {
 func TestAccSiloDataSourceSilo_full(t *testing.T) {
 	blockName := newBlockName("datasource-silo")
 
-	dnsName := os.Getenv("OXIDE_SILO_DNS_NAME")
-	if dnsName == "" {
-		t.Skip("Skipping test. Export OXIDE_SILO_DNS_NAME to run.")
-	}
+	dnsName := testAccSiloDNSName()
 
 	config, err := parsedAccConfig(
 		dataSourceSiloConfig{

--- a/internal/provider/resource_silo_saml_identity_provider_test.go
+++ b/internal/provider/resource_silo_saml_identity_provider_test.go
@@ -11,7 +11,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -110,10 +109,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		siloSamlIdentityProviderBlockName,
 	)
 
-	siloDNSName := os.Getenv("OXIDE_SILO_DNS_NAME")
-	if siloDNSName == "" {
-		t.Skip("Skipping test. Export OXIDE_SILO_DNS_NAME to run.")
-	}
+	siloDNSName := testAccSiloDNSName()
 
 	config, err := parsedAccConfig(
 		resourceSiloIdentifyProviderConfig{

--- a/internal/provider/resource_silo_test.go
+++ b/internal/provider/resource_silo_test.go
@@ -7,7 +7,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -140,10 +139,7 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 	blockName := newBlockName("silo")
 	resourceName := fmt.Sprintf("oxide_silo.%s", blockName)
 
-	dnsName := os.Getenv("OXIDE_SILO_DNS_NAME")
-	if dnsName == "" {
-		t.Skip("Skipping test. Export OXIDE_SILO_DNS_NAME to run.")
-	}
+	dnsName := testAccSiloDNSName()
 
 	config, err := parsedAccConfig(
 		resourceSiloConfig{

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -7,7 +7,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -174,10 +173,7 @@ resource "oxide_subnet_pool_silo_link" "test" {
 `
 
 func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
-	siloDNSName := os.Getenv("OXIDE_SILO_DNS_NAME")
-	if siloDNSName == "" {
-		t.Skip("Skipping test. Export OXIDE_SILO_DNS_NAME to run.")
-	}
+	siloDNSName := testAccSiloDNSName()
 
 	link1ResourceName := "oxide_subnet_pool_silo_link.link1"
 	link2ResourceName := "oxide_subnet_pool_silo_link.link2"

--- a/internal/provider/testutils.go
+++ b/internal/provider/testutils.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -92,6 +93,13 @@ func testAccVerifyResourceIDChanged(
 		}
 		return nil
 	}
+}
+
+func testAccSiloDNSName() string {
+	if v := os.Getenv("OXIDE_TEST_SILO_DNS_NAME"); v != "" {
+		return v
+	}
+	return "*.sys.oxide-dev.test"
 }
 
 var subnetCounter uint32


### PR DESCRIPTION
Some tests only run if specific environment variables, prefixed by OXIDE_TEST_, are set. As a result, it's easy to unintentionally skip tests, and potentially miss regressions that those tests would have caught. This patch adds defaults where possible for these environment variables, and configures all acceptance tests to run by default, unless running them could be unsafe in a non-simulated environment.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
