### PR TITLE
fix: use updated api operations

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -186,10 +186,6 @@ Optional:
 - `ip_version` (String) IP version to use when multiple default pools exist. Conflicts with `pool_id`.
 - `pool_id` (String) ID of the IP pool to allocate from. Conflicts with `ip_version`.
 
-Read-Only:
-
-- `ip` (String) The external ephemeral IP attached to the instance.
-
 
 <a id="nestedatt--external_ips--floating"></a>
 ### Nested Schema for `external_ips.floating`
@@ -197,11 +193,6 @@ Read-Only:
 Required:
 
 - `id` (String) The external floating IP ID.
-
-Read-Only:
-
-- `ip` (String) The external floating IP attached to the instance.
-- `name` (String) The name of the external floating IP attached to the instance.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b h1:KDUeTr6i0kGdMhs1JB/H1nM0mmd3ZZ9ww2GNpop51hc=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260206215021-1401cd9ed09b/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895 h1:o46kHstj4v5zH3eRgrhNSdVyOM/0GdwvjxdEIBGJXuk=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/internal/provider/data_source_ip_pool.go
+++ b/internal/provider/data_source_ip_pool.go
@@ -122,10 +122,10 @@ func (d *ipPoolDataSource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	params := oxide.ProjectIpPoolViewParams{
+	params := oxide.IpPoolViewParams{
 		Pool: oxide.NameOrId(state.Name.ValueString()),
 	}
-	ipPool, err := d.client.ProjectIpPoolView(ctx, params)
+	ipPool, err := d.client.IpPoolView(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read IP pool:",

--- a/internal/provider/data_source_subnet_pool.go
+++ b/internal/provider/data_source_subnet_pool.go
@@ -147,10 +147,10 @@ func (d *subnetPoolDataSource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolViewParams{
+	params := oxide.SystemSubnetPoolViewParams{
 		Pool: oxide.NameOrId(state.Name.ValueString()),
 	}
-	pool, err := d.client.SubnetPoolView(ctx, params)
+	pool, err := d.client.SystemSubnetPoolView(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read subnet pool:",
@@ -174,9 +174,12 @@ func (d *subnetPoolDataSource) Read(
 	state.TimeModified = types.StringValue(pool.TimeModified.String())
 
 	// Read members
-	members, err := d.client.SubnetPoolMemberListAllPages(ctx, oxide.SubnetPoolMemberListParams{
-		Pool: oxide.NameOrId(pool.Id),
-	})
+	members, err := d.client.SystemSubnetPoolMemberListAllPages(
+		ctx,
+		oxide.SystemSubnetPoolMemberListParams{
+			Pool: oxide.NameOrId(pool.Id),
+		},
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read subnet pool members:",

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -163,13 +163,13 @@ func (r *ipPoolResource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolCreateParams{
+	params := oxide.SystemIpPoolCreateParams{
 		Body: &oxide.IpPoolCreate{
 			Description: plan.Description.ValueString(),
 			Name:        oxide.Name(plan.Name.ValueString()),
 		},
 	}
-	ipPool, err := r.client.IpPoolCreate(ctx, params)
+	ipPool, err := r.client.SystemIpPoolCreate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating IP Pool",
@@ -222,7 +222,7 @@ func (r *ipPoolResource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	ipPool, err := r.client.IpPoolView(ctx, oxide.IpPoolViewParams{
+	ipPool, err := r.client.SystemIpPoolView(ctx, oxide.SystemIpPoolViewParams{
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 	})
 	if err != nil {
@@ -245,11 +245,11 @@ func (r *ipPoolResource) Read(
 	state.TimeModified = types.StringValue(ipPool.TimeCreated.String())
 
 	// Append information about IP Pool ranges
-	listParams := oxide.IpPoolRangeListParams{
+	listParams := oxide.SystemIpPoolRangeListParams{
 		Pool:  oxide.NameOrId(ipPool.Id),
 		Limit: oxide.NewPointer(1000000000),
 	}
-	ipPoolRanges, err := r.client.IpPoolRangeList(ctx, listParams)
+	ipPoolRanges, err := r.client.SystemIpPoolRangeList(ctx, listParams)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read IP Pool ranges:",
@@ -347,7 +347,7 @@ func (r *ipPoolResource) Update(
 		return
 	}
 
-	params := oxide.IpPoolUpdateParams{
+	params := oxide.SystemIpPoolUpdateParams{
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 		Body: &oxide.IpPoolUpdate{
 			Description: plan.Description.ValueString(),
@@ -355,7 +355,7 @@ func (r *ipPoolResource) Update(
 		},
 	}
 
-	ipPool, err := r.client.IpPoolUpdate(ctx, params)
+	ipPool, err := r.client.SystemIpPoolUpdate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating IP Pool",
@@ -405,9 +405,9 @@ func (r *ipPoolResource) Delete(
 	defer cancel()
 
 	// Remove all IP pool ranges first
-	ranges, err := r.client.IpPoolRangeList(
+	ranges, err := r.client.SystemIpPoolRangeList(
 		ctx,
-		oxide.IpPoolRangeListParams{
+		oxide.SystemIpPoolRangeListParams{
 			Pool:  oxide.NameOrId(state.ID.ValueString()),
 			Limit: oxide.NewPointer(1000000000),
 		},
@@ -429,11 +429,11 @@ func (r *ipPoolResource) Delete(
 
 	for _, item := range ranges.Items {
 		// item.Range is now a struct with a Value field containing the variant
-		params := oxide.IpPoolRangeRemoveParams{
+		params := oxide.SystemIpPoolRangeRemoveParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 			Body: &item.Range,
 		}
-		if err := r.client.IpPoolRangeRemove(ctx, params); err != nil {
+		if err := r.client.SystemIpPoolRangeRemove(ctx, params); err != nil {
 			if !is404(err) {
 				resp.Diagnostics.AddError(
 					"Error deleting IP Pool range:",
@@ -449,9 +449,9 @@ func (r *ipPoolResource) Delete(
 		), map[string]any{"success": true})
 	}
 
-	if err := r.client.IpPoolDelete(
+	if err := r.client.SystemIpPoolDelete(
 		ctx,
-		oxide.IpPoolDeleteParams{
+		oxide.SystemIpPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
 		if !is404(err) {
@@ -490,12 +490,12 @@ func addRanges(
 			return diags
 		}
 
-		params := oxide.IpPoolRangeAddParams{
+		params := oxide.SystemIpPoolRangeAddParams{
 			Pool: oxide.NameOrId(poolID),
 			Body: &body,
 		}
 
-		ipR, err := client.IpPoolRangeAdd(ctx, params)
+		ipR, err := client.SystemIpPoolRangeAdd(ctx, params)
 		if err != nil {
 			diags.AddError(
 				"Error creating range within IP Pool",
@@ -539,12 +539,12 @@ func removeRanges(
 			return diags
 		}
 
-		params := oxide.IpPoolRangeRemoveParams{
+		params := oxide.SystemIpPoolRangeRemoveParams{
 			Pool: oxide.NameOrId(poolID),
 			Body: &body,
 		}
 
-		err = client.IpPoolRangeRemove(ctx, params)
+		err = client.SystemIpPoolRangeRemove(ctx, params)
 		if err != nil {
 			diags.AddError(
 				"Error removing range within IP Pool",

--- a/internal/provider/resource_ip_pool_silo_link.go
+++ b/internal/provider/resource_ip_pool_silo_link.go
@@ -144,14 +144,14 @@ func (r *ipPoolSiloLinkResource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolSiloLinkParams{
+	params := oxide.SystemIpPoolSiloLinkParams{
 		Pool: oxide.NameOrId(plan.IPPoolID.ValueString()),
 		Body: &oxide.IpPoolLinkSilo{
 			IsDefault: plan.IsDefault.ValueBoolPointer(),
 			Silo:      oxide.NameOrId(plan.SiloID.ValueString()),
 		},
 	}
-	link, err := r.client.IpPoolSiloLink(ctx, params)
+	link, err := r.client.SystemIpPoolSiloLink(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating IP pool silo link",
@@ -197,13 +197,13 @@ func (r *ipPoolSiloLinkResource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolSiloListParams{
+	params := oxide.SystemIpPoolSiloListParams{
 		Pool:   oxide.NameOrId(state.IPPoolID.ValueString()),
 		Limit:  oxide.NewPointer(1000000000),
 		SortBy: oxide.IdSortModeIdAscending,
 	}
 
-	links, err := r.client.IpPoolSiloList(ctx, params)
+	links, err := r.client.SystemIpPoolSiloList(ctx, params)
 	if err != nil {
 		if is404(err) {
 			// Remove resource from state during a refresh
@@ -277,14 +277,14 @@ func (r *ipPoolSiloLinkResource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolSiloUpdateParams{
+	params := oxide.SystemIpPoolSiloUpdateParams{
 		Pool: oxide.NameOrId(state.IPPoolID.ValueString()),
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 		Body: &oxide.IpPoolSiloUpdate{
 			IsDefault: plan.IsDefault.ValueBoolPointer(),
 		},
 	}
-	link, err := r.client.IpPoolSiloUpdate(ctx, params)
+	link, err := r.client.SystemIpPoolSiloUpdate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating link",
@@ -330,11 +330,11 @@ func (r *ipPoolSiloLinkResource) Delete(
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolSiloUnlinkParams{
+	params := oxide.SystemIpPoolSiloUnlinkParams{
 		Pool: oxide.NameOrId(state.IPPoolID.ValueString()),
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
-	if err := r.client.IpPoolSiloUnlink(ctx, params); err != nil {
+	if err := r.client.SystemIpPoolSiloUnlink(ctx, params); err != nil {
 		if !is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting link:",

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -194,13 +194,13 @@ func testAccIPPoolSiloLinkDestroy(s *terraform.State) error {
 
 		ipPoolID := rs.Primary.Attributes["ip_pool_id"]
 		siloID := rs.Primary.Attributes["silo_id"]
-		params := oxide.IpPoolSiloListParams{
+		params := oxide.SystemIpPoolSiloListParams{
 			Pool:   oxide.NameOrId(oxide.NameOrId(ipPoolID)),
 			Limit:  oxide.NewPointer(1000000000),
 			SortBy: oxide.IdSortModeIdAscending,
 		}
 
-		links, err := client.IpPoolSiloList(ctx, params)
+		links, err := client.SystemIpPoolSiloList(ctx, params)
 		if err != nil && is404(err) {
 			continue
 		}

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -187,17 +187,17 @@ func testAccIPPoolDestroy(s *terraform.State) error {
 
 		ctx := context.Background()
 
-		res, err := client.IpPoolView(
+		res, err := client.SystemIpPoolView(
 			ctx,
-			oxide.IpPoolViewParams{Pool: "terraform-acc-myippool"},
+			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool"},
 		)
 		if err == nil || !is404(err) {
 			return fmt.Errorf("ip_pool (%v) still exists", &res.Name)
 		}
 
-		res2, err := client.IpPoolView(
+		res2, err := client.SystemIpPoolView(
 			ctx,
-			oxide.IpPoolViewParams{Pool: "terraform-acc-myippool2"},
+			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool2"},
 		)
 		if err != nil && is404(err) {
 			continue

--- a/internal/provider/resource_subnet_pool.go
+++ b/internal/provider/resource_subnet_pool.go
@@ -152,14 +152,14 @@ func (r *subnetPoolResource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolCreateParams{
+	params := oxide.SystemSubnetPoolCreateParams{
 		Body: &oxide.SubnetPoolCreate{
 			Description: plan.Description.ValueString(),
 			Name:        oxide.Name(plan.Name.ValueString()),
 			IpVersion:   oxide.IpVersion(plan.IpVersion.ValueString()),
 		},
 	}
-	pool, err := r.client.SubnetPoolCreate(ctx, params)
+	pool, err := r.client.SystemSubnetPoolCreate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating subnet pool",
@@ -207,7 +207,7 @@ func (r *subnetPoolResource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	pool, err := r.client.SubnetPoolView(ctx, oxide.SubnetPoolViewParams{
+	pool, err := r.client.SystemSubnetPoolView(ctx, oxide.SystemSubnetPoolViewParams{
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 	})
 	if err != nil {
@@ -272,7 +272,7 @@ func (r *subnetPoolResource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolUpdateParams{
+	params := oxide.SystemSubnetPoolUpdateParams{
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 		Body: &oxide.SubnetPoolUpdate{
 			Description: plan.Description.ValueString(),
@@ -280,7 +280,7 @@ func (r *subnetPoolResource) Update(
 		},
 	}
 
-	pool, err := r.client.SubnetPoolUpdate(ctx, params)
+	pool, err := r.client.SystemSubnetPoolUpdate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating subnet pool",
@@ -328,9 +328,9 @@ func (r *subnetPoolResource) Delete(
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
-	if err := r.client.SubnetPoolDelete(
+	if err := r.client.SystemSubnetPoolDelete(
 		ctx,
-		oxide.SubnetPoolDeleteParams{
+		oxide.SystemSubnetPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
 		if !is404(err) {

--- a/internal/provider/resource_subnet_pool_member.go
+++ b/internal/provider/resource_subnet_pool_member.go
@@ -195,12 +195,12 @@ func (r *subnetPoolMemberResource) Create(
 		body.MaxPrefixLength = &maxPrefixLen
 	}
 
-	params := oxide.SubnetPoolMemberAddParams{
+	params := oxide.SystemSubnetPoolMemberAddParams{
 		Pool: oxide.NameOrId(plan.SubnetPoolID.ValueString()),
 		Body: body,
 	}
 
-	member, err := r.client.SubnetPoolMemberAdd(ctx, params)
+	member, err := r.client.SystemSubnetPoolMemberAdd(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating subnet pool member",
@@ -251,9 +251,9 @@ func (r *subnetPoolMemberResource) Read(
 
 	// The API doesn't have a direct "view" endpoint for a single member by ID.
 	// We need to list all members and find the one matching our ID.
-	members, err := r.client.SubnetPoolMemberListAllPages(
+	members, err := r.client.SystemSubnetPoolMemberListAllPages(
 		ctx,
-		oxide.SubnetPoolMemberListParams{
+		oxide.SystemSubnetPoolMemberListParams{
 			Pool: oxide.NameOrId(state.SubnetPoolID.ValueString()),
 		},
 	)
@@ -350,14 +350,14 @@ func (r *subnetPoolMemberResource) Delete(
 		return
 	}
 
-	params := oxide.SubnetPoolMemberRemoveParams{
+	params := oxide.SystemSubnetPoolMemberRemoveParams{
 		Pool: oxide.NameOrId(state.SubnetPoolID.ValueString()),
 		Body: &oxide.SubnetPoolMemberRemove{
 			Subnet: subnet,
 		},
 	}
 
-	if err := r.client.SubnetPoolMemberRemove(ctx, params); err != nil {
+	if err := r.client.SystemSubnetPoolMemberRemove(ctx, params); err != nil {
 		// The API returns 400 with "does not exist" if the member is already gone,
 		// rather than 404. Handle both cases for idempotent deletes.
 		//

--- a/internal/provider/resource_subnet_pool_member_test.go
+++ b/internal/provider/resource_subnet_pool_member_test.go
@@ -234,14 +234,14 @@ func testAccSubnetPoolMemberDisappears(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("error parsing subnet: %w", err)
 		}
 
-		params := oxide.SubnetPoolMemberRemoveParams{
+		params := oxide.SystemSubnetPoolMemberRemoveParams{
 			Pool: oxide.NameOrId(rs.Primary.Attributes["subnet_pool_id"]),
 			Body: &oxide.SubnetPoolMemberRemove{
 				Subnet: subnet,
 			},
 		}
 
-		return client.SubnetPoolMemberRemove(context.Background(), params)
+		return client.SystemSubnetPoolMemberRemove(context.Background(), params)
 	}
 }
 
@@ -276,9 +276,9 @@ func testAccSubnetPoolMemberDestroy(s *terraform.State) error {
 		poolID := rs.Primary.Attributes["subnet_pool_id"]
 
 		// List members and check if ours still exists
-		members, err := client.SubnetPoolMemberListAllPages(
+		members, err := client.SystemSubnetPoolMemberListAllPages(
 			ctx,
-			oxide.SubnetPoolMemberListParams{Pool: oxide.NameOrId(poolID)},
+			oxide.SystemSubnetPoolMemberListParams{Pool: oxide.NameOrId(poolID)},
 		)
 		if err != nil && is404(err) {
 			// Pool doesn't exist, so member is definitely gone

--- a/internal/provider/resource_subnet_pool_silo_link.go
+++ b/internal/provider/resource_subnet_pool_silo_link.go
@@ -152,14 +152,14 @@ func (r *subnetPoolSiloLinkResource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolSiloLinkParams{
+	params := oxide.SystemSubnetPoolSiloLinkParams{
 		Pool: oxide.NameOrId(plan.SubnetPoolID.ValueString()),
 		Body: &oxide.SubnetPoolLinkSilo{
 			IsDefault: plan.IsDefault.ValueBoolPointer(),
 			Silo:      oxide.NameOrId(plan.SiloID.ValueString()),
 		},
 	}
-	link, err := r.client.SubnetPoolSiloLink(ctx, params)
+	link, err := r.client.SystemSubnetPoolSiloLink(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating subnet pool silo link",
@@ -272,14 +272,14 @@ func (r *subnetPoolSiloLinkResource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolSiloUpdateParams{
+	params := oxide.SystemSubnetPoolSiloUpdateParams{
 		Pool: oxide.NameOrId(state.SubnetPoolID.ValueString()),
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 		Body: &oxide.SubnetPoolSiloUpdate{
 			IsDefault: plan.IsDefault.ValueBoolPointer(),
 		},
 	}
-	link, err := r.client.SubnetPoolSiloUpdate(ctx, params)
+	link, err := r.client.SystemSubnetPoolSiloUpdate(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating subnet pool silo link",
@@ -325,11 +325,11 @@ func (r *subnetPoolSiloLinkResource) Delete(
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
-	params := oxide.SubnetPoolSiloUnlinkParams{
+	params := oxide.SystemSubnetPoolSiloUnlinkParams{
 		Pool: oxide.NameOrId(state.SubnetPoolID.ValueString()),
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
-	if err := r.client.SubnetPoolSiloUnlink(ctx, params); err != nil {
+	if err := r.client.SystemSubnetPoolSiloUnlink(ctx, params); err != nil {
 		if !is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool silo link:",

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -145,12 +145,12 @@ func testAccSubnetPoolSiloLinkDisappears(resourceName string) resource.TestCheck
 			return err
 		}
 
-		params := oxide.SubnetPoolSiloUnlinkParams{
+		params := oxide.SystemSubnetPoolSiloUnlinkParams{
 			Pool: oxide.NameOrId(rs.Primary.Attributes["subnet_pool_id"]),
 			Silo: oxide.NameOrId(rs.Primary.Attributes["silo_id"]),
 		}
 
-		return client.SubnetPoolSiloUnlink(context.Background(), params)
+		return client.SystemSubnetPoolSiloUnlink(context.Background(), params)
 	}
 }
 
@@ -319,9 +319,9 @@ func testAccLinksDestroyed(poolResourceName string) resource.TestCheckFunc {
 			return err
 		}
 
-		links, err := client.SubnetPoolSiloListAllPages(
+		links, err := client.SystemSubnetPoolSiloListAllPages(
 			context.Background(),
-			oxide.SubnetPoolSiloListParams{Pool: oxide.NameOrId(rs.Primary.ID)},
+			oxide.SystemSubnetPoolSiloListParams{Pool: oxide.NameOrId(rs.Primary.ID)},
 		)
 		if err != nil {
 			return err

--- a/internal/provider/resource_subnet_pool_test.go
+++ b/internal/provider/resource_subnet_pool_test.go
@@ -127,9 +127,9 @@ func testAccSubnetPoolDisappears(resourceName string) resource.TestCheckFunc {
 			return err
 		}
 
-		return client.SubnetPoolDelete(
+		return client.SystemSubnetPoolDelete(
 			context.Background(),
-			oxide.SubnetPoolDeleteParams{Pool: oxide.NameOrId(rs.Primary.ID)},
+			oxide.SystemSubnetPoolDeleteParams{Pool: oxide.NameOrId(rs.Primary.ID)},
 		)
 	}
 }


### PR DESCRIPTION
Pulled in the `oxide.go` changes from
https://github.com/oxidecomputer/oxide.go/pull/375 and updated the method calls in Terraform accordingly.

Relates to SSE-141.
