### PR TITLE
ci: add job ID to acceptance test artifact

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -126,5 +126,5 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
-          name: logs-${{ matrix.tf-binary }}
+          name: logs-${{ matrix.tf-binary }}-${{ job.check_run_id }}
           path: acctest/tmp/


### PR DESCRIPTION
Make acceptance test artifact upload names unique.

The goal is to avoid this:
<img width="228" height="137" alt="image" src="https://github.com/user-attachments/assets/9c4e598b-702b-4b5f-8585-33a4f61f0367" />


Sample run: https://github.com/oxidecomputer/terraform-provider-oxide/actions/runs/22157578954

Using `job.check_run_id` ensures each attempt gets an unique name.