### PR TITLE
instance: fix state migration from v0

### DIFF
--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -700,24 +700,16 @@ func (r *instanceResource) UpgradeState(ctx context.Context) map[int64]resource.
 						TimeCreated:  oldNIC.TimeCreated,
 						TimeModified: oldNIC.TimeModified,
 						VPCID:        oldNIC.VPCID,
+
+						// New attribute added in schema v1.
+						//
+						// Ideally we would check the value of ip_config or
+						// ip_addr in the user configuration file, but we don't
+						// have access to it during state migration, so assume
+						// the user has not changed their config and leave
+						// ip_config as nil.
+						IPConfig: nil,
 					}
-
-					if oldNIC.IPConfig != nil {
-						newNIC.IPConfig = &instanceResourceIPConfigModel{}
-
-						if oldNIC.IPConfig.V4 != nil {
-							newNIC.IPConfig.V4 = &instanceResourceIPConfigV4Model{
-								IP: oldNIC.IPConfig.V4.IP,
-							}
-						}
-
-						if oldNIC.IPConfig.V6 != nil {
-							newNIC.IPConfig.V6 = &instanceResourceIPConfigV6Model{
-								IP: oldNIC.IPConfig.V6.IP,
-							}
-						}
-					}
-
 					newNICs = append(newNICs, newNIC)
 				}
 
@@ -747,27 +739,33 @@ func (r *instanceResource) UpgradeState(ctx context.Context) map[int64]resource.
 				}
 
 				newState := instanceResourceModel{
-					AntiAffinityGroups:        oldState.AntiAffinityGroups,
-					AutoRestartPolicy:         oldState.AutoRestartPolicy,
-					BootDiskID:                oldState.BootDiskID,
-					Description:               oldState.Description,
-					DiskAttachments:           oldState.DiskAttachments,
-					ExternalIPs:               newExtIPs,
-					HostnameDeprecated:        oldState.HostnameDeprecated,
-					Hostname:                  oldState.Hostname,
-					ID:                        oldState.ID,
-					Memory:                    oldState.Memory,
-					Name:                      oldState.Name,
-					NetworkInterfaces:         newNICs,
-					AttachedNetworkInterfaces: oldState.AttachedNetworkInterfaces,
-					NCPUs:                     oldState.NCPUs,
-					ProjectID:                 oldState.ProjectID,
-					SSHPublicKeys:             oldState.SSHPublicKeys,
-					StartOnCreate:             oldState.StartOnCreate,
-					TimeCreated:               oldState.TimeCreated,
-					TimeModified:              oldState.TimeModified,
-					Timeouts:                  oldState.Timeouts,
-					UserData:                  oldState.UserData,
+					AntiAffinityGroups: oldState.AntiAffinityGroups,
+					AutoRestartPolicy:  oldState.AutoRestartPolicy,
+					BootDiskID:         oldState.BootDiskID,
+					Description:        oldState.Description,
+					DiskAttachments:    oldState.DiskAttachments,
+					ExternalIPs:        newExtIPs,
+					HostnameDeprecated: oldState.HostName,
+					Hostname:           oldState.HostName,
+					ID:                 oldState.ID,
+					Memory:             oldState.Memory,
+					Name:               oldState.Name,
+					NetworkInterfaces:  newNICs,
+					NCPUs:              oldState.NCPUs,
+					ProjectID:          oldState.ProjectID,
+					SSHPublicKeys:      oldState.SSHPublicKeys,
+					StartOnCreate:      oldState.StartOnCreate,
+					TimeCreated:        oldState.TimeCreated,
+					TimeModified:       oldState.TimeModified,
+					Timeouts:           oldState.Timeouts,
+					UserData:           oldState.UserData,
+
+					// New attribute added in schema v1.
+					//
+					// This is a computed attribute, so leave it as a null map
+					// that is going to be populated when the state is
+					// refreshed.
+					AttachedNetworkInterfaces: types.MapNull(instanceResourceAttachedNICType),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)

--- a/internal/provider/resource_instance_v0.go
+++ b/internal/provider/resource_instance_v0.go
@@ -23,95 +23,47 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
+// Schema and structs source:
+// https://github.com/oxidecomputer/terraform-provider-oxide/blob/v0.17.0/internal/provider/resource_instance.go
+
 type instanceResourceModelV0 struct {
-	AntiAffinityGroups        types.Set                           `tfsdk:"anti_affinity_groups"`
-	AutoRestartPolicy         types.String                        `tfsdk:"auto_restart_policy"`
-	BootDiskID                types.String                        `tfsdk:"boot_disk_id"`
-	Description               types.String                        `tfsdk:"description"`
-	DiskAttachments           types.Set                           `tfsdk:"disk_attachments"`
-	ExternalIPs               []instanceResourceExternalIPModelV0 `tfsdk:"external_ips"`
-	HostnameDeprecated        types.String                        `tfsdk:"host_name"`
-	Hostname                  types.String                        `tfsdk:"hostname"`
-	ID                        types.String                        `tfsdk:"id"`
-	Memory                    types.Int64                         `tfsdk:"memory"`
-	Name                      types.String                        `tfsdk:"name"`
-	NetworkInterfaces         []instanceResourceNICModelV0        `tfsdk:"network_interfaces"`
-	AttachedNetworkInterfaces types.Map                           `tfsdk:"attached_network_interfaces"`
-	NCPUs                     types.Int64                         `tfsdk:"ncpus"`
-	ProjectID                 types.String                        `tfsdk:"project_id"`
-	SSHPublicKeys             types.Set                           `tfsdk:"ssh_public_keys"`
-	StartOnCreate             types.Bool                          `tfsdk:"start_on_create"`
-	TimeCreated               types.String                        `tfsdk:"time_created"`
-	TimeModified              types.String                        `tfsdk:"time_modified"`
-	Timeouts                  timeouts.Value                      `tfsdk:"timeouts"`
-	UserData                  types.String                        `tfsdk:"user_data"`
+	AntiAffinityGroups types.Set                           `tfsdk:"anti_affinity_groups"`
+	AutoRestartPolicy  types.String                        `tfsdk:"auto_restart_policy"`
+	BootDiskID         types.String                        `tfsdk:"boot_disk_id"`
+	Description        types.String                        `tfsdk:"description"`
+	DiskAttachments    types.Set                           `tfsdk:"disk_attachments"`
+	ExternalIPs        []instanceResourceExternalIPModelV0 `tfsdk:"external_ips"`
+	HostName           types.String                        `tfsdk:"host_name"`
+	ID                 types.String                        `tfsdk:"id"`
+	Memory             types.Int64                         `tfsdk:"memory"`
+	Name               types.String                        `tfsdk:"name"`
+	NetworkInterfaces  []instanceResourceNICModelV0        `tfsdk:"network_interfaces"`
+	NCPUs              types.Int64                         `tfsdk:"ncpus"`
+	ProjectID          types.String                        `tfsdk:"project_id"`
+	SSHPublicKeys      types.Set                           `tfsdk:"ssh_public_keys"`
+	StartOnCreate      types.Bool                          `tfsdk:"start_on_create"`
+	TimeCreated        types.String                        `tfsdk:"time_created"`
+	TimeModified       types.String                        `tfsdk:"time_modified"`
+	Timeouts           timeouts.Value                      `tfsdk:"timeouts"`
+	UserData           types.String                        `tfsdk:"user_data"`
 }
 
 type instanceResourceNICModelV0 struct {
-	Description  types.String                     `tfsdk:"description"`
-	ID           types.String                     `tfsdk:"id"`
-	IPAddr       types.String                     `tfsdk:"ip_address"`
-	IPConfig     *instanceResourceIPConfigModelV0 `tfsdk:"ip_config"`
-	MAC          types.String                     `tfsdk:"mac_address"`
-	Name         types.String                     `tfsdk:"name"`
-	Primary      types.Bool                       `tfsdk:"primary"`
-	SubnetID     types.String                     `tfsdk:"subnet_id"`
-	TimeCreated  types.String                     `tfsdk:"time_created"`
-	TimeModified types.String                     `tfsdk:"time_modified"`
-	VPCID        types.String                     `tfsdk:"vpc_id"`
-}
-
-type instanceResourceIPConfigModelV0 struct {
-	V4 *instanceResourceIPConfigV4ModelV0 `tfsdk:"v4"`
-	V6 *instanceResourceIPConfigV6ModelV0 `tfsdk:"v6"`
-}
-
-type instanceResourceIPConfigV4ModelV0 struct {
-	IP types.String `tfsdk:"ip"`
-}
-
-type instanceResourceIPConfigV6ModelV0 struct {
-	IP types.String `tfsdk:"ip"`
+	Description  types.String `tfsdk:"description"`
+	ID           types.String `tfsdk:"id"`
+	IPAddr       types.String `tfsdk:"ip_address"`
+	MAC          types.String `tfsdk:"mac_address"`
+	Name         types.String `tfsdk:"name"`
+	Primary      types.Bool   `tfsdk:"primary"`
+	SubnetID     types.String `tfsdk:"subnet_id"`
+	TimeCreated  types.String `tfsdk:"time_created"`
+	TimeModified types.String `tfsdk:"time_modified"`
+	VPCID        types.String `tfsdk:"vpc_id"`
 }
 
 type instanceResourceExternalIPModelV0 struct {
 	ID   types.String `tfsdk:"id"`
 	Type types.String `tfsdk:"type"`
-}
-
-// The following structs are not currently used because we can migrate state
-// without changing their values. But it's useful to have them declared in case
-// a migration is needed in the future.
-
-//nolint:unused
-type instanceResourceAttachedNICModelV0 struct {
-	ID           types.String                   `tfsdk:"id"`
-	Name         types.String                   `tfsdk:"name"`
-	Description  types.String                   `tfsdk:"description"`
-	SubnetID     types.String                   `tfsdk:"subnet_id"`
-	VPCID        types.String                   `tfsdk:"vpc_id"`
-	InstanceID   types.String                   `tfsdk:"instance_id"`
-	Primary      types.Bool                     `tfsdk:"primary"`
-	MAC          types.String                   `tfsdk:"mac_address"`
-	IPStack      instanceResourceIPStackModelV0 `tfsdk:"ip_stack"`
-	TimeCreated  types.String                   `tfsdk:"time_created"`
-	TimeModified types.String                   `tfsdk:"time_modified"`
-}
-
-//nolint:unused
-type instanceResourceIPStackModelV0 struct {
-	V4 *instanceResourceIPStackV4Model `tfsdk:"v4"`
-	V6 *instanceResourceIPStackV6Model `tfsdk:"v6"`
-}
-
-//nolint:unused
-type instanceResourceIPStackV4ModelV0 struct {
-	IP types.String `tfsdk:"ip"`
-}
-
-//nolint:unused
-type instanceResourceIPStackV6ModelV0 struct {
-	IP types.String `tfsdk:"ip"`
 }
 
 func (r *instanceResource) schemaV0(ctx context.Context) *schema.Schema {
@@ -147,29 +99,10 @@ This resource manages instances.
 				},
 			},
 			"host_name": schema.StringAttribute{
-				Optional:           true,
-				Computed:           true,
-				DeprecationMessage: "Use hostname instead. This attribute will be removed in the next minor version of the provider.",
-				Description:        "Hostname of the instance.",
+				Required:    true,
+				Description: "Host name of the instance.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIf(
-						ModifyPlanForHostnameDeprecation, "", "",
-					),
-				},
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(
-						path.MatchRoot("hostname"),
-					),
-				},
-			},
-			"hostname": schema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: "Hostname of the instance.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIf(
-						ModifyPlanForHostnameDeprecation, "", "",
-					),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"memory": schema.Int64Attribute{
@@ -275,44 +208,9 @@ This resource manages instances.
 								),
 							},
 						},
-						"ip_config": schema.SingleNestedAttribute{
-							// Make this attribute optional to support zero-change provider updates
-							// and instance imports. It should be marked as required once the
-							// deprecated attributes are removed.
-							Optional:    true,
-							Description: "IP stack to create for the instance network interface.",
-							Attributes: map[string]schema.Attribute{
-								"v4": schema.SingleNestedAttribute{
-									Optional:    true,
-									Description: "Creates an IPv4 stack for the instance network interface.",
-									Attributes: map[string]schema.Attribute{
-										"ip": schema.StringAttribute{
-											Required: true,
-											Validators: []validator.String{
-												ipConfigValidator{oxide.IpVersionV4},
-											},
-											Description: `The IPv4 address for the instance network interface or "auto" to auto-assign one.`,
-										},
-									},
-								},
-								"v6": schema.SingleNestedAttribute{
-									Optional: true,
-									Attributes: map[string]schema.Attribute{
-										"ip": schema.StringAttribute{
-											Required: true,
-											Validators: []validator.String{
-												ipConfigValidator{oxide.IpVersionV6},
-											},
-											Description: `The IPv6 address for the instance network interface or "auto" to auto-assign one.`,
-										},
-									},
-								},
-							},
-						},
 						"ip_address": schema.StringAttribute{
-							DeprecationMessage: "Use ip_config to set the instance network interface IP address and attached_network_interfaces[<name>].ip_stack to retrieve its value. This attribute will be removed in the next minor version of the provider.",
-							Optional:           true,
-							Computed:           true,
+							Optional: true,
+							Computed: true,
 							Description: "IP address for the instance network interface. " +
 								"One will be auto-assigned if not provided.",
 							PlanModifiers: []planmodifier.String{
@@ -320,95 +218,16 @@ This resource manages instances.
 							},
 						},
 						"mac_address": schema.StringAttribute{
-							DeprecationMessage: "Use attached_network_interfaces[<name>].mac_address instead.",
-							Computed:           true,
-							Description:        "MAC address assigned to the instance network interface.",
+							Computed:    true,
+							Description: "MAC address assigned to the instance network interface.",
 						},
-						"id": schema.StringAttribute{
-							DeprecationMessage: "Use attached_network_interfaces[<name>].id instead.",
-							Computed:           true,
-							Description:        "Unique, immutable, system-controlled identifier of the instance network interface.",
-						},
-						"primary": schema.BoolAttribute{
-							DeprecationMessage: "Use attached_network_interfaces[<name>].primary instead.",
-							Computed:           true,
-							Description:        "True if this is the primary network interface for the instance to which it's attached to.",
-						},
-						"time_created": schema.StringAttribute{
-							DeprecationMessage: "Use attached_network_interfaces[<name>].time_created instead.",
-							Computed:           true,
-							Description:        "Timestamp of when this instance network interface was created.",
-						},
-						"time_modified": schema.StringAttribute{
-							DeprecationMessage: "Use attached_network_interfaces[<name>].time_modified instead.",
-							Computed:           true,
-							Description:        "Timestamp of when this instance network interface was last modified.",
-						},
-					},
-				},
-			},
-			"attached_network_interfaces": schema.MapNestedAttribute{
-				Computed:    true,
-				Description: "Network interfaces attached to the instance.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							Computed:    true,
 							Description: "Unique, immutable, system-controlled identifier of the instance network interface.",
 						},
-						"name": schema.StringAttribute{
-							Computed:    true,
-							Description: "Name of the instance network interface.",
-						},
-						"description": schema.StringAttribute{
-							Computed:    true,
-							Description: "Description of the instance network interface.",
-						},
-						"subnet_id": schema.StringAttribute{
-							Computed:    true,
-							Description: "VPC subnet ID of the instance network interface.",
-						},
-						"vpc_id": schema.StringAttribute{
-							Computed:    true,
-							Description: "VPC ID of the instance network interface.",
-						},
-						"instance_id": schema.StringAttribute{
-							Computed:    true,
-							Description: "Instance ID of the network interface.",
-						},
 						"primary": schema.BoolAttribute{
 							Computed:    true,
 							Description: "True if this is the primary network interface for the instance to which it's attached to.",
-						},
-						"mac_address": schema.StringAttribute{
-							Computed:    true,
-							Description: "MAC address of the instance network interface.",
-						},
-						"ip_stack": schema.SingleNestedAttribute{
-							Computed:    true,
-							Description: "IP stack of the instance network interface.",
-							Attributes: map[string]schema.Attribute{
-								"v4": schema.SingleNestedAttribute{
-									Computed:    true,
-									Description: "IPv4 stack of the instance network interface.",
-									Attributes: map[string]schema.Attribute{
-										"ip": schema.StringAttribute{
-											Computed:    true,
-											Description: "IPv4 address of the instance network interface.",
-										},
-									},
-								},
-								"v6": schema.SingleNestedAttribute{
-									Computed:    true,
-									Description: "IPv6 stack of the instance network interface.",
-									Attributes: map[string]schema.Attribute{
-										"ip": schema.StringAttribute{
-											Computed:    true,
-											Description: "IPv6 address of the instance network interface.",
-										},
-									},
-								},
-							},
 						},
 						"time_created": schema.StringAttribute{
 							Computed:    true,
@@ -424,9 +243,7 @@ This resource manages instances.
 			"external_ips": schema.SetNestedAttribute{
 				Optional:    true,
 				Description: "External IP addresses provided to this instance.",
-				Validators: []validator.Set{
-					setvalidator.AlsoRequires(path.MatchRoot("network_interfaces")),
-				},
+				Validators:  []validator.Set{},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						// The id attribute is optional, computed, and has a default to account for


### PR DESCRIPTION
Previous implementation of the `oxide_instance` resource state migration from v0 used model structs from an unreleased commit instead of the v0.17.0 tag, so it contained a lot of unnecessary fields.

Terraform ignores them when parsing real state into these structs, and we currently ignore them for the migration logic, but they could cause problems if we do try to access them in the future.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.

No changelog since this is an internal fix.
