### PR TITLE
ci: fix omicron build

### DIFF
--- a/acctest/Dockerfile
+++ b/acctest/Dockerfile
@@ -3,8 +3,9 @@ FROM rust:bookworm AS builder
 
 ARG OMICRON_SHA
 
-RUN curl -sL "https://github.com/oxidecomputer/omicron/archive/${OMICRON_SHA}.tar.gz" | tar xz && \
-    mv omicron-* omicron
+RUN git clone https://github.com/oxidecomputer/omicron.git /omicron && \
+    cd /omicron && \
+    git checkout "${OMICRON_SHA}"
 
 WORKDIR /omicron
 


### PR DESCRIPTION
[omicron#9933](https://github.com/oxidecomputer/omicron/pull/9933) introduced the need for the git repo data to be available in the local filesystem to resolve OpenAPI spec files git stubs.