### PR TITLE
Run silo tests in series.

### DIFF
--- a/internal/provider/data_source_silo_test.go
+++ b/internal/provider/data_source_silo_test.go
@@ -99,7 +99,10 @@ func TestAccSiloDataSourceSilo_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/provider/resource_silo_saml_identity_provider_test.go
+++ b/internal/provider/resource_silo_saml_identity_provider_test.go
@@ -125,7 +125,10 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/provider/resource_silo_test.go
+++ b/internal/provider/resource_silo_test.go
@@ -165,7 +165,10 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -114,7 +114,10 @@ func TestAccResourceSubnetPoolSiloLink_disappears(t *testing.T) {
 	poolResourceName := "oxide_subnet_pool.test"
 	linkResourceName := "oxide_subnet_pool_silo_link.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -178,7 +181,10 @@ func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
 	link1ResourceName := "oxide_subnet_pool_silo_link.link1"
 	link2ResourceName := "oxide_subnet_pool_silo_link.link2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{


### PR DESCRIPTION
As we found in https://github.com/oxidecomputer/omicron/issues/9851, silo creation and deletion can easily contend the database in nexus. The upstream fix is probably a low priority, so in the meantime, we run all silo-related tests in series.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
