### PR TITLE
ci: save omicron-dev container logs

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -98,11 +98,6 @@ jobs:
           TF_ACC_SIM: "1"
           TF_LOG: "TRACE"
           TF_LOG_PATH: "terraform.log"
-      - name: print omicron logs
-        if: always()
-        continue-on-error: true
-        working-directory: acctest
-        run: docker compose logs omicron-dev
       - name: extract log files
         if: always()
         continue-on-error: true
@@ -110,6 +105,7 @@ jobs:
         run: |
           docker compose exec -T omicron-dev sh -c 'tar -cf - /tmp/omicron-dev*.log' | tar -xf -
           docker compose exec -T mitmproxy sh -c 'tar -cf - /tmp/mitmproxy.log' | tar -xf -
+          docker compose logs omicron-dev > ./tmp/omicron-dev.log
           mv ../internal/provider/terraform.log ./tmp
           mv ./acc-tests.xml ./tmp
       - name: rerun warn


### PR DESCRIPTION
With #660, we now have important information about panics that are sent to the container STDOUT.

Save `omicron-dev` container logs to the artifacts bundle instead of just printing them to the action output so they re easier to find.

For context, this came up while I was investigating https://github.com/oxidecomputer/terraform-provider-oxide/issues/688 and it took me a while to find where the backtrace was being printed.