### PR TITLE
misc: use `go.work` for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ tf/
 acctest/oxide-token
 alpine.qcow2
 alpine.raw
+
+# Go.
+go.work
+go.work.sum

--- a/Makefile
+++ b/Makefile
@@ -152,14 +152,16 @@ testacc-local: export OXIDE_TOKEN=$(shell cat ./acctest/oxide-token)
 testacc-local: testacc
 
 .PHONY: local-api
-## Use local API language client
+## Use local Go SDK.
 local-api:
-	@ go mod edit -replace=github.com/oxidecomputer/oxide.go=../oxide.go
+	@ echo "Initializing go.work"
+	@ go work init 2> /dev/null || true
+	@ go work use . ../oxide.go
 
 .PHONY: unset-local-api
-## Removes local API language client
+## Stop using local Go SDK.
 unset-local-api:
-	@ go mod edit -dropreplace=github.com/oxidecomputer/oxide.go
+	rm -f go.work go.work.sum
 
 .PHONY: changelog
 ## Creates a changelog prior to a release


### PR DESCRIPTION
Switched to using `go.work` to override Go SDK with a local copy. This is better than using a `replace` directive in `go.mod` since it's local only, doesn't modify modules in `go.mod`, and doesn't risk being committed to source control.
