### PR TITLE
feat(switch_port_settings): support unnumbered bgp sessions

### DIFF
--- a/.changelog/0.19.0.toml
+++ b/.changelog/0.19.0.toml
@@ -1,0 +1,15 @@
+[[breaking]]
+title = ""
+description = ""
+
+[[features]]
+title = "`oxide_switch_port_settings`"
+description = "Added support for unnumbered BGP sessions. [#653](https://github.com/oxidecomputer/terraform-provider-oxide/pull/653)."
+
+[[enhancements]]
+title = ""
+description = ""
+
+[[bugs]]
+title = ""
+description = ""

--- a/docs/resources/switch_port_settings.md
+++ b/docs/resources/switch_port_settings.md
@@ -206,7 +206,6 @@ Required:
 
 Required:
 
-- `address` (String) Address of the host to peer with.
 - `allowed_export` (Attributes) Export policy for the peer. (see [below for nested schema](#nestedatt--bgp_peers--peers--allowed_export))
 - `allowed_import` (Attributes) Import policy for the peer. (see [below for nested schema](#nestedatt--bgp_peers--peers--allowed_import))
 - `bgp_config` (String) Name or ID of the global BGP configuration used for establishing a session with this peer.
@@ -221,6 +220,7 @@ Required:
 
 Optional:
 
+- `address` (String) Address of the host to peer with. If not provided, this is an unnumbered BGP session that will be established over the interface specified by `interface_name`.
 - `local_pref` (Number) BGP local preference value for routes received from this peer.
 - `md5_auth_key` (String) MD5 authentication key for this BGP session.
 - `min_ttl` (Number) Minimum acceptable TTL for BGP packets from this peer.

--- a/internal/provider/resource_switch_port_settings.go
+++ b/internal/provider/resource_switch_port_settings.go
@@ -232,9 +232,9 @@ func (r *switchPortSettingsResource) Schema(
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
-										Required:    true,
+										Optional:    true,
 										CustomType:  iptypes.IPAddressType{},
-										Description: "Address of the host to peer with.",
+										Description: "Address of the host to peer with. If not provided, this is an unnumbered BGP session that will be established over the interface specified by `interface_name`.",
 									},
 									"allowed_export": schema.SingleNestedAttribute{
 										Required:    true,
@@ -871,7 +871,12 @@ func toSwitchPortSettingsModel(
 			}
 
 			bgpPeerModel := switchPortSettingsBGPPeerPeerModel{
-				Address:        iptypes.NewIPAddressValue(bgpPeer.Addr),
+				Address: func() iptypes.IPAddress {
+					if bgpPeer.Addr == "" {
+						return iptypes.NewIPAddressNull()
+					}
+					return iptypes.NewIPAddressValue(bgpPeer.Addr)
+				}(),
 				BGPConfig:      types.StringValue(string(bgpPeer.BgpConfig)),
 				ConnectRetry:   types.Int64Value(int64(*bgpPeer.ConnectRetry)),
 				DelayOpen:      types.Int64Value(int64(*bgpPeer.DelayOpen)),


### PR DESCRIPTION
Added support for unnumbered BGP sessions in line with the upstream API changes that moved `bgp_peers[].peers[].addr` to `nullable`.
