### PR TITLE
chore: skip fail-fast on terraform/tofu test matrix.

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -11,6 +11,7 @@ jobs:
   acceptance:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         tf-binary:
           - terraform


### PR DESCRIPTION
Sometimes terraform and opentofu tests fail for different reasons (usually test flakes). It's useful to see whether only one branch is failing (probably a flake) or both (more likely a true regression). This patch sets `fail-fast: false` so that we allow both branches to run to completion even if one fails.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
