### PR TITLE
chore: fix docstring nit.

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -49,7 +49,7 @@ func defaultTimeout() time.Duration {
 	return 10 * time.Minute
 }
 
-// sliceDiff returns a string slice of the elements in `a` that aren't in `b`.
+// sliceDiff returns a slice of the elements in `a` that aren't in `b`.
 // This function is a bit expensive, but given the fact that
 // the expected number of elements is relatively slow
 // it's not a big deal.


### PR DESCRIPTION
Correct a docstring to indicate that `sliceDiff` returns a slice of object, not a string slice.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
