### PR TITLE
ci: set RUST_BACKTRACE in acceptance tests

### DIFF
--- a/acctest/docker-compose.yaml
+++ b/acctest/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
     build: "."
     image: "acctest-omicron-dev:${TEST_ACC_DOCKER_TAG:-latest}"
     platform: "linux/amd64"
+    environment:
+      RUST_BACKTRACE: "1"
     command:
       - "omicron-dev"
       - "run-all"


### PR DESCRIPTION
While investigating #655, I noticed a panic in the handler for the Crucible endpoint call:

```
08:00:30.337Z ERRO omicron-dev (omicron_sled_agent::sim::Server): handler panicked; propagating panic
    kind = pantry
    local_addr = [::1]:36361
    method = POST
    remote_addr = [::1]:55960
    req_id = 08e45cef-9f24-4f07-9e57-b7b01926c6b5
    sled_id = b6d65341-167c-41df-9b5c-41cded99c229
    uri = /crucible/pantry/0/volume/0e834800-ee6d-4a55-85a2-77dc20f45b65/snapshot
```

I am not sure if `RUST_BACKTRACE` will provide us with more information about this specific error, but it probably doesn't hurt to have it enabled to collect more data in general.
