### PR TITLE
instance: fix network interface plan modifier

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -2873,6 +2873,7 @@ func (v instanceNetworkInterfacesPlanModifier) PlanModifySet(
 		if nic.Hash() != stateNIC.Hash() {
 			plan[i].ID = types.StringUnknown()
 			plan[i].IPAddr = types.StringUnknown()
+			plan[i].MAC = types.StringUnknown()
 			plan[i].Primary = types.BoolUnknown()
 			plan[i].TimeCreated = types.StringUnknown()
 			plan[i].TimeModified = types.StringUnknown()


### PR DESCRIPTION
The instance `mac_address` is also a computed attribute, so it needs to be set to `unknown` if the network interface is recreated.

I tried to create a reflect-based approach to handle this automatically, but the code was a bit too much for what it is doing. I don't expect we would change the schema too often, so I found a more explicit approach better. We should reconsider this decision If we find ourselves running into problems keeping this function updated though.