### PR TITLE
misc: update `oxide.go`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20260216192632-3a774965bc83
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895 h1:o46kHstj4v5zH3eRgrhNSdVyOM/0GdwvjxdEIBGJXuk=
-github.com/oxidecomputer/oxide.go v0.7.1-0.20260210052317-44dc2f2e0895/go.mod h1:ZlG5ri4a6ClA/yhDCbQN6m/F3d/m41XHx5s9WbfFLWc=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260216192632-3a774965bc83 h1:oO9JyCkZHu4jX6Aqm8bn1VYz0MUEWYdqZQbAeG8C0Es=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20260216192632-3a774965bc83/go.mod h1:pL9BcSmHMyhR8Utxr2AcV6wG59OIrcSV3dNduIzGGdo=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/data_source_disk.go
+++ b/internal/provider/data_source_disk.go
@@ -211,10 +211,21 @@ func (d *diskDataSource) Read(
 
 	// Set disk state
 	state.State = &diskDataSourceModelState{
-		State: types.StringValue(string(disk.State.State)),
+		State: types.StringValue(string(disk.State.State())),
 	}
-	if disk.State.Instance != "" {
-		state.State.Instance = types.StringValue(disk.State.Instance)
+	switch v := disk.State.Value.(type) {
+	case *oxide.DiskStateAttaching:
+		if v.Instance != "" {
+			state.State.Instance = types.StringValue(v.Instance)
+		}
+	case *oxide.DiskStateAttached:
+		if v.Instance != "" {
+			state.State.Instance = types.StringValue(v.Instance)
+		}
+	case *oxide.DiskStateDetaching:
+		if v.Instance != "" {
+			state.State.Instance = types.StringValue(v.Instance)
+		}
 	}
 
 	// Save retrieved state into Terraform state.

--- a/internal/provider/data_source_image.go
+++ b/internal/provider/data_source_image.go
@@ -197,8 +197,10 @@ func (d *imageDataSource) Read(
 	state.Version = types.StringValue(image.Version)
 
 	digestState := imageDataSourceDigestModel{
-		Type:  types.StringValue(string(image.Digest.Type)),
-		Value: types.StringValue(image.Digest.Value),
+		Type: types.StringValue(string(image.Digest.Type())),
+	}
+	if v, ok := image.Digest.Value.(*oxide.DigestSha256); ok {
+		digestState.Value = types.StringValue(v.Value)
 	}
 	state.Digest = &digestState
 

--- a/internal/provider/data_source_images.go
+++ b/internal/provider/data_source_images.go
@@ -220,8 +220,10 @@ func (d *imagesDataSource) Read(
 		}
 
 		digestState := imageDigestModel{
-			Type:  types.StringValue(string(image.Digest.Type)),
-			Value: types.StringValue(image.Digest.Value),
+			Type: types.StringValue(string(image.Digest.Type())),
+		}
+		if v, ok := image.Digest.Value.(*oxide.DigestSha256); ok {
+			digestState.Value = types.StringValue(v.Value)
 		}
 
 		imageState.Digest = digestState

--- a/internal/provider/data_source_instance_external_ips.go
+++ b/internal/provider/data_source_instance_external_ips.go
@@ -146,8 +146,15 @@ func (d *instanceExternalIPsDataSource) Read(
 	// Map response body to model
 	for _, ip := range ips.Items {
 		externalIPState := externalIPDatasourceModel{
-			IP:   types.StringValue(ip.Ip),
-			Kind: types.StringValue(string(ip.Kind)),
+			Kind: types.StringValue(string(ip.Kind())),
+		}
+		switch v := ip.Value.(type) {
+		case *oxide.ExternalIpSnat:
+			externalIPState.IP = types.StringValue(v.Ip)
+		case *oxide.ExternalIpEphemeral:
+			externalIPState.IP = types.StringValue(v.Ip)
+		case *oxide.ExternalIpFloating:
+			externalIPState.IP = types.StringValue(v.Ip)
 		}
 		state.ExternalIPs = append(state.ExternalIPs, externalIPState)
 	}

--- a/internal/provider/resource_external_subnet.go
+++ b/internal/provider/resource_external_subnet.go
@@ -250,32 +250,39 @@ func (r *externalSubnetResource) Create(
 			return
 		}
 		params.Body.Allocator = oxide.ExternalSubnetAllocator{
-			Type:   oxide.ExternalSubnetAllocatorTypeExplicit,
-			Subnet: ipNet,
+			Value: &oxide.ExternalSubnetAllocatorExplicit{
+				Subnet: ipNet,
+			},
 		}
 	} else {
 		// Automatic allocation. The `prefix_len` attribute will always be defined if we reach this
 		// code due to validation in ConfigValidators.
 		prefixLen := int(plan.PrefixLen.ValueInt64())
-		params.Body.Allocator = oxide.ExternalSubnetAllocator{
-			Type:      oxide.ExternalSubnetAllocatorTypeAuto,
-			PrefixLen: &prefixLen,
-		}
 
+		var poolSelector oxide.PoolSelector
 		// Set pool selector
 		if pool := plan.SubnetPoolID.ValueString(); pool != "" {
 			// Auto subnet allocation from explicit pool.
-			params.Body.Allocator.PoolSelector = oxide.PoolSelector{
-				Type: oxide.PoolSelectorTypeExplicit,
-				Pool: oxide.NameOrId(pool),
+			poolSelector = oxide.PoolSelector{
+				Value: &oxide.PoolSelectorExplicit{
+					Pool: oxide.NameOrId(pool),
+				},
 			}
 		} else {
 			// Auto subnet allocation from default pool. If there are multiple default pools IP
 			// version is required.
-			params.Body.Allocator.PoolSelector = oxide.PoolSelector{
-				Type:      oxide.PoolSelectorTypeAuto,
-				IpVersion: oxide.IpVersion(plan.IPVersion.ValueString()),
+			poolSelector = oxide.PoolSelector{
+				Value: &oxide.PoolSelectorAuto{
+					IpVersion: oxide.IpVersion(plan.IPVersion.ValueString()),
+				},
 			}
+		}
+
+		params.Body.Allocator = oxide.ExternalSubnetAllocator{
+			Value: &oxide.ExternalSubnetAllocatorAuto{
+				PrefixLen:    &prefixLen,
+				PoolSelector: poolSelector,
+			},
 		}
 	}
 

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -220,26 +220,31 @@ func (f *floatingIPResource) Create(
 	if ip := plan.IP.ValueString(); ip != "" {
 		// Explicit IP with the pool inferred from IP address.
 		params.Body.AddressAllocator = oxide.AddressAllocator{
-			Type: oxide.AddressAllocatorTypeExplicit,
-			Ip:   ip,
+			Value: &oxide.AddressAllocatorExplicit{
+				Ip: ip,
+			},
 		}
 	} else if pool := plan.IPPoolID.ValueString(); pool != "" {
 		// Auto IP from explicit pool.
 		params.Body.AddressAllocator = oxide.AddressAllocator{
-			Type: oxide.AddressAllocatorTypeAuto,
-			PoolSelector: oxide.PoolSelector{
-				Type: oxide.PoolSelectorTypeExplicit,
-				Pool: oxide.NameOrId(pool),
+			Value: &oxide.AddressAllocatorAuto{
+				PoolSelector: oxide.PoolSelector{
+					Value: &oxide.PoolSelectorExplicit{
+						Pool: oxide.NameOrId(pool),
+					},
+				},
 			},
 		}
 	} else {
 		// Auto IP from default pool. If there are multiple default pools IP
 		// version is required.
 		params.Body.AddressAllocator = oxide.AddressAllocator{
-			Type: oxide.AddressAllocatorTypeAuto,
-			PoolSelector: oxide.PoolSelector{
-				Type:      oxide.PoolSelectorTypeAuto,
-				IpVersion: oxide.IpVersion(plan.IPVersion.ValueString()),
+			Value: &oxide.AddressAllocatorAuto{
+				PoolSelector: oxide.PoolSelector{
+					Value: &oxide.PoolSelectorAuto{
+						IpVersion: oxide.IpVersion(plan.IPVersion.ValueString()),
+					},
+				},
 			},
 		}
 	}

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -218,10 +218,11 @@ func (r *imageResource) Create(
 		},
 	}
 
-	is := oxide.ImageSource{}
-	is.Id = plan.SourceSnapshotID.ValueString()
-	is.Type = oxide.ImageSourceTypeSnapshot
-	params.Body.Source = is
+	params.Body.Source = oxide.ImageSource{
+		Value: &oxide.ImageSourceSnapshot{
+			Id: plan.SourceSnapshotID.ValueString(),
+		},
+	}
 
 	image, err := r.client.ImageCreate(ctx, params)
 	if err != nil {
@@ -251,8 +252,10 @@ func (r *imageResource) Create(
 
 	// Parse imageResourceDigestModel into types.Object
 	dm := imageResourceDigestModel{
-		Type:  types.StringValue(string(image.Digest.Type)),
-		Value: types.StringValue(image.Digest.Value),
+		Type: types.StringValue(string(image.Digest.Type())),
+	}
+	if v, ok := image.Digest.Value.(*oxide.DigestSha256); ok {
+		dm.Value = types.StringValue(v.Value)
 	}
 	attributeTypes := map[string]attr.Type{
 		"type":  types.StringType,
@@ -338,8 +341,10 @@ func (r *imageResource) Read(
 
 	// Parse imageResourceDigestModel into types.Object
 	dm := imageResourceDigestModel{
-		Type:  types.StringValue(string(image.Digest.Type)),
-		Value: types.StringValue(image.Digest.Value),
+		Type: types.StringValue(string(image.Digest.Type())),
+	}
+	if v, ok := image.Digest.Value.(*oxide.DigestSha256); ok {
+		dm.Value = types.StringValue(v.Value)
 	}
 	attributeTypes := map[string]attr.Type{
 		"type":  types.StringType,

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -2449,79 +2449,90 @@ func testAccInstanceDestroy(s *terraform.State) error {
 }
 
 func TestFilterBootDiskFromDisks(t *testing.T) {
-	boot_disk := oxide.InstanceDiskAttachment{
-		Name: "testboot01",
-		Type: oxide.InstanceDiskAttachmentTypeAttach,
+	bootDisk := oxide.InstanceDiskAttachment{
+		Value: &oxide.InstanceDiskAttachmentAttach{
+			Name: "testboot01",
+		},
 	}
 
 	tests := []struct {
-		boot_disk oxide.InstanceDiskAttachment
-		disks     []oxide.InstanceDiskAttachment
-		want      []oxide.InstanceDiskAttachment
+		bootDisk oxide.InstanceDiskAttachment
+		disks    []oxide.InstanceDiskAttachment
+		want     []oxide.InstanceDiskAttachment
 	}{
 		{
-			boot_disk: boot_disk,
+			bootDisk: bootDisk,
 			disks: []oxide.InstanceDiskAttachment{
-				boot_disk,
+				bootDisk,
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 			},
 			want: []oxide.InstanceDiskAttachment{
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 			},
 		},
 		{
-			boot_disk: oxide.InstanceDiskAttachment{},
+			bootDisk: oxide.InstanceDiskAttachment{},
 			disks: []oxide.InstanceDiskAttachment{
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testboot01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testboot01",
+					},
 				},
 			},
 			want: []oxide.InstanceDiskAttachment{
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testdisk01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testdisk01",
+					},
 				},
 				{
-					Name: "testboot01",
-					Type: oxide.InstanceDiskAttachmentTypeAttach,
+					Value: &oxide.InstanceDiskAttachmentAttach{
+						Name: "testboot01",
+					},
 				},
 			},
 		},
 		{
-			boot_disk: oxide.InstanceDiskAttachment{},
-			disks:     []oxide.InstanceDiskAttachment{},
-			want:      []oxide.InstanceDiskAttachment{},
+			bootDisk: oxide.InstanceDiskAttachment{},
+			disks:    []oxide.InstanceDiskAttachment{},
+			want:     []oxide.InstanceDiskAttachment{},
 		},
 	}
 	for _, tt := range tests {
-		disks := filterBootDiskFromDisks(tt.disks, &tt.boot_disk)
+		disks := filterBootDiskFromDisks(tt.disks, tt.bootDisk)
 		if !reflect.DeepEqual(disks, tt.want) {
 			t.Errorf("want: %+v, got: %+v", tt.want, disks)
 		}

--- a/internal/provider/resource_silo_saml_identity_provider.go
+++ b/internal/provider/resource_silo_saml_identity_provider.go
@@ -227,15 +227,20 @@ func (r *siloSamlIdentityProvider) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	idpMetadataSource := oxide.IdpMetadataSource{
-		Type: oxide.IdpMetadataSourceType(plan.IdpMetadataSource.Type.ValueString()),
-	}
-
-	switch idpMetadataSource.Type {
+	var idpMetadataSource oxide.IdpMetadataSource
+	switch oxide.IdpMetadataSourceType(plan.IdpMetadataSource.Type.ValueString()) {
 	case oxide.IdpMetadataSourceTypeBase64EncodedXml:
-		idpMetadataSource.Data = plan.IdpMetadataSource.Data.ValueString()
+		idpMetadataSource = oxide.IdpMetadataSource{
+			Value: &oxide.IdpMetadataSourceBase64EncodedXml{
+				Data: plan.IdpMetadataSource.Data.ValueString(),
+			},
+		}
 	case oxide.IdpMetadataSourceTypeUrl:
-		idpMetadataSource.Url = plan.IdpMetadataSource.Url.ValueString()
+		idpMetadataSource = oxide.IdpMetadataSource{
+			Value: &oxide.IdpMetadataSourceUrl{
+				Url: plan.IdpMetadataSource.Url.ValueString(),
+			},
+		}
 	}
 
 	params := oxide.SamlIdentityProviderCreateParams{


### PR DESCRIPTION
Updated `oxide.go` to a release 18 compatible version.

Relates to SSE-141.

Amp-Thread: https://ampcode.com/threads/T-019c6812-f9a3-7442-bc98-c24a3ef763e4