### PR TITLE
misc: repository refactor phase 1

### DIFF
--- a/internal/provider/data_source_address_lot.go
+++ b/internal/provider/data_source_address_lot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_address_lot.go
+++ b/internal/provider/data_source_address_lot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*addressLotDataSource)(nil)
@@ -134,7 +135,7 @@ func (d *addressLotDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_address_lot_test.go
+++ b/internal/provider/data_source_address_lot_test.go
@@ -33,10 +33,10 @@ data "oxide_address_lot" "test" {
 
 func TestAccDataSourceAddressLot_full(t *testing.T) {
 	resourceName := "oxide_address_lot.test"
-	addressLotName := newResourceName()
+	addressLotName := NewResourceName()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAddressLotConfig(addressLotName),

--- a/internal/provider/data_source_address_lot_test.go
+++ b/internal/provider/data_source_address_lot_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func testDataSourceAddressLotConfig(name string) string {
@@ -33,10 +34,10 @@ data "oxide_address_lot" "test" {
 
 func TestAccDataSourceAddressLot_full(t *testing.T) {
 	resourceName := "oxide_address_lot.test"
-	addressLotName := NewResourceName()
+	addressLotName := sharedtest.NewResourceName()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAddressLotConfig(addressLotName),

--- a/internal/provider/data_source_address_lot_test.go
+++ b/internal/provider/data_source_address_lot_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_anti_affinity_group.go
+++ b/internal/provider/data_source_anti_affinity_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_anti_affinity_group.go
+++ b/internal/provider/data_source_anti_affinity_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -128,7 +129,7 @@ func (d *antiAffinityGroupDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_anti_affinity_group_test.go
+++ b/internal/provider/data_source_anti_affinity_group_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceAntiAffinityGroupConfig struct {
@@ -40,13 +41,13 @@ data "oxide_anti_affinity_group" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
-	blockName := NewBlockName("datasource-anti-affinity-group")
-	resourceName := NewResourceName()
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-anti-affinity-group")
+	resourceName := sharedtest.NewResourceName()
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceAntiAffinityGroupConfig{
 			BlockName:         blockName,
-			SupportBlockName:  NewBlockName("support"),
-			SupportBlockName2: NewBlockName("support"),
+			SupportBlockName:  sharedtest.NewBlockName("support"),
+			SupportBlockName2: sharedtest.NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceAntiAffinityGroupConfigTpl,
@@ -56,8 +57,8 @@ func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_anti_affinity_group_test.go
+++ b/internal/provider/data_source_anti_affinity_group_test.go
@@ -40,13 +40,13 @@ data "oxide_anti_affinity_group" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
-	blockName := newBlockName("datasource-anti-affinity-group")
-	resourceName := newResourceName()
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-anti-affinity-group")
+	resourceName := NewResourceName()
+	config, err := ParsedAccConfig(
 		dataSourceAntiAffinityGroupConfig{
 			BlockName:         blockName,
-			SupportBlockName:  newBlockName("support"),
-			SupportBlockName2: newBlockName("support"),
+			SupportBlockName:  NewBlockName("support"),
+			SupportBlockName2: NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceAntiAffinityGroupConfigTpl,
@@ -56,8 +56,8 @@ func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_anti_affinity_group_test.go
+++ b/internal/provider/data_source_anti_affinity_group_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_disk.go
+++ b/internal/provider/data_source_disk.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_disk.go
+++ b/internal/provider/data_source_disk.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -179,7 +180,7 @@ func (d *diskDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_disk_test.go
+++ b/internal/provider/data_source_disk_test.go
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceDiskConfig struct {
@@ -37,8 +38,8 @@ data "oxide_disk" "test" {
 `
 
 func TestAccCloudDataSourceDisk_full(t *testing.T) {
-	diskName := NewResourceName()
-	config, err := ParsedAccConfig(
+	diskName := sharedtest.NewResourceName()
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -49,8 +50,8 @@ func TestAccCloudDataSourceDisk_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_disk_test.go
+++ b/internal/provider/data_source_disk_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_disk_test.go
+++ b/internal/provider/data_source_disk_test.go
@@ -37,8 +37,8 @@ data "oxide_disk" "test" {
 `
 
 func TestAccCloudDataSourceDisk_full(t *testing.T) {
-	diskName := newResourceName()
-	config, err := parsedAccConfig(
+	diskName := NewResourceName()
+	config, err := ParsedAccConfig(
 		dataSourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -49,8 +49,8 @@ func TestAccCloudDataSourceDisk_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_floating_ip.go
+++ b/internal/provider/data_source_floating_ip.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_floating_ip.go
+++ b/internal/provider/data_source_floating_ip.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // floatingIPDataSourceModel represents the Terraform configuration and state
@@ -146,7 +147,7 @@ func (f *floatingIPDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -162,7 +163,7 @@ func (f *floatingIPDataSource) Read(
 
 	floatingIP, err := f.client.FloatingIpView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/data_source_floating_ip_test.go
+++ b/internal/provider/data_source_floating_ip_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceFloatingIPConfig struct {
@@ -40,13 +41,13 @@ data "oxide_floating_ip" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
-	blockName := NewBlockName("datasource-floating-ip")
-	resourceName := NewResourceName()
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-floating-ip")
+	resourceName := sharedtest.NewResourceName()
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceFloatingIPConfig{
 			BlockName:         blockName,
-			SupportBlockName:  NewBlockName("support"),
-			SupportBlockName2: NewBlockName("support"),
+			SupportBlockName:  sharedtest.NewBlockName("support"),
+			SupportBlockName2: sharedtest.NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceFloatingIPConfigTpl,
@@ -56,8 +57,8 @@ func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_floating_ip_test.go
+++ b/internal/provider/data_source_floating_ip_test.go
@@ -40,13 +40,13 @@ data "oxide_floating_ip" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
-	blockName := newBlockName("datasource-floating-ip")
-	resourceName := newResourceName()
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-floating-ip")
+	resourceName := NewResourceName()
+	config, err := ParsedAccConfig(
 		dataSourceFloatingIPConfig{
 			BlockName:         blockName,
-			SupportBlockName:  newBlockName("support"),
-			SupportBlockName2: newBlockName("support"),
+			SupportBlockName:  NewBlockName("support"),
+			SupportBlockName2: NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceFloatingIPConfigTpl,
@@ -56,8 +56,8 @@ func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_floating_ip_test.go
+++ b/internal/provider/data_source_floating_ip_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_image.go
+++ b/internal/provider/data_source_image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_image.go
+++ b/internal/provider/data_source_image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -158,7 +159,7 @@ func (d *imageDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_image_test.go
+++ b/internal/provider/data_source_image_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceImageConfig struct {
@@ -37,12 +38,12 @@ data "oxide_image" "{{.BlockName}}" {
 
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImage_full(t *testing.T) {
-	blockName := NewBlockName("datasource-image")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-image")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceImageConfig{
 			BlockName:         blockName,
-			SupportBlockName:  NewBlockName("support"),
-			SupportBlockName2: NewBlockName("support"),
+			SupportBlockName:  sharedtest.NewBlockName("support"),
+			SupportBlockName2: sharedtest.NewBlockName("support"),
 		},
 		dataSourceImageConfigTpl,
 	)
@@ -51,8 +52,8 @@ func TestAccCloudDataSourceImage_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_image_test.go
+++ b/internal/provider/data_source_image_test.go
@@ -37,12 +37,12 @@ data "oxide_image" "{{.BlockName}}" {
 
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImage_full(t *testing.T) {
-	blockName := newBlockName("datasource-image")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-image")
+	config, err := ParsedAccConfig(
 		dataSourceImageConfig{
 			BlockName:         blockName,
-			SupportBlockName:  newBlockName("support"),
-			SupportBlockName2: newBlockName("support"),
+			SupportBlockName:  NewBlockName("support"),
+			SupportBlockName2: NewBlockName("support"),
 		},
 		dataSourceImageConfigTpl,
 	)
@@ -51,8 +51,8 @@ func TestAccCloudDataSourceImage_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_image_test.go
+++ b/internal/provider/data_source_image_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_images.go
+++ b/internal/provider/data_source_images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -169,7 +170,7 @@ func (d *imagesDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_images.go
+++ b/internal/provider/data_source_images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_images_test.go
+++ b/internal/provider/data_source_images_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceProjectImagesConfig struct {
@@ -39,11 +40,11 @@ data "oxide_images" "{{.BlockName}}" {}
 
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_project(t *testing.T) {
-	blockName := NewBlockName("datasource-images")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-images")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceProjectImagesConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceProjectImagesConfigTpl,
 	)
@@ -52,8 +53,8 @@ func TestAccCloudDataSourceImages_project(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -67,8 +68,8 @@ func TestAccCloudDataSourceImages_project(t *testing.T) {
 
 // NB: The silo must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_silo(t *testing.T) {
-	blockName := NewBlockName("datasource-images")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-images")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceSiloImagesConfig{
 			BlockName: blockName,
 		},
@@ -79,8 +80,8 @@ func TestAccCloudDataSourceImages_silo(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_images_test.go
+++ b/internal/provider/data_source_images_test.go
@@ -39,11 +39,11 @@ data "oxide_images" "{{.BlockName}}" {}
 
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_project(t *testing.T) {
-	blockName := newBlockName("datasource-images")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-images")
+	config, err := ParsedAccConfig(
 		dataSourceProjectImagesConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceProjectImagesConfigTpl,
 	)
@@ -52,8 +52,8 @@ func TestAccCloudDataSourceImages_project(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -67,8 +67,8 @@ func TestAccCloudDataSourceImages_project(t *testing.T) {
 
 // NB: The silo must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_silo(t *testing.T) {
-	blockName := newBlockName("datasource-images")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-images")
+	config, err := ParsedAccConfig(
 		dataSourceSiloImagesConfig{
 			BlockName: blockName,
 		},
@@ -79,8 +79,8 @@ func TestAccCloudDataSourceImages_silo(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_images_test.go
+++ b/internal/provider/data_source_images_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_instance_external_ips.go
+++ b/internal/provider/data_source_instance_external_ips.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -114,7 +115,7 @@ func (d *instanceExternalIPsDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_instance_external_ips.go
+++ b/internal/provider/data_source_instance_external_ips.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_instance_external_ips_test.go
+++ b/internal/provider/data_source_instance_external_ips_test.go
@@ -68,13 +68,13 @@ data "oxide_instance_external_ips" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
-	blockName := newBlockName("datasource-instance-external-ips")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-instance-external-ips")
+	config, err := ParsedAccConfig(
 		dataSourceInstanceExternalIPConfig{
 			BlockName:         blockName,
-			SupportBlockName:  newBlockName("support"),
-			InstanceName:      newResourceName(),
-			InstanceBlockName: newBlockName("instance"),
+			SupportBlockName:  NewBlockName("support"),
+			InstanceName:      NewResourceName(),
+			InstanceBlockName: NewBlockName("instance"),
 		},
 		datasourceInstanceExternalIPsConfigTpl,
 	)
@@ -83,8 +83,8 @@ func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_instance_external_ips_test.go
+++ b/internal/provider/data_source_instance_external_ips_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceInstanceExternalIPConfig struct {
@@ -68,13 +69,13 @@ data "oxide_instance_external_ips" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
-	blockName := NewBlockName("datasource-instance-external-ips")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-instance-external-ips")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceInstanceExternalIPConfig{
 			BlockName:         blockName,
-			SupportBlockName:  NewBlockName("support"),
-			InstanceName:      NewResourceName(),
-			InstanceBlockName: NewBlockName("instance"),
+			SupportBlockName:  sharedtest.NewBlockName("support"),
+			InstanceName:      sharedtest.NewResourceName(),
+			InstanceBlockName: sharedtest.NewBlockName("instance"),
 		},
 		datasourceInstanceExternalIPsConfigTpl,
 	)
@@ -83,8 +84,8 @@ func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_instance_external_ips_test.go
+++ b/internal/provider/data_source_instance_external_ips_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_ip_pool.go
+++ b/internal/provider/data_source_ip_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_ip_pool.go
+++ b/internal/provider/data_source_ip_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*ipPoolDataSource)(nil)
@@ -114,7 +115,7 @@ func (d *ipPoolDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_ip_pool_test.go
+++ b/internal/provider/data_source_ip_pool_test.go
@@ -26,11 +26,11 @@ data "oxide_ip_pool" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceIPPool_full(t *testing.T) {
-	blockName := newBlockName("datasource-ip-pool")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-ip-pool")
+	config, err := ParsedAccConfig(
 		dataSourceIPPoolConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceIPPoolConfigTpl,
 	)
@@ -39,8 +39,8 @@ func TestAccSiloDataSourceIPPool_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_ip_pool_test.go
+++ b/internal/provider/data_source_ip_pool_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceIPPoolConfig struct {
@@ -26,11 +27,11 @@ data "oxide_ip_pool" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceIPPool_full(t *testing.T) {
-	blockName := NewBlockName("datasource-ip-pool")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-ip-pool")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceIPPoolConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceIPPoolConfigTpl,
 	)
@@ -39,8 +40,8 @@ func TestAccSiloDataSourceIPPool_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_ip_pool_test.go
+++ b/internal/provider/data_source_ip_pool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*projectDataSource)(nil)
@@ -106,7 +107,7 @@ func (d *projectDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceProjectConfig struct {
@@ -26,11 +27,11 @@ data "oxide_project" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceProject_full(t *testing.T) {
-	blockName := NewBlockName("datasource-project")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-project")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceProjectConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceProjectConfigTpl,
 	)
@@ -39,8 +40,8 @@ func TestAccCloudDataSourceProject_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -26,11 +26,11 @@ data "oxide_project" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceProject_full(t *testing.T) {
-	blockName := newBlockName("datasource-project")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-project")
+	config, err := ParsedAccConfig(
 		dataSourceProjectConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceProjectConfigTpl,
 	)
@@ -39,8 +39,8 @@ func TestAccCloudDataSourceProject_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*projectsDataSource)(nil)
@@ -124,7 +125,7 @@ func (d *projectsDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_projects_test.go
+++ b/internal/provider/data_source_projects_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceProjectsConfig struct {
@@ -24,8 +25,8 @@ data "oxide_projects" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceProjects_full(t *testing.T) {
-	blockName := NewBlockName("datasource-projects")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-projects")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceProjectsConfig{
 			BlockName: blockName,
 		},
@@ -36,8 +37,8 @@ func TestAccCloudDataSourceProjects_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_projects_test.go
+++ b/internal/provider/data_source_projects_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_projects_test.go
+++ b/internal/provider/data_source_projects_test.go
@@ -24,8 +24,8 @@ data "oxide_projects" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceProjects_full(t *testing.T) {
-	blockName := newBlockName("datasource-projects")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-projects")
+	config, err := ParsedAccConfig(
 		dataSourceProjectsConfig{
 			BlockName: blockName,
 		},
@@ -36,8 +36,8 @@ func TestAccCloudDataSourceProjects_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_silo.go
+++ b/internal/provider/data_source_silo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_silo.go
+++ b/internal/provider/data_source_silo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*siloDataSource)(nil)
@@ -119,7 +120,7 @@ func (d *siloDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_silo_test.go
+++ b/internal/provider/data_source_silo_test.go
@@ -84,11 +84,11 @@ data "oxide_silo" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceSilo_full(t *testing.T) {
-	blockName := newBlockName("datasource-silo")
+	blockName := NewBlockName("datasource-silo")
 
-	dnsName := testAccSiloDNSName()
+	dnsName := SiloDNSName()
 
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		dataSourceSiloConfig{
 			BlockName:   blockName,
 			SiloDNSName: dnsName,
@@ -103,8 +103,8 @@ func TestAccSiloDataSourceSilo_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/data_source_silo_test.go
+++ b/internal/provider/data_source_silo_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceSiloConfig struct {
@@ -84,11 +85,11 @@ data "oxide_silo" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceSilo_full(t *testing.T) {
-	blockName := NewBlockName("datasource-silo")
+	blockName := sharedtest.NewBlockName("datasource-silo")
 
-	dnsName := SiloDNSName()
+	dnsName := sharedtest.SiloDNSName()
 
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceSiloConfig{
 			BlockName:   blockName,
 			SiloDNSName: dnsName,
@@ -103,8 +104,8 @@ func TestAccSiloDataSourceSilo_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/data_source_silo_test.go
+++ b/internal/provider/data_source_silo_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -123,7 +124,7 @@ func (d *sshKeyDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_ssh_key_test.go
+++ b/internal/provider/data_source_ssh_key_test.go
@@ -38,13 +38,13 @@ data "oxide_ssh_key" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
-	blockName := newBlockName("datasource-ssh-key")
-	resourceName := newResourceName()
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-ssh-key")
+	resourceName := NewResourceName()
+	config, err := ParsedAccConfig(
 		dataSourceSSHKeyConfig{
 			BlockName:         blockName,
-			SupportBlockName:  newBlockName("support"),
-			SupportBlockName2: newBlockName("support"),
+			SupportBlockName:  NewBlockName("support"),
+			SupportBlockName2: NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceSSHKeyConfigTpl,
@@ -54,8 +54,8 @@ func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_ssh_key_test.go
+++ b/internal/provider/data_source_ssh_key_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceSSHKeyConfig struct {
@@ -38,13 +39,13 @@ data "oxide_ssh_key" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
-	blockName := NewBlockName("datasource-ssh-key")
-	resourceName := NewResourceName()
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-ssh-key")
+	resourceName := sharedtest.NewResourceName()
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceSSHKeyConfig{
 			BlockName:         blockName,
-			SupportBlockName:  NewBlockName("support"),
-			SupportBlockName2: NewBlockName("support"),
+			SupportBlockName:  sharedtest.NewBlockName("support"),
+			SupportBlockName2: sharedtest.NewBlockName("support"),
 			Name:              resourceName,
 		},
 		dataSourceSSHKeyConfigTpl,
@@ -54,8 +55,8 @@ func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_ssh_key_test.go
+++ b/internal/provider/data_source_ssh_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_subnet_pool.go
+++ b/internal/provider/data_source_subnet_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_subnet_pool.go
+++ b/internal/provider/data_source_subnet_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*subnetPoolDataSource)(nil)
@@ -139,7 +140,7 @@ func (d *subnetPoolDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_subnet_pool_test.go
+++ b/internal/provider/data_source_subnet_pool_test.go
@@ -14,11 +14,11 @@ import (
 func TestAccDataSourceSubnetPool_full(t *testing.T) {
 	dataSourceName := "data.oxide_subnet_pool.test"
 
-	subnet := nextSubnetCIDR(t)
+	subnet := NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_subnet_pool_test.go
+++ b/internal/provider/data_source_subnet_pool_test.go
@@ -2,23 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccDataSourceSubnetPool_full(t *testing.T) {
 	dataSourceName := "data.oxide_subnet_pool.test"
 
-	subnet := NextSubnetCIDR(t)
+	subnet := sharedtest.NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_subnet_pool_test.go
+++ b/internal/provider/data_source_subnet_pool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_system_ip_pools.go
+++ b/internal/provider/data_source_system_ip_pools.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_system_ip_pools.go
+++ b/internal/provider/data_source_system_ip_pools.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var _ datasource.DataSource = (*systemIpPoolsDataSource)(nil)
@@ -121,7 +122,7 @@ func (d *systemIpPoolsDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_system_ip_pools_test.go
+++ b/internal/provider/data_source_system_ip_pools_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceSystemIPPoolsConfig struct {
@@ -25,11 +26,11 @@ data "oxide_system_ip_pools" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceSystemIPPools_full(t *testing.T) {
-	blockName := NewBlockName("datasource-ip-pool")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-ip-pool")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceSystemIPPoolsConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceSystemIPPoolsConfigTpl,
 	)
@@ -38,8 +39,8 @@ func TestAccSiloDataSourceSystemIPPools_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_system_ip_pools_test.go
+++ b/internal/provider/data_source_system_ip_pools_test.go
@@ -25,11 +25,11 @@ data "oxide_system_ip_pools" "{{.BlockName}}" {
 `
 
 func TestAccSiloDataSourceSystemIPPools_full(t *testing.T) {
-	blockName := newBlockName("datasource-ip-pool")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-ip-pool")
+	config, err := ParsedAccConfig(
 		dataSourceSystemIPPoolsConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceSystemIPPoolsConfigTpl,
 	)
@@ -38,8 +38,8 @@ func TestAccSiloDataSourceSystemIPPools_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_system_ip_pools_test.go
+++ b/internal/provider/data_source_system_ip_pools_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_vpc.go
+++ b/internal/provider/data_source_vpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_vpc.go
+++ b/internal/provider/data_source_vpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -133,7 +134,7 @@ func (d *vpcDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_vpc_internet_gateway.go
+++ b/internal/provider/data_source_vpc_internet_gateway.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_vpc_internet_gateway.go
+++ b/internal/provider/data_source_vpc_internet_gateway.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -123,7 +124,7 @@ func (d *vpcInternetGatewayDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_vpc_internet_gateway_test.go
+++ b/internal/provider/data_source_vpc_internet_gateway_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceVPCInternetGatewayConfig struct {
@@ -39,11 +40,11 @@ data "oxide_vpc_internet_gateway" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCInternetGateway_full(t *testing.T) {
-	blockName := NewBlockName("datasource-vpc-router")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-vpc-router")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceVPCInternetGatewayConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceVPCInternetGatewayConfigTpl,
 	)
@@ -52,8 +53,8 @@ func TestAccCloudDataSourceVPCInternetGateway_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_internet_gateway_test.go
+++ b/internal/provider/data_source_vpc_internet_gateway_test.go
@@ -39,11 +39,11 @@ data "oxide_vpc_internet_gateway" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCInternetGateway_full(t *testing.T) {
-	blockName := newBlockName("datasource-vpc-router")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-vpc-router")
+	config, err := ParsedAccConfig(
 		dataSourceVPCInternetGatewayConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceVPCInternetGatewayConfigTpl,
 	)
@@ -52,8 +52,8 @@ func TestAccCloudDataSourceVPCInternetGateway_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_internet_gateway_test.go
+++ b/internal/provider/data_source_vpc_internet_gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_vpc_router.go
+++ b/internal/provider/data_source_vpc_router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_vpc_router.go
+++ b/internal/provider/data_source_vpc_router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -128,7 +129,7 @@ func (d *vpcRouterDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_vpc_router_route.go
+++ b/internal/provider/data_source_vpc_router_route.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -121,7 +122,7 @@ Retrieve information about a specified VPC router route.
 						Computed:            true,
 					},
 					"value": schema.StringAttribute{
-						MarkdownDescription: replaceBackticks(`
+						MarkdownDescription: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -149,7 +150,7 @@ Depending on the type, it will be one of the following:
 						Computed:            true,
 					},
 					"value": schema.StringAttribute{
-						MarkdownDescription: replaceBackticks(`
+						MarkdownDescription: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -187,7 +188,7 @@ func (d *vpcRouterRouteDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_vpc_router_route.go
+++ b/internal/provider/data_source_vpc_router_route.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_vpc_router_route_test.go
+++ b/internal/provider/data_source_vpc_router_route_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceVPCRouterRouteConfig struct {
@@ -30,11 +31,11 @@ data "oxide_vpc_router_route" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCRouterRoute_full(t *testing.T) {
-	blockName := NewBlockName("datasource-vpc-router")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-vpc-router")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceVPCRouterRouteConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceVPCRouterRouteConfigTpl,
 	)
@@ -43,8 +44,8 @@ func TestAccCloudDataSourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_router_route_test.go
+++ b/internal/provider/data_source_vpc_router_route_test.go
@@ -30,11 +30,11 @@ data "oxide_vpc_router_route" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCRouterRoute_full(t *testing.T) {
-	blockName := newBlockName("datasource-vpc-router")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-vpc-router")
+	config, err := ParsedAccConfig(
 		dataSourceVPCRouterRouteConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceVPCRouterRouteConfigTpl,
 	)
@@ -43,8 +43,8 @@ func TestAccCloudDataSourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_router_route_test.go
+++ b/internal/provider/data_source_vpc_router_route_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_vpc_router_test.go
+++ b/internal/provider/data_source_vpc_router_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceVPCRouterConfig struct {
@@ -40,11 +41,11 @@ data "oxide_vpc_router" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
-	blockName := NewBlockName("datasource-vpc-router")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-vpc-router")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceVPCRouterConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceVPCRouterConfigTpl,
 	)
@@ -53,8 +54,8 @@ func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_router_test.go
+++ b/internal/provider/data_source_vpc_router_test.go
@@ -40,11 +40,11 @@ data "oxide_vpc_router" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
-	blockName := newBlockName("datasource-vpc-router")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-vpc-router")
+	config, err := ParsedAccConfig(
 		dataSourceVPCRouterConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceVPCRouterConfigTpl,
 	)
@@ -53,8 +53,8 @@ func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_router_test.go
+++ b/internal/provider/data_source_vpc_router_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_vpc_subnet.go
+++ b/internal/provider/data_source_vpc_subnet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/data_source_vpc_subnet.go
+++ b/internal/provider/data_source_vpc_subnet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -137,7 +138,7 @@ func (d *vpcSubnetDataSource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_vpc_subnet_test.go
+++ b/internal/provider/data_source_vpc_subnet_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceVPCSubnetConfig struct {
@@ -28,11 +29,11 @@ data "oxide_vpc_subnet" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCSubnet_full(t *testing.T) {
-	blockName := NewBlockName("datasource-vpc-subnet")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-vpc-subnet")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceVPCSubnetConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceVPCSubnetConfigTpl,
 	)
@@ -41,8 +42,8 @@ func TestAccCloudDataSourceVPCSubnet_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_subnet_test.go
+++ b/internal/provider/data_source_vpc_subnet_test.go
@@ -28,11 +28,11 @@ data "oxide_vpc_subnet" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPCSubnet_full(t *testing.T) {
-	blockName := newBlockName("datasource-vpc-subnet")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-vpc-subnet")
+	config, err := ParsedAccConfig(
 		dataSourceVPCSubnetConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceVPCSubnetConfigTpl,
 	)
@@ -41,8 +41,8 @@ func TestAccCloudDataSourceVPCSubnet_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_subnet_test.go
+++ b/internal/provider/data_source_vpc_subnet_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/data_source_vpc_test.go
+++ b/internal/provider/data_source_vpc_test.go
@@ -27,11 +27,11 @@ data "oxide_vpc" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPC_full(t *testing.T) {
-	blockName := newBlockName("datasource-vpc")
-	config, err := parsedAccConfig(
+	blockName := NewBlockName("datasource-vpc")
+	config, err := ParsedAccConfig(
 		dataSourceVPCConfig{
 			BlockName:        blockName,
-			SupportBlockName: newBlockName("support"),
+			SupportBlockName: NewBlockName("support"),
 		},
 		dataSourceVPCConfigTpl,
 	)
@@ -40,8 +40,8 @@ func TestAccCloudDataSourceVPC_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_test.go
+++ b/internal/provider/data_source_vpc_test.go
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type dataSourceVPCConfig struct {
@@ -27,11 +28,11 @@ data "oxide_vpc" "{{.BlockName}}" {
 `
 
 func TestAccCloudDataSourceVPC_full(t *testing.T) {
-	blockName := NewBlockName("datasource-vpc")
-	config, err := ParsedAccConfig(
+	blockName := sharedtest.NewBlockName("datasource-vpc")
+	config, err := sharedtest.ParsedAccConfig(
 		dataSourceVPCConfig{
 			BlockName:        blockName,
-			SupportBlockName: NewBlockName("support"),
+			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceVPCConfigTpl,
 	)
@@ -40,8 +41,8 @@ func TestAccCloudDataSourceVPC_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/provider/data_source_vpc_test.go
+++ b/internal/provider/data_source_vpc_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,4 +1,4 @@
-package provider
+package provider_test
 
 import (
 	"fmt"
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -156,7 +157,7 @@ provider "oxide" {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resource.UnitTest(t, resource.TestCase{
-				ProtoV6ProviderFactories: ProviderFactories(),
+				ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 				Steps: []resource.TestStep{
 					{
 						PreConfig: func() {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 // lintignore:AT004

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -156,7 +156,7 @@ provider "oxide" {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resource.UnitTest(t, resource.TestCase{
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+				ProtoV6ProviderFactories: ProviderFactories(),
 				Steps: []resource.TestStep{
 					{
 						PreConfig: func() {

--- a/internal/provider/resource_address_lot.go
+++ b/internal/provider/resource_address_lot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_address_lot.go
+++ b/internal/provider/resource_address_lot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -182,7 +183,7 @@ func (r *addressLotResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -256,7 +257,7 @@ func (r *addressLotResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -334,7 +335,7 @@ func (r *addressLotResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -347,7 +348,7 @@ func (r *addressLotResource) Delete(
 		oxide.NetworkingAddressLotDeleteParams{
 			AddressLot: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting Address Lot:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_address_lot_test.go
+++ b/internal/provider/resource_address_lot_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestAccAddressLot_full(t *testing.T) {
 	resourceName := "oxide_address_lot.test"
-	addressLotName := newResourceName()
+	addressLotName := NewResourceName()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceAddressLotConfig(addressLotName),

--- a/internal/provider/resource_address_lot_test.go
+++ b/internal/provider/resource_address_lot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/resource_address_lot_test.go
+++ b/internal/provider/resource_address_lot_test.go
@@ -1,18 +1,19 @@
-package provider
+package provider_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccAddressLot_full(t *testing.T) {
 	resourceName := "oxide_address_lot.test"
-	addressLotName := NewResourceName()
+	addressLotName := sharedtest.NewResourceName()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceAddressLotConfig(addressLotName),

--- a/internal/provider/resource_anti_affinity_group.go
+++ b/internal/provider/resource_anti_affinity_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_anti_affinity_group.go
+++ b/internal/provider/resource_anti_affinity_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -164,7 +165,7 @@ func (r *antiAffinityGroupResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,7 +225,7 @@ func (r *antiAffinityGroupResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -237,7 +238,7 @@ func (r *antiAffinityGroupResource) Read(
 	}
 	antiAffinityGroup, err := r.client.AntiAffinityGroupView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -292,7 +293,7 @@ func (r *antiAffinityGroupResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -348,7 +349,7 @@ func (r *antiAffinityGroupResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -360,7 +361,7 @@ func (r *antiAffinityGroupResource) Delete(
 		AntiAffinityGroup: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.AntiAffinityGroupDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting AntiAffinityGroup:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_anti_affinity_group_test.go
+++ b/internal/provider/resource_anti_affinity_group_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_anti_affinity_group_test.go
+++ b/internal/provider/resource_anti_affinity_group_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceAntiAffinityGroupConfig struct {
@@ -54,11 +55,11 @@ resource "oxide_anti_affinity_group" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
-	antiAffinityGroupName := newResourceName()
-	blockName := newBlockName("anti_affinity_group")
+	antiAffinityGroupName := NewResourceName()
+	blockName := NewBlockName("anti_affinity_group")
 	resourceName := fmt.Sprintf("oxide_anti_affinity_group.%s", blockName)
-	supportBlockName := newBlockName("support")
-	config, err := parsedAccConfig(
+	supportBlockName := NewBlockName("support")
+	config, err := ParsedAccConfig(
 		resourceAntiAffinityGroupConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupName,
@@ -71,7 +72,7 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	antiAffinityGroupNameUpdated := antiAffinityGroupName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceAntiAffinityGroupConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupNameUpdated,
@@ -84,8 +85,8 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccAntiAffinityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -143,7 +144,7 @@ func checkResourceAntiAffinityGroupUpdate(
 }
 
 func testAccAntiAffinityGroupDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func testAccAntiAffinityGroupDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.AntiAffinityGroupView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_anti_affinity_group_test.go
+++ b/internal/provider/resource_anti_affinity_group_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceAntiAffinityGroupConfig struct {
@@ -55,11 +56,11 @@ resource "oxide_anti_affinity_group" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
-	antiAffinityGroupName := NewResourceName()
-	blockName := NewBlockName("anti_affinity_group")
+	antiAffinityGroupName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("anti_affinity_group")
 	resourceName := fmt.Sprintf("oxide_anti_affinity_group.%s", blockName)
-	supportBlockName := NewBlockName("support")
-	config, err := ParsedAccConfig(
+	supportBlockName := sharedtest.NewBlockName("support")
+	config, err := sharedtest.ParsedAccConfig(
 		resourceAntiAffinityGroupConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupName,
@@ -72,7 +73,7 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	antiAffinityGroupNameUpdated := antiAffinityGroupName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceAntiAffinityGroupConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupNameUpdated,
@@ -85,8 +86,8 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccAntiAffinityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -144,7 +145,7 @@ func checkResourceAntiAffinityGroupUpdate(
 }
 
 func testAccAntiAffinityGroupDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_disk.go
+++ b/internal/provider/resource_disk.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -106,7 +107,7 @@ func (r *diskResource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages disks.
 
 To create a blank disk it's necessary to set ''block_size''. Otherwise, one of ''source_image_id'' or ''source_snapshot_id'' must be set; ''block_size'' will be automatically calculated.
@@ -254,7 +255,7 @@ func (r *diskResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -349,7 +350,7 @@ func (r *diskResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -362,7 +363,7 @@ func (r *diskResource) Read(
 	}
 	disk, err := r.client.DiskView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -427,7 +428,7 @@ func (r *diskResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -439,7 +440,7 @@ func (r *diskResource) Delete(
 		Disk: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.DiskDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete disk:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_disk.go
+++ b/internal/provider/resource_disk.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_disk_test.go
+++ b/internal/provider/resource_disk_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceDiskConfig struct {
@@ -41,8 +42,8 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_full(t *testing.T) {
-	diskName := newResourceName()
-	config, err := parsedAccConfig(
+	diskName := NewResourceName()
+	config, err := ParsedAccConfig(
 		resourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -53,8 +54,8 @@ func TestAccCloudResourceDisk_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -85,9 +86,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_local(t *testing.T) {
-	diskName := newResourceName()
+	diskName := NewResourceName()
 
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -98,8 +99,8 @@ func TestAccCloudResourceDisk_local(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -130,9 +131,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_localSourceValidation(t *testing.T) {
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceDiskConfig{
-			DiskName: newResourceName(),
+			DiskName: NewResourceName(),
 		},
 		resourceDiskLocalInvalidConfigTpl,
 	)
@@ -141,8 +142,8 @@ func TestAccCloudResourceDisk_localSourceValidation(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
@@ -177,9 +178,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_readOnly(t *testing.T) {
-	diskName := newResourceName()
+	diskName := NewResourceName()
 
-	configReadOnly, err := parsedAccConfig(
+	configReadOnly, err := ParsedAccConfig(
 		resourceDiskReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: true,
@@ -190,7 +191,7 @@ func TestAccCloudResourceDisk_readOnly(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configReadWrite, err := parsedAccConfig(
+	configReadWrite, err := ParsedAccConfig(
 		resourceDiskReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: false,
@@ -202,8 +203,8 @@ func TestAccCloudResourceDisk_readOnly(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -258,7 +259,7 @@ func checkResourceDisk(resourceName, diskName string) resource.TestCheckFunc {
 }
 
 func testAccDiskDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -277,7 +278,7 @@ func testAccDiskDestroy(s *terraform.State) error {
 		}
 		res, err := client.DiskView(ctx, params)
 
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_disk_test.go
+++ b/internal/provider/resource_disk_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_disk_test.go
+++ b/internal/provider/resource_disk_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceDiskConfig struct {
@@ -42,8 +43,8 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_full(t *testing.T) {
-	diskName := NewResourceName()
-	config, err := ParsedAccConfig(
+	diskName := sharedtest.NewResourceName()
+	config, err := sharedtest.ParsedAccConfig(
 		resourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -54,8 +55,8 @@ func TestAccCloudResourceDisk_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -86,9 +87,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_local(t *testing.T) {
-	diskName := NewResourceName()
+	diskName := sharedtest.NewResourceName()
 
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceDiskConfig{
 			DiskName: diskName,
 		},
@@ -99,8 +100,8 @@ func TestAccCloudResourceDisk_local(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -131,9 +132,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_localSourceValidation(t *testing.T) {
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceDiskConfig{
-			DiskName: NewResourceName(),
+			DiskName: sharedtest.NewResourceName(),
 		},
 		resourceDiskLocalInvalidConfigTpl,
 	)
@@ -142,8 +143,8 @@ func TestAccCloudResourceDisk_localSourceValidation(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
@@ -178,9 +179,9 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_readOnly(t *testing.T) {
-	diskName := NewResourceName()
+	diskName := sharedtest.NewResourceName()
 
-	configReadOnly, err := ParsedAccConfig(
+	configReadOnly, err := sharedtest.ParsedAccConfig(
 		resourceDiskReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: true,
@@ -191,7 +192,7 @@ func TestAccCloudResourceDisk_readOnly(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configReadWrite, err := ParsedAccConfig(
+	configReadWrite, err := sharedtest.ParsedAccConfig(
 		resourceDiskReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: false,
@@ -203,8 +204,8 @@ func TestAccCloudResourceDisk_readOnly(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccDiskDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -259,7 +260,7 @@ func checkResourceDisk(resourceName, diskName string) resource.TestCheckFunc {
 }
 
 func testAccDiskDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_external_subnet.go
+++ b/internal/provider/resource_external_subnet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -223,7 +224,7 @@ func (r *externalSubnetResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -329,7 +330,7 @@ func (r *externalSubnetResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -343,7 +344,7 @@ func (r *externalSubnetResource) Read(
 
 	externalSubnet, err := r.client.ExternalSubnetView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -397,7 +398,7 @@ func (r *externalSubnetResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -459,7 +460,7 @@ func (r *externalSubnetResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -472,7 +473,7 @@ func (r *externalSubnetResource) Delete(
 	}
 
 	if err := r.client.ExternalSubnetDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting external subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_external_subnet.go
+++ b/internal/provider/resource_external_subnet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_external_subnet_attachment.go
+++ b/internal/provider/resource_external_subnet_attachment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -129,7 +130,7 @@ func (r *externalSubnetAttachmentResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -186,7 +187,7 @@ func (r *externalSubnetAttachmentResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -200,7 +201,7 @@ func (r *externalSubnetAttachmentResource) Read(
 
 	externalSubnet, err := r.client.ExternalSubnetView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -266,7 +267,7 @@ func (r *externalSubnetAttachmentResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -284,7 +285,7 @@ func (r *externalSubnetAttachmentResource) Delete(
 		ctx, viewParams,
 	)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -304,7 +305,7 @@ func (r *externalSubnetAttachmentResource) Delete(
 	if _, err := r.client.ExternalSubnetDetach(
 		ctx, detachParams,
 	); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error detaching external subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_external_subnet_attachment.go
+++ b/internal/provider/resource_external_subnet_attachment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_external_subnet_attachment_test.go
+++ b/internal/provider/resource_external_subnet_attachment_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type externalSubnetAttachmentTestConfig struct {
@@ -114,7 +115,7 @@ func buildExternalSubnetAttachmentConfig(
 	cfg externalSubnetAttachmentTestConfig,
 ) string {
 	t.Helper()
-	config, err := ParsedAccConfig(cfg, externalSubnetAttachmentConfigTpl)
+	config, err := sharedtest.ParsedAccConfig(cfg, externalSubnetAttachmentConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -124,7 +125,7 @@ func buildExternalSubnetAttachmentConfig(
 func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 	resourceName := "oxide_external_subnet_attachment.test"
 
-	subnet := NextSubnetCIDR(t)
+	subnet := sharedtest.NextSubnetCIDR(t)
 
 	baseConfig := externalSubnetAttachmentTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-attach",
@@ -146,8 +147,8 @@ func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 	detachedConfig.IncludeAttachment = false
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		// Note that this check isn't particularly useful, since destroying the subnet and instance
 		// will automatically destroy the attachment. We include it for completeness, but the real
 		// test is in `testAccExternalSubnetVerifyDetached` below.
@@ -193,7 +194,7 @@ func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 func TestAccResourceExternalSubnetAttachment_disappears(t *testing.T) {
 	resourceName := "oxide_external_subnet_attachment.test"
 
-	subnet := NextSubnetCIDR(t)
+	subnet := sharedtest.NextSubnetCIDR(t)
 
 	config := buildExternalSubnetAttachmentConfig(t, externalSubnetAttachmentTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-attach-pool-dis",
@@ -208,8 +209,8 @@ func TestAccResourceExternalSubnetAttachment_disappears(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +232,7 @@ func testAccExternalSubnetAttachmentDisappears(resourceName string) resource.Tes
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -253,7 +254,7 @@ func testAccExternalSubnetVerifyDetached(
 			return fmt.Errorf("resource not found: %s", subnetResourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -283,7 +284,7 @@ func testAccExternalSubnetVerifyDetached(
 }
 
 func testAccExternalSubnetAttachmentDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_external_subnet_attachment_test.go
+++ b/internal/provider/resource_external_subnet_attachment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_external_subnet_attachment_test.go
+++ b/internal/provider/resource_external_subnet_attachment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type externalSubnetAttachmentTestConfig struct {
@@ -113,7 +114,7 @@ func buildExternalSubnetAttachmentConfig(
 	cfg externalSubnetAttachmentTestConfig,
 ) string {
 	t.Helper()
-	config, err := parsedAccConfig(cfg, externalSubnetAttachmentConfigTpl)
+	config, err := ParsedAccConfig(cfg, externalSubnetAttachmentConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -123,7 +124,7 @@ func buildExternalSubnetAttachmentConfig(
 func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 	resourceName := "oxide_external_subnet_attachment.test"
 
-	subnet := nextSubnetCIDR(t)
+	subnet := NextSubnetCIDR(t)
 
 	baseConfig := externalSubnetAttachmentTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-attach",
@@ -145,8 +146,8 @@ func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 	detachedConfig.IncludeAttachment = false
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		// Note that this check isn't particularly useful, since destroying the subnet and instance
 		// will automatically destroy the attachment. We include it for completeness, but the real
 		// test is in `testAccExternalSubnetVerifyDetached` below.
@@ -192,7 +193,7 @@ func TestAccResourceExternalSubnetAttachment_full(t *testing.T) {
 func TestAccResourceExternalSubnetAttachment_disappears(t *testing.T) {
 	resourceName := "oxide_external_subnet_attachment.test"
 
-	subnet := nextSubnetCIDR(t)
+	subnet := NextSubnetCIDR(t)
 
 	config := buildExternalSubnetAttachmentConfig(t, externalSubnetAttachmentTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-attach-pool-dis",
@@ -207,8 +208,8 @@ func TestAccResourceExternalSubnetAttachment_disappears(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -230,7 +231,7 @@ func testAccExternalSubnetAttachmentDisappears(resourceName string) resource.Tes
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -252,7 +253,7 @@ func testAccExternalSubnetVerifyDetached(
 			return fmt.Errorf("resource not found: %s", subnetResourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -282,7 +283,7 @@ func testAccExternalSubnetVerifyDetached(
 }
 
 func testAccExternalSubnetAttachmentDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -298,7 +299,7 @@ func testAccExternalSubnetAttachmentDestroy(s *terraform.State) error {
 			ctx,
 			oxide.ExternalSubnetViewParams{ExternalSubnet: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		if err == nil && res.InstanceId != "" {

--- a/internal/provider/resource_external_subnet_test.go
+++ b/internal/provider/resource_external_subnet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // externalSubnetTestConfig holds parameters for generating test configurations.
@@ -87,7 +88,7 @@ resource "oxide_external_subnet" "test" {
 
 func buildExternalSubnetConfig(t *testing.T, cfg externalSubnetTestConfig) string {
 	t.Helper()
-	config, err := parsedAccConfig(cfg, externalSubnetConfigTpl)
+	config, err := ParsedAccConfig(cfg, externalSubnetConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 	resourceName := "oxide_external_subnet.test"
 	var originalID string
 
-	poolMemberSubnet := nextSubnetCIDR(t)
+	poolMemberSubnet := NextSubnetCIDR(t)
 
 	baseConfig := externalSubnetTestConfig{
 		PoolName:         "terraform-acc-ext-subnet-pool",
@@ -132,8 +133,8 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 	replaceConfig.SubnetPool = "oxide_subnet_pool.test.id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -157,7 +158,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_pool_member_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 					resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-					testAccCaptureResourceID(resourceName, &originalID),
+					CaptureResourceID(resourceName, &originalID),
 				),
 			},
 			// Update in place.
@@ -181,7 +182,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 			{
 				Config: buildExternalSubnetConfig(t, replaceConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccVerifyResourceIDChanged(resourceName, &originalID),
+					VerifyResourceIDChanged(resourceName, &originalID),
 					resource.TestCheckResourceAttr(resourceName, "prefix_len", "29"),
 				),
 			},
@@ -203,7 +204,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 func TestAccResourceExternalSubnet_explicit(t *testing.T) {
 	resourceName := "oxide_external_subnet.test"
 
-	subnet := nextSubnetCIDR(t)
+	subnet := NextSubnetCIDR(t)
 
 	config := buildExternalSubnetConfig(t, externalSubnetTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-pool-explicit",
@@ -218,8 +219,8 @@ func TestAccResourceExternalSubnet_explicit(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -247,7 +248,7 @@ func TestAccResourceExternalSubnet_withPool(t *testing.T) {
 		PoolName:          "terraform-acc-ext-subnet-pool-with-pool",
 		PoolDescription:   "a subnet pool for pool selection tests",
 		PoolIPVersion:     "v4",
-		PoolMemberSubnet:  nextSubnetCIDR(t),
+		PoolMemberSubnet:  NextSubnetCIDR(t),
 		MaxPrefixLength:   30,
 		IsDefault:         false,
 		SubnetName:        "terraform-acc-external-subnet-with-pool",
@@ -257,8 +258,8 @@ func TestAccResourceExternalSubnet_withPool(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -290,7 +291,7 @@ func TestAccResourceExternalSubnet_disappears(t *testing.T) {
 		PoolName:          "terraform-acc-ext-subnet-pool-disappears",
 		PoolDescription:   "a subnet pool for disappears test",
 		PoolIPVersion:     "v4",
-		PoolMemberSubnet:  nextSubnetCIDR(t),
+		PoolMemberSubnet:  NextSubnetCIDR(t),
 		MaxPrefixLength:   30,
 		IsDefault:         false,
 		SubnetName:        "terraform-acc-external-subnet-disappears",
@@ -300,8 +301,8 @@ func TestAccResourceExternalSubnet_disappears(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -323,7 +324,7 @@ func testAccExternalSubnetDisappears(resourceName string) resource.TestCheckFunc
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -353,8 +354,8 @@ func TestAccResourceExternalSubnet_v6(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -377,7 +378,7 @@ func TestAccResourceExternalSubnet_v6(t *testing.T) {
 }
 
 func testAccExternalSubnetDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -393,7 +394,7 @@ func testAccExternalSubnetDestroy(s *terraform.State) error {
 			ctx,
 			oxide.ExternalSubnetViewParams{ExternalSubnet: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		if err == nil {

--- a/internal/provider/resource_external_subnet_test.go
+++ b/internal/provider/resource_external_subnet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_external_subnet_test.go
+++ b/internal/provider/resource_external_subnet_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 // externalSubnetTestConfig holds parameters for generating test configurations.
@@ -88,7 +89,7 @@ resource "oxide_external_subnet" "test" {
 
 func buildExternalSubnetConfig(t *testing.T, cfg externalSubnetTestConfig) string {
 	t.Helper()
-	config, err := ParsedAccConfig(cfg, externalSubnetConfigTpl)
+	config, err := sharedtest.ParsedAccConfig(cfg, externalSubnetConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 	resourceName := "oxide_external_subnet.test"
 	var originalID string
 
-	poolMemberSubnet := NextSubnetCIDR(t)
+	poolMemberSubnet := sharedtest.NextSubnetCIDR(t)
 
 	baseConfig := externalSubnetTestConfig{
 		PoolName:         "terraform-acc-ext-subnet-pool",
@@ -133,8 +134,8 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 	replaceConfig.SubnetPool = "oxide_subnet_pool.test.id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +159,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_pool_member_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 					resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
-					CaptureResourceID(resourceName, &originalID),
+					sharedtest.CaptureResourceID(resourceName, &originalID),
 				),
 			},
 			// Update in place.
@@ -182,7 +183,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 			{
 				Config: buildExternalSubnetConfig(t, replaceConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					VerifyResourceIDChanged(resourceName, &originalID),
+					sharedtest.VerifyResourceIDChanged(resourceName, &originalID),
 					resource.TestCheckResourceAttr(resourceName, "prefix_len", "29"),
 				),
 			},
@@ -204,7 +205,7 @@ func TestAccResourceExternalSubnet_full(t *testing.T) {
 func TestAccResourceExternalSubnet_explicit(t *testing.T) {
 	resourceName := "oxide_external_subnet.test"
 
-	subnet := NextSubnetCIDR(t)
+	subnet := sharedtest.NextSubnetCIDR(t)
 
 	config := buildExternalSubnetConfig(t, externalSubnetTestConfig{
 		PoolName:          "terraform-acc-ext-subnet-pool-explicit",
@@ -219,8 +220,8 @@ func TestAccResourceExternalSubnet_explicit(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -248,7 +249,7 @@ func TestAccResourceExternalSubnet_withPool(t *testing.T) {
 		PoolName:          "terraform-acc-ext-subnet-pool-with-pool",
 		PoolDescription:   "a subnet pool for pool selection tests",
 		PoolIPVersion:     "v4",
-		PoolMemberSubnet:  NextSubnetCIDR(t),
+		PoolMemberSubnet:  sharedtest.NextSubnetCIDR(t),
 		MaxPrefixLength:   30,
 		IsDefault:         false,
 		SubnetName:        "terraform-acc-external-subnet-with-pool",
@@ -258,8 +259,8 @@ func TestAccResourceExternalSubnet_withPool(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -291,7 +292,7 @@ func TestAccResourceExternalSubnet_disappears(t *testing.T) {
 		PoolName:          "terraform-acc-ext-subnet-pool-disappears",
 		PoolDescription:   "a subnet pool for disappears test",
 		PoolIPVersion:     "v4",
-		PoolMemberSubnet:  NextSubnetCIDR(t),
+		PoolMemberSubnet:  sharedtest.NextSubnetCIDR(t),
 		MaxPrefixLength:   30,
 		IsDefault:         false,
 		SubnetName:        "terraform-acc-external-subnet-disappears",
@@ -301,8 +302,8 @@ func TestAccResourceExternalSubnet_disappears(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -324,7 +325,7 @@ func testAccExternalSubnetDisappears(resourceName string) resource.TestCheckFunc
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -354,8 +355,8 @@ func TestAccResourceExternalSubnet_v6(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccExternalSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -378,7 +379,7 @@ func TestAccResourceExternalSubnet_v6(t *testing.T) {
 }
 
 func testAccExternalSubnetDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_floating_ip.go
+++ b/internal/provider/resource_floating_ip.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // floatingIPResourceModel represents the Terraform configuration and state for
@@ -201,7 +202,7 @@ func (f *floatingIPResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -289,7 +290,7 @@ func (f *floatingIPResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -304,7 +305,7 @@ func (f *floatingIPResource) Read(
 
 	floatingIP, err := f.client.FloatingIpView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -358,7 +359,7 @@ func (f *floatingIPResource) Update(
 		return
 	}
 
-	updateTimeout, diags := state.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := state.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -419,7 +420,7 @@ func (f *floatingIPResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -433,7 +434,7 @@ func (f *floatingIPResource) Delete(
 	}
 
 	if err := f.client.FloatingIpDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete floating IP:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_floating_ip_test.go
+++ b/internal/provider/resource_floating_ip_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_floating_ip_test.go
+++ b/internal/provider/resource_floating_ip_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceFloatingIPConfig struct {
@@ -86,11 +87,11 @@ resource "oxide_floating_ip" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceFloatingIP_full(t *testing.T) {
-	floatingIPName := NewResourceName()
-	blockName := NewBlockName("floating_ip")
+	floatingIPName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("floating_ip")
 	resourceName := fmt.Sprintf("oxide_floating_ip.%s", blockName)
-	supportBlockName := NewBlockName("support")
-	config, err := ParsedAccConfig(
+	supportBlockName := sharedtest.NewBlockName("support")
+	config, err := sharedtest.ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -103,7 +104,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 	}
 
 	floatingIPNameUpdated := floatingIPName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPNameUpdated,
@@ -115,7 +116,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configV6, err := ParsedAccConfig(
+	configV6, err := sharedtest.ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -127,7 +128,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configNonDefaultPool, err := ParsedAccConfig(
+	configNonDefaultPool, err := sharedtest.ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -140,8 +141,8 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -235,7 +236,7 @@ func checkResourceFloatingIPNonDefaultPool(
 }
 
 func testAccFloatingIPDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_floating_ip_test.go
+++ b/internal/provider/resource_floating_ip_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceFloatingIPConfig struct {
@@ -85,11 +86,11 @@ resource "oxide_floating_ip" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceFloatingIP_full(t *testing.T) {
-	floatingIPName := newResourceName()
-	blockName := newBlockName("floating_ip")
+	floatingIPName := NewResourceName()
+	blockName := NewBlockName("floating_ip")
 	resourceName := fmt.Sprintf("oxide_floating_ip.%s", blockName)
-	supportBlockName := newBlockName("support")
-	config, err := parsedAccConfig(
+	supportBlockName := NewBlockName("support")
+	config, err := ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -102,7 +103,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 	}
 
 	floatingIPNameUpdated := floatingIPName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPNameUpdated,
@@ -114,7 +115,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configV6, err := parsedAccConfig(
+	configV6, err := ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -126,7 +127,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configNonDefaultPool, err := parsedAccConfig(
+	configNonDefaultPool, err := ParsedAccConfig(
 		resourceFloatingIPConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -139,8 +140,8 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -234,7 +235,7 @@ func checkResourceFloatingIPNonDefaultPool(
 }
 
 func testAccFloatingIPDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -253,7 +254,7 @@ func testAccFloatingIPDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.FloatingIpView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 
@@ -264,14 +265,14 @@ func testAccFloatingIPDestroy(s *terraform.State) error {
 }
 
 func testAccFloatingIPIsV4(value string) error {
-	if !isIPv4(value) {
+	if !shared.IsIPv4(value) {
 		return fmt.Errorf("expected %s to be IPv4", value)
 	}
 	return nil
 }
 
 func testAccFloatingIPIsV6(value string) error {
-	if !isIPv6(value) {
+	if !shared.IsIPv6(value) {
 		return fmt.Errorf("expected %s to be IPv6", value)
 	}
 	return nil

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_image.go
+++ b/internal/provider/resource_image.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -122,7 +123,7 @@ This resource manages images.
 			},
 			"os": schema.StringAttribute{
 				Required: true,
-				MarkdownDescription: replaceBackticks(
+				MarkdownDescription: shared.ReplaceBackticks(
 					`OS image distribution. Example: ''"alpine"''.`,
 				),
 				PlanModifiers: []planmodifier.String{
@@ -130,8 +131,10 @@ This resource manages images.
 				},
 			},
 			"version": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: replaceBackticks(`OS image version. Example: ''"3.16"''.`),
+				Required: true,
+				MarkdownDescription: shared.ReplaceBackticks(
+					`OS image version. Example: ''"3.16"''.`,
+				),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -200,7 +203,7 @@ func (r *imageResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -297,7 +300,7 @@ func (r *imageResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -310,7 +313,7 @@ func (r *imageResource) Read(
 	}
 	image, err := r.client.ImageView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -407,7 +410,7 @@ func (r *imageResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -418,7 +421,7 @@ func (r *imageResource) Delete(
 	if err := r.client.ImageDelete(ctx, oxide.ImageDeleteParams{
 		Image: oxide.NameOrId(state.ID.ValueString()),
 	}); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to read image:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_image_test.go
+++ b/internal/provider/resource_image_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_image_test.go
+++ b/internal/provider/resource_image_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceImageConfig struct {
@@ -71,19 +72,19 @@ var resourceImageConfigTpl = `
  `
 
 func TestAccCloudResourceImage_full(t *testing.T) {
-	imageName := newResourceName()
-	blockName := newBlockName("image")
-	supportBlockName := newBlockName("support")
+	imageName := NewResourceName()
+	blockName := NewBlockName("image")
+	supportBlockName := NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_image.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceImageConfig{
 			BlockName:         blockName,
 			ImageName:         imageName,
-			DiskName:          newResourceName(),
-			SnapshotName:      newResourceName(),
+			DiskName:          NewResourceName(),
+			SnapshotName:      NewResourceName(),
 			SupportBlockName:  supportBlockName,
-			DiskBlockName:     newBlockName("support"),
-			SnapshotBlockName: newBlockName("support"),
+			DiskBlockName:     NewBlockName("support"),
+			SnapshotBlockName: NewBlockName("support"),
 		},
 		resourceImageConfigTpl,
 	)
@@ -92,8 +93,8 @@ func TestAccCloudResourceImage_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccImageDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -127,7 +128,7 @@ func checkResourceImage(resourceName, imageName string) resource.TestCheckFunc {
 }
 
 func testAccImageDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func testAccImageDestroy(s *terraform.State) error {
 		}
 		res, err := client.ImageView(ctx, params)
 
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_image_test.go
+++ b/internal/provider/resource_image_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceImageConfig struct {
@@ -72,19 +73,19 @@ var resourceImageConfigTpl = `
  `
 
 func TestAccCloudResourceImage_full(t *testing.T) {
-	imageName := NewResourceName()
-	blockName := NewBlockName("image")
-	supportBlockName := NewBlockName("support")
+	imageName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("image")
+	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_image.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceImageConfig{
 			BlockName:         blockName,
 			ImageName:         imageName,
-			DiskName:          NewResourceName(),
-			SnapshotName:      NewResourceName(),
+			DiskName:          sharedtest.NewResourceName(),
+			SnapshotName:      sharedtest.NewResourceName(),
 			SupportBlockName:  supportBlockName,
-			DiskBlockName:     NewBlockName("support"),
-			SnapshotBlockName: NewBlockName("support"),
+			DiskBlockName:     sharedtest.NewBlockName("support"),
+			SnapshotBlockName: sharedtest.NewBlockName("support"),
 		},
 		resourceImageConfigTpl,
 	)
@@ -93,8 +94,8 @@ func TestAccCloudResourceImage_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccImageDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -128,7 +129,7 @@ func checkResourceImage(resourceName, imageName string) resource.TestCheckFunc {
 }
 
 func testAccImageDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -880,7 +880,7 @@ func (r *instanceResource) Create(
 	// The control plane API counts the BootDisk and the Disk attachments when it calculates the
 	// limit on disk attachments. If bootdisk is set explicitly, we don't want it to be in the API
 	// call, but we need it in the state entry.
-	params.Body.Disks = filterBootDiskFromDisks(disks, params.Body.BootDisk)
+	params.Body.Disks = FilterBootDiskFromDisks(disks, params.Body.BootDisk)
 
 	externalIPs := newExternalIPsOnCreate(plan.ExternalIPs)
 	params.Body.ExternalIps = externalIPs
@@ -1921,7 +1921,7 @@ func diskAttachmentName(d oxide.InstanceDiskAttachment) oxide.Name {
 	}
 }
 
-func filterBootDiskFromDisks(
+func FilterBootDiskFromDisks(
 	disks []oxide.InstanceDiskAttachment,
 	bootDisk oxide.InstanceDiskAttachment,
 ) []oxide.InstanceDiskAttachment {

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -227,7 +228,7 @@ func (r *instanceResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		Version: 2,
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages instances.
 
 !> Updates will stop and start the instance.
@@ -341,7 +342,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -351,7 +352,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -360,7 +361,7 @@ This resource manages instances.
 							Description: "ID of the VPC subnet in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -369,7 +370,7 @@ This resource manages instances.
 							Description: "ID of the VPC in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -785,7 +786,7 @@ func (r *instanceResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -856,14 +857,14 @@ func (r *instanceResource) Create(
 		}
 	}
 
-	sshKeys, diags := newNameOrIdList(plan.SSHPublicKeys)
+	sshKeys, diags := shared.NewNameOrIdList(plan.SSHPublicKeys)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	params.Body.SshPublicKeys = sshKeys
 
-	antiAffinityGroupIDs, diags := newNameOrIdList(plan.AntiAffinityGroups)
+	antiAffinityGroupIDs, diags := shared.NewNameOrIdList(plan.AntiAffinityGroups)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -960,7 +961,7 @@ func (r *instanceResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -973,7 +974,7 @@ func (r *instanceResource) Read(
 	}
 	instance, err := r.client.InstanceView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -1099,7 +1100,7 @@ func (r *instanceResource) Update(
 		return
 	}
 
-	updateTimeout, diags := state.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := state.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1113,7 +1114,7 @@ func (r *instanceResource) Update(
 	}
 	_, err := r.client.InstanceStop(ctx, stopParams)
 	if err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to stop instance:",
 				"API error: "+err.Error(),
@@ -1141,7 +1142,7 @@ func (r *instanceResource) Update(
 	stateDisks := state.DiskAttachments.Elements()
 
 	// Check plan and if it has an ID that the state doesn't then attach it
-	disksToAttach := sliceDiff(planDisks, stateDisks)
+	disksToAttach := shared.SliceDiff(planDisks, stateDisks)
 	resp.Diagnostics.Append(attachDisks(ctx, r.client, disksToAttach, state.ID.ValueString())...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1191,7 +1192,7 @@ func (r *instanceResource) Update(
 	//
 	// We only detach disks once we have made changes to the boot disk (if any)
 	// in case we need to remove the previous boot disk
-	disksToDetach := sliceDiff(stateDisks, planDisks)
+	disksToDetach := shared.SliceDiff(stateDisks, planDisks)
 	resp.Diagnostics.Append(detachDisks(ctx, r.client, disksToDetach, state.ID.ValueString())...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1221,7 +1222,7 @@ func (r *instanceResource) Update(
 	// For example, each network interface needs to be in a separate subnet, so
 	// we must first make room for new network interface if it is replacing one
 	// in the same subnet.
-	nicsToDelete := sliceDiffByID(
+	nicsToDelete := shared.SliceDiffByID(
 		state.NetworkInterfaces,
 		plan.NetworkInterfaces,
 		func(e instanceResourceNICModel) any {
@@ -1249,7 +1250,7 @@ func (r *instanceResource) Update(
 	}
 
 	// Add new network interfaces.
-	nicsToCreate := sliceDiffByID(
+	nicsToCreate := shared.SliceDiffByID(
 		plan.NetworkInterfaces,
 		state.NetworkInterfaces,
 		func(e instanceResourceNICModel) any {
@@ -1279,7 +1280,7 @@ func (r *instanceResource) Update(
 	stateAntiAffinityGroups := state.AntiAffinityGroups.Elements()
 
 	// Check plan and if it has an ID that the state doesn't then add it
-	antiAffinityGroupsToAdd := sliceDiff(planAntiAffinityGroups, stateAntiAffinityGroups)
+	antiAffinityGroupsToAdd := shared.SliceDiff(planAntiAffinityGroups, stateAntiAffinityGroups)
 	resp.Diagnostics.Append(
 		addAntiAffinityGroups(ctx, r.client, antiAffinityGroupsToAdd, state.ID.ValueString())...)
 	if resp.Diagnostics.HasError() {
@@ -1287,7 +1288,7 @@ func (r *instanceResource) Update(
 	}
 
 	// Check state and if it has an ID that the plan doesn't then remove it
-	antiAffinityGroupsToRemove := sliceDiff(stateAntiAffinityGroups, planAntiAffinityGroups)
+	antiAffinityGroupsToRemove := shared.SliceDiff(stateAntiAffinityGroups, planAntiAffinityGroups)
 	resp.Diagnostics.Append(
 		removeAntiAffinityGroups(
 			ctx,
@@ -1302,7 +1303,7 @@ func (r *instanceResource) Update(
 	startParams := oxide.InstanceStartParams{Instance: oxide.NameOrId(state.ID.ValueString())}
 	_, err = r.client.InstanceStart(ctx, startParams)
 	if err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to start instance:",
 				"API error: "+err.Error(),
@@ -1400,7 +1401,7 @@ func (r *instanceResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1413,7 +1414,7 @@ func (r *instanceResource) Delete(
 	}
 	_, err := r.client.InstanceStop(ctx, params)
 	if err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to stop instance:",
 				"API error: "+err.Error(),
@@ -1437,7 +1438,7 @@ func (r *instanceResource) Delete(
 		Instance: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.InstanceDelete(ctx, params2); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete instance:",
 				"API error: "+err.Error(),
@@ -1481,7 +1482,7 @@ func waitForInstanceStop(
 			}
 			instance, err := client.InstanceView(ctx, params)
 			if err != nil {
-				if !is404(err) {
+				if !shared.Is404(err) {
 					return nil, "nil", fmt.Errorf(
 						"while polling for the status of instance %v: %v",
 						instanceID,
@@ -1499,7 +1500,7 @@ func waitForInstanceStop(
 		},
 	}
 	if _, err := stateConfig.WaitForStateContext(ctx); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			diags.AddError(
 				"Error stopping instance",
 				"API error: "+err.Error(),
@@ -1796,9 +1797,9 @@ func newAttachedExternalIPModel(
 			// the IP address so it is always present in state, even if the
 			// user does not provide it.
 			var ipVersion string
-			if isIPv4(v.Ip) {
+			if shared.IsIPv4(v.Ip) {
 				ipVersion = string(oxide.IpVersionV4)
-			} else if isIPv6(v.Ip) {
+			} else if shared.IsIPv6(v.Ip) {
 				ipVersion = string(oxide.IpVersionV6)
 			}
 
@@ -2112,7 +2113,7 @@ func deleteNICs(
 			Interface: oxide.NameOrId(model.ID.ValueString()),
 		}
 		if err := client.InstanceNetworkInterfaceDelete(ctx, params); err != nil {
-			if !is404(err) {
+			if !shared.Is404(err) {
 				diags.AddError(
 					"Error deleting instance network interface:",
 					"API error: "+err.Error(),
@@ -2165,7 +2166,7 @@ func attachEphemeralIPs(
 	if state == nil {
 		ipsToAttach = plan.Ephemeral
 	} else {
-		ipsToAttach = sliceDiff(plan.Ephemeral, state.Ephemeral)
+		ipsToAttach = shared.SliceDiff(plan.Ephemeral, state.Ephemeral)
 	}
 
 	var diags diag.Diagnostics
@@ -2230,7 +2231,7 @@ func attachFloatingIPs(
 	if state == nil {
 		ipsToAttach = plan.Floating
 	} else {
-		ipsToAttach = sliceDiff(plan.Floating, state.Floating)
+		ipsToAttach = shared.SliceDiff(plan.Floating, state.Floating)
 	}
 
 	var diags diag.Diagnostics
@@ -2300,7 +2301,7 @@ func detachEphemeralIPs(
 	if plan == nil {
 		ipsToDetach = state.Ephemeral
 	} else {
-		ipsToDetach = sliceDiff(state.Ephemeral, plan.Ephemeral)
+		ipsToDetach = shared.SliceDiff(state.Ephemeral, plan.Ephemeral)
 	}
 
 	var diags diag.Diagnostics
@@ -2353,7 +2354,7 @@ func detachFloatingIPs(
 	if plan == nil {
 		ipsToDetach = state.Floating
 	} else {
-		ipsToDetach = sliceDiff(state.Floating, plan.Floating)
+		ipsToDetach = shared.SliceDiff(state.Floating, plan.Floating)
 	}
 
 	var diags diag.Diagnostics
@@ -2540,7 +2541,7 @@ func removeAntiAffinityGroups(
 		if err != nil {
 			// If the anti-affinity group doesn't exist anymore, it means
 			// the instance isn't part of it. We can just return.
-			if is404(err) {
+			if shared.Is404(err) {
 				return nil
 			}
 			diags.AddError(
@@ -2606,11 +2607,11 @@ func (v ipConfigValidator) ValidateString(
 	switch v.ipVersion {
 	case oxide.IpVersionV4:
 		valid = (value == string(oxide.Ipv4AssignmentTypeAuto) ||
-			isIPv4(req.ConfigValue.ValueString()))
+			shared.IsIPv4(req.ConfigValue.ValueString()))
 
 	case oxide.IpVersionV6:
 		valid = (value == string(oxide.Ipv6AssignmentTypeAuto) ||
-			isIPv6(req.ConfigValue.ValueString()))
+			shared.IsIPv6(req.ConfigValue.ValueString()))
 	}
 
 	if !valid {

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -16,7 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccCloudResourceInstance_full(t *testing.T) {
@@ -154,11 +156,11 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceName := NewResourceName()
-	blockName := NewBlockName("instance")
-	supportBlockName := NewBlockName("support")
+	instanceName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance")
+	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -170,21 +172,21 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	instanceName2 := NewResourceName()
-	instanceDiskName := NewResourceName()
-	instanceNicName := NewResourceName()
-	instanceFloatingIPName := NewResourceName()
-	instanceSshKeyName := NewResourceName()
-	instanceAaGroupName := NewResourceName()
-	blockName2 := NewBlockName("instance")
-	diskBlockName := NewBlockName("disk")
-	supportBlockName3 := NewBlockName("support")
-	supportBlockName2 := NewBlockName("support")
-	supportBlockNameSSHKeys := NewBlockName("support-instance-ssh-keys")
-	supportBlockNameAaGroup := NewBlockName("support-instance-anti-affinity-group")
+	instanceName2 := sharedtest.NewResourceName()
+	instanceDiskName := sharedtest.NewResourceName()
+	instanceNicName := sharedtest.NewResourceName()
+	instanceFloatingIPName := sharedtest.NewResourceName()
+	instanceSshKeyName := sharedtest.NewResourceName()
+	instanceAaGroupName := sharedtest.NewResourceName()
+	blockName2 := sharedtest.NewBlockName("instance")
+	diskBlockName := sharedtest.NewBlockName("disk")
+	supportBlockName3 := sharedtest.NewBlockName("support")
+	supportBlockName2 := sharedtest.NewBlockName("support")
+	supportBlockNameSSHKeys := sharedtest.NewBlockName("support-instance-ssh-keys")
+	supportBlockNameAaGroup := sharedtest.NewBlockName("support-instance-anti-affinity-group")
 	resourceName2 := fmt.Sprintf("oxide_instance.%s", blockName2)
 	autoRestartPolicy := "best_effort"
-	config2, err := ParsedAccConfig(
+	config2, err := sharedtest.ParsedAccConfig(
 		resourceInstanceFullConfig{
 			BlockName:                  blockName2,
 			InstanceName:               instanceName2,
@@ -207,8 +209,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -473,13 +475,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 		ipPoolName = "default"
 	}
 
-	instanceName := NewResourceName()
-	floatingIPName := NewResourceName()
-	blockName := NewBlockName("instance")
-	supportBlockName := NewBlockName("support")
-	ipPoolBlockName := NewBlockName("ip-pool")
+	instanceName := sharedtest.NewResourceName()
+	floatingIPName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance")
+	supportBlockName := sharedtest.NewBlockName("support")
+	ipPoolBlockName := sharedtest.NewBlockName("ip-pool")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	initialConfig, err := ParsedAccConfig(
+	initialConfig, err := sharedtest.ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -494,7 +496,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing initial config template data: %e", err)
 	}
 
-	updateConfig1, err := ParsedAccConfig(
+	updateConfig1, err := sharedtest.ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -507,7 +509,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing first update config template data: %e", err)
 	}
 
-	updateConfig1SingleStack, err := ParsedAccConfig(
+	updateConfig1SingleStack, err := sharedtest.ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -520,7 +522,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing first update single stack config template data: %e", err)
 	}
 
-	updateConfig2, err := ParsedAccConfig(
+	updateConfig2, err := sharedtest.ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -534,8 +536,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			// Ephemeral external IP with specified IP pool ID.
@@ -614,13 +616,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceSshKeysName := NewResourceName()
-	instanceSshKeysName2 := NewResourceName()
-	blockNameSshKeys := NewBlockName("instance-ssh-keys")
-	supportBlockNameSshKeys := NewBlockName("support-instance-ssh-keys")
-	supportBlockNameSshKeys2 := NewBlockName("support-instance-ssh-keys-2")
+	instanceSshKeysName := sharedtest.NewResourceName()
+	instanceSshKeysName2 := sharedtest.NewResourceName()
+	blockNameSshKeys := sharedtest.NewBlockName("instance-ssh-keys")
+	supportBlockNameSshKeys := sharedtest.NewBlockName("support-instance-ssh-keys")
+	supportBlockNameSshKeys2 := sharedtest.NewBlockName("support-instance-ssh-keys-2")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameSshKeys)
-	configSshKeys, err := ParsedAccConfig(
+	configSshKeys, err := sharedtest.ParsedAccConfig(
 		resourceInstanceSshKeyConfig{
 			BlockName:         blockNameSshKeys,
 			SshKeyName:        instanceSshKeysName2,
@@ -635,8 +637,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -870,17 +872,17 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceNicName := NewResourceName()
-	nicName := NewResourceName()
-	blockNameSubnet := NewBlockName("instance-nic-subnet")
-	blockNameInstanceNic := NewBlockName("instance-nic")
-	supportBlockName := NewBlockName("support")
-	supportBlockName2 := NewBlockName("support")
+	instanceNicName := sharedtest.NewResourceName()
+	nicName := sharedtest.NewResourceName()
+	blockNameSubnet := sharedtest.NewBlockName("instance-nic-subnet")
+	blockNameInstanceNic := sharedtest.NewBlockName("instance-nic")
+	supportBlockName := sharedtest.NewBlockName("support")
+	supportBlockName2 := sharedtest.NewBlockName("support")
 	resourceNameInstanceNic := fmt.Sprintf("oxide_instance.%s", blockNameInstanceNic)
-	nonDefaultSubnetName := NewResourceName()
+	nonDefaultSubnetName := sharedtest.NewResourceName()
 	nonDefaultSubnetIPv4Block := fmt.Sprintf("10.%d.%d.0/24", rand.IntN(255), rand.IntN(255))
 	nonDefaultSubnetIPv6NetNum := rand.IntN(200)
-	configNic, err := ParsedAccConfig(
+	configNic, err := sharedtest.ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -896,7 +898,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicAdd, err := ParsedAccConfig(
+	configNicAdd, err := sharedtest.ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -912,7 +914,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicUpdateSingleStack, err := ParsedAccConfig(
+	configNicUpdateSingleStack, err := sharedtest.ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -928,7 +930,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicDelete, err := ParsedAccConfig(
+	configNicDelete, err := sharedtest.ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -946,8 +948,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1081,16 +1083,16 @@ resource "oxide_instance" "{{.BlockName}}" {
   disk_attachments = [oxide_disk.{{.DiskBlockName}}.id]
 }
 `
-	instanceDiskName := NewResourceName()
-	diskName := NewResourceName()
-	diskName2 := NewResourceName()
-	supportBlockName := NewBlockName("support")
-	supportBlockName2 := NewBlockName("support-update")
-	blockNameInstance := NewBlockName("instance")
-	blockNameInstanceDisk := NewBlockName("instance-disk")
-	blockNameInstanceDisk2 := NewBlockName("instance-disk-2")
+	instanceDiskName := sharedtest.NewResourceName()
+	diskName := sharedtest.NewResourceName()
+	diskName2 := sharedtest.NewResourceName()
+	supportBlockName := sharedtest.NewBlockName("support")
+	supportBlockName2 := sharedtest.NewBlockName("support-update")
+	blockNameInstance := sharedtest.NewBlockName("instance")
+	blockNameInstanceDisk := sharedtest.NewBlockName("instance-disk")
+	blockNameInstanceDisk2 := sharedtest.NewBlockName("instance-disk-2")
 	resourceNameInstanceDisk := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	configDisk, err := ParsedAccConfig(
+	configDisk, err := sharedtest.ParsedAccConfig(
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1105,7 +1107,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configDiskUpdate, err := ParsedAccConfig(
+	configDiskUpdate, err := sharedtest.ParsedAccConfig(
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1122,8 +1124,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1206,12 +1208,12 @@ resource "oxide_instance" "{{.BlockName}}" {
   start_on_create = true
 }
 `
-	instanceName := NewResourceName()
-	supportBlockName := NewBlockName("support")
-	supportBlockName2 := NewBlockName("support-update")
-	blockNameInstance := NewBlockName("instance")
+	instanceName := sharedtest.NewResourceName()
+	supportBlockName := sharedtest.NewBlockName("support")
+	supportBlockName2 := sharedtest.NewBlockName("support-update")
+	blockNameInstance := sharedtest.NewBlockName("instance")
 	resourceNameInstance := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1223,7 +1225,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1235,7 +1237,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate2, err := ParsedAccConfig(
+	configUpdate2, err := sharedtest.ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1248,8 +1250,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1317,13 +1319,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceName := NewResourceName()
-	diskName := NewResourceName()
-	blockName := NewBlockName("instance-no-boot-disk")
-	diskBlockName := NewBlockName("disk")
-	supportBlockName := NewBlockName("support")
+	instanceName := sharedtest.NewResourceName()
+	diskName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance-no-boot-disk")
+	diskBlockName := sharedtest.NewBlockName("disk")
+	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceInstanceNoBootDiskConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -1338,8 +1340,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1455,15 +1457,21 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceAntiAffinityGroupsName := NewResourceName()
-	antiAffinityGroupName1 := NewResourceName()
-	antiAffinityGroupName2 := NewResourceName()
-	blockNameAntiAffinityGroups := NewBlockName("instance-anti-affinity-groups")
-	supportBlockNameAntiAffinityGroups := NewBlockName("support-instance-anti-affinity-groups")
-	supportBlockNameAntiAffinityGroup1 := NewBlockName("support-instance-anti-affinity-group")
-	supportBlockNameAntiAffinityGroup2 := NewBlockName("support-instance-anti-affinity-group")
+	instanceAntiAffinityGroupsName := sharedtest.NewResourceName()
+	antiAffinityGroupName1 := sharedtest.NewResourceName()
+	antiAffinityGroupName2 := sharedtest.NewResourceName()
+	blockNameAntiAffinityGroups := sharedtest.NewBlockName("instance-anti-affinity-groups")
+	supportBlockNameAntiAffinityGroups := sharedtest.NewBlockName(
+		"support-instance-anti-affinity-groups",
+	)
+	supportBlockNameAntiAffinityGroup1 := sharedtest.NewBlockName(
+		"support-instance-anti-affinity-group",
+	)
+	supportBlockNameAntiAffinityGroup2 := sharedtest.NewBlockName(
+		"support-instance-anti-affinity-group",
+	)
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameAntiAffinityGroups)
-	configAntiAffinityGroups, err := ParsedAccConfig(
+	configAntiAffinityGroups, err := sharedtest.ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                  blockNameAntiAffinityGroups,
 			InstanceName:               instanceAntiAffinityGroupsName,
@@ -1477,7 +1485,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configAntiAffinityGroupsUpdate, err := ParsedAccConfig(
+	configAntiAffinityGroupsUpdate, err := sharedtest.ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1493,7 +1501,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configAntiAffinityGroupsUpdate2, err := ParsedAccConfig(
+	configAntiAffinityGroupsUpdate2, err := sharedtest.ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1510,8 +1518,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1987,7 +1995,7 @@ func testResourceInstanceNetworkInterface(
 }
 
 func testAccInstanceDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -2079,7 +2087,7 @@ func TestFilterBootDiskFromDisks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		disks := filterBootDiskFromDisks(tt.disks, tt.bootDisk)
+		disks := provider.FilterBootDiskFromDisks(tt.disks, tt.bootDisk)
 		if !reflect.DeepEqual(disks, tt.want) {
 			t.Errorf("want: %+v, got: %+v", tt.want, disks)
 		}

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccCloudResourceInstance_full(t *testing.T) {
@@ -153,11 +154,11 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceName := newResourceName()
-	blockName := newBlockName("instance")
-	supportBlockName := newBlockName("support")
+	instanceName := NewResourceName()
+	blockName := NewBlockName("instance")
+	supportBlockName := NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -169,21 +170,21 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	instanceName2 := newResourceName()
-	instanceDiskName := newResourceName()
-	instanceNicName := newResourceName()
-	instanceFloatingIPName := newResourceName()
-	instanceSshKeyName := newResourceName()
-	instanceAaGroupName := newResourceName()
-	blockName2 := newBlockName("instance")
-	diskBlockName := newBlockName("disk")
-	supportBlockName3 := newBlockName("support")
-	supportBlockName2 := newBlockName("support")
-	supportBlockNameSSHKeys := newBlockName("support-instance-ssh-keys")
-	supportBlockNameAaGroup := newBlockName("support-instance-anti-affinity-group")
+	instanceName2 := NewResourceName()
+	instanceDiskName := NewResourceName()
+	instanceNicName := NewResourceName()
+	instanceFloatingIPName := NewResourceName()
+	instanceSshKeyName := NewResourceName()
+	instanceAaGroupName := NewResourceName()
+	blockName2 := NewBlockName("instance")
+	diskBlockName := NewBlockName("disk")
+	supportBlockName3 := NewBlockName("support")
+	supportBlockName2 := NewBlockName("support")
+	supportBlockNameSSHKeys := NewBlockName("support-instance-ssh-keys")
+	supportBlockNameAaGroup := NewBlockName("support-instance-anti-affinity-group")
 	resourceName2 := fmt.Sprintf("oxide_instance.%s", blockName2)
 	autoRestartPolicy := "best_effort"
-	config2, err := parsedAccConfig(
+	config2, err := ParsedAccConfig(
 		resourceInstanceFullConfig{
 			BlockName:                  blockName2,
 			InstanceName:               instanceName2,
@@ -206,8 +207,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -472,13 +473,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 		ipPoolName = "default"
 	}
 
-	instanceName := newResourceName()
-	floatingIPName := newResourceName()
-	blockName := newBlockName("instance")
-	supportBlockName := newBlockName("support")
-	ipPoolBlockName := newBlockName("ip-pool")
+	instanceName := NewResourceName()
+	floatingIPName := NewResourceName()
+	blockName := NewBlockName("instance")
+	supportBlockName := NewBlockName("support")
+	ipPoolBlockName := NewBlockName("ip-pool")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	initialConfig, err := parsedAccConfig(
+	initialConfig, err := ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -493,7 +494,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing initial config template data: %e", err)
 	}
 
-	updateConfig1, err := parsedAccConfig(
+	updateConfig1, err := ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -506,7 +507,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing first update config template data: %e", err)
 	}
 
-	updateConfig1SingleStack, err := parsedAccConfig(
+	updateConfig1SingleStack, err := ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -519,7 +520,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing first update single stack config template data: %e", err)
 	}
 
-	updateConfig2, err := parsedAccConfig(
+	updateConfig2, err := ParsedAccConfig(
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -533,8 +534,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			// Ephemeral external IP with specified IP pool ID.
@@ -613,13 +614,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceSshKeysName := newResourceName()
-	instanceSshKeysName2 := newResourceName()
-	blockNameSshKeys := newBlockName("instance-ssh-keys")
-	supportBlockNameSshKeys := newBlockName("support-instance-ssh-keys")
-	supportBlockNameSshKeys2 := newBlockName("support-instance-ssh-keys-2")
+	instanceSshKeysName := NewResourceName()
+	instanceSshKeysName2 := NewResourceName()
+	blockNameSshKeys := NewBlockName("instance-ssh-keys")
+	supportBlockNameSshKeys := NewBlockName("support-instance-ssh-keys")
+	supportBlockNameSshKeys2 := NewBlockName("support-instance-ssh-keys-2")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameSshKeys)
-	configSshKeys, err := parsedAccConfig(
+	configSshKeys, err := ParsedAccConfig(
 		resourceInstanceSshKeyConfig{
 			BlockName:         blockNameSshKeys,
 			SshKeyName:        instanceSshKeysName2,
@@ -634,8 +635,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -869,17 +870,17 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceNicName := newResourceName()
-	nicName := newResourceName()
-	blockNameSubnet := newBlockName("instance-nic-subnet")
-	blockNameInstanceNic := newBlockName("instance-nic")
-	supportBlockName := newBlockName("support")
-	supportBlockName2 := newBlockName("support")
+	instanceNicName := NewResourceName()
+	nicName := NewResourceName()
+	blockNameSubnet := NewBlockName("instance-nic-subnet")
+	blockNameInstanceNic := NewBlockName("instance-nic")
+	supportBlockName := NewBlockName("support")
+	supportBlockName2 := NewBlockName("support")
 	resourceNameInstanceNic := fmt.Sprintf("oxide_instance.%s", blockNameInstanceNic)
-	nonDefaultSubnetName := newResourceName()
+	nonDefaultSubnetName := NewResourceName()
 	nonDefaultSubnetIPv4Block := fmt.Sprintf("10.%d.%d.0/24", rand.IntN(255), rand.IntN(255))
 	nonDefaultSubnetIPv6NetNum := rand.IntN(200)
-	configNic, err := parsedAccConfig(
+	configNic, err := ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -895,7 +896,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicAdd, err := parsedAccConfig(
+	configNicAdd, err := ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -911,7 +912,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicUpdateSingleStack, err := parsedAccConfig(
+	configNicUpdateSingleStack, err := ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -927,7 +928,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configNicDelete, err := parsedAccConfig(
+	configNicDelete, err := ParsedAccConfig(
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -945,8 +946,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1080,16 +1081,16 @@ resource "oxide_instance" "{{.BlockName}}" {
   disk_attachments = [oxide_disk.{{.DiskBlockName}}.id]
 }
 `
-	instanceDiskName := newResourceName()
-	diskName := newResourceName()
-	diskName2 := newResourceName()
-	supportBlockName := newBlockName("support")
-	supportBlockName2 := newBlockName("support-update")
-	blockNameInstance := newBlockName("instance")
-	blockNameInstanceDisk := newBlockName("instance-disk")
-	blockNameInstanceDisk2 := newBlockName("instance-disk-2")
+	instanceDiskName := NewResourceName()
+	diskName := NewResourceName()
+	diskName2 := NewResourceName()
+	supportBlockName := NewBlockName("support")
+	supportBlockName2 := NewBlockName("support-update")
+	blockNameInstance := NewBlockName("instance")
+	blockNameInstanceDisk := NewBlockName("instance-disk")
+	blockNameInstanceDisk2 := NewBlockName("instance-disk-2")
 	resourceNameInstanceDisk := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	configDisk, err := parsedAccConfig(
+	configDisk, err := ParsedAccConfig(
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1104,7 +1105,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
-	configDiskUpdate, err := parsedAccConfig(
+	configDiskUpdate, err := ParsedAccConfig(
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1121,8 +1122,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1205,12 +1206,12 @@ resource "oxide_instance" "{{.BlockName}}" {
   start_on_create = true
 }
 `
-	instanceName := newResourceName()
-	supportBlockName := newBlockName("support")
-	supportBlockName2 := newBlockName("support-update")
-	blockNameInstance := newBlockName("instance")
+	instanceName := NewResourceName()
+	supportBlockName := NewBlockName("support")
+	supportBlockName2 := NewBlockName("support-update")
+	blockNameInstance := NewBlockName("instance")
 	resourceNameInstance := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1222,7 +1223,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1234,7 +1235,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate2, err := parsedAccConfig(
+	configUpdate2, err := ParsedAccConfig(
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1247,8 +1248,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1316,13 +1317,13 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceName := newResourceName()
-	diskName := newResourceName()
-	blockName := newBlockName("instance-no-boot-disk")
-	diskBlockName := newBlockName("disk")
-	supportBlockName := newBlockName("support")
+	instanceName := NewResourceName()
+	diskName := NewResourceName()
+	blockName := NewBlockName("instance-no-boot-disk")
+	diskBlockName := NewBlockName("disk")
+	supportBlockName := NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceInstanceNoBootDiskConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -1337,8 +1338,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1454,15 +1455,15 @@ resource "oxide_instance" "{{.BlockName}}" {
 }
 `
 
-	instanceAntiAffinityGroupsName := newResourceName()
-	antiAffinityGroupName1 := newResourceName()
-	antiAffinityGroupName2 := newResourceName()
-	blockNameAntiAffinityGroups := newBlockName("instance-anti-affinity-groups")
-	supportBlockNameAntiAffinityGroups := newBlockName("support-instance-anti-affinity-groups")
-	supportBlockNameAntiAffinityGroup1 := newBlockName("support-instance-anti-affinity-group")
-	supportBlockNameAntiAffinityGroup2 := newBlockName("support-instance-anti-affinity-group")
+	instanceAntiAffinityGroupsName := NewResourceName()
+	antiAffinityGroupName1 := NewResourceName()
+	antiAffinityGroupName2 := NewResourceName()
+	blockNameAntiAffinityGroups := NewBlockName("instance-anti-affinity-groups")
+	supportBlockNameAntiAffinityGroups := NewBlockName("support-instance-anti-affinity-groups")
+	supportBlockNameAntiAffinityGroup1 := NewBlockName("support-instance-anti-affinity-group")
+	supportBlockNameAntiAffinityGroup2 := NewBlockName("support-instance-anti-affinity-group")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameAntiAffinityGroups)
-	configAntiAffinityGroups, err := parsedAccConfig(
+	configAntiAffinityGroups, err := ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                  blockNameAntiAffinityGroups,
 			InstanceName:               instanceAntiAffinityGroupsName,
@@ -1476,7 +1477,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configAntiAffinityGroupsUpdate, err := parsedAccConfig(
+	configAntiAffinityGroupsUpdate, err := ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1492,7 +1493,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configAntiAffinityGroupsUpdate2, err := parsedAccConfig(
+	configAntiAffinityGroupsUpdate2, err := ParsedAccConfig(
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1509,8 +1510,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1986,7 +1987,7 @@ func testResourceInstanceNetworkInterface(
 }
 
 func testAccInstanceDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -2006,7 +2007,7 @@ func testAccInstanceDestroy(s *terraform.State) error {
 			Instance: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.InstanceView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_instance_v0.go
+++ b/internal/provider/resource_instance_v0.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_instance_v0.go
+++ b/internal/provider/resource_instance_v0.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Schema and structs source:
@@ -69,7 +70,7 @@ type instanceResourceExternalIPModelV0 struct {
 func (r *instanceResource) schemaV0(ctx context.Context) *schema.Schema {
 	return &schema.Schema{
 		Version: 0,
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages instances.
 
 !> Updates will stop and start the instance.
@@ -176,7 +177,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -186,7 +187,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -195,7 +196,7 @@ This resource manages instances.
 							Description: "ID of the VPC subnet in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -204,7 +205,7 @@ This resource manages instances.
 							Description: "ID of the VPC in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},

--- a/internal/provider/resource_instance_v1.go
+++ b/internal/provider/resource_instance_v1.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type instanceResourceModelV1 struct {
@@ -184,7 +185,7 @@ func (r *instanceResource) schemaV1(
 ) *schema.Schema {
 	return &schema.Schema{
 		Version: 1,
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages instances.
 
 !> Updates will stop and start the instance.
@@ -314,7 +315,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -324,7 +325,7 @@ This resource manages instances.
 							// TODO: Remove once update is implemented
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -333,7 +334,7 @@ This resource manages instances.
 							Description: "ID of the VPC subnet in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},
@@ -342,7 +343,7 @@ This resource manages instances.
 							Description: "ID of the VPC in which to create the instance network interface.",
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplaceIf(
-									RequiresReplaceUnlessEmptyStringOrNull(), "", "",
+									shared.RequiresReplaceUnlessEmptyStringOrNull(), "", "",
 								),
 							},
 						},

--- a/internal/provider/resource_instance_v1.go
+++ b/internal/provider/resource_instance_v1.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -155,7 +156,7 @@ func (r *ipPoolResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -214,7 +215,7 @@ func (r *ipPoolResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -322,7 +323,7 @@ func (r *ipPoolResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -334,14 +335,14 @@ func (r *ipPoolResource) Update(
 	stateRanges := state.Ranges
 
 	// Check plan and if it has a range that the state doesn't then attach it
-	rangesToAdd := sliceDiff(planRanges, stateRanges)
+	rangesToAdd := shared.SliceDiff(planRanges, stateRanges)
 	resp.Diagnostics.Append(addRanges(ctx, r.client, rangesToAdd, state.ID.ValueString())...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Check state and if it has a range that the plan doesn't then detach it
-	rangesToDetach := sliceDiff(stateRanges, planRanges)
+	rangesToDetach := shared.SliceDiff(stateRanges, planRanges)
 	resp.Diagnostics.Append(removeRanges(ctx, r.client, rangesToDetach, state.ID.ValueString())...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -396,7 +397,7 @@ func (r *ipPoolResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -413,7 +414,7 @@ func (r *ipPoolResource) Delete(
 		},
 	)
 	if err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error retrieving IP Pool ranges:",
 				"API error: "+err.Error(),
@@ -434,7 +435,7 @@ func (r *ipPoolResource) Delete(
 			Body: &item.Range,
 		}
 		if err := r.client.SystemIpPoolRangeRemove(ctx, params); err != nil {
-			if !is404(err) {
+			if !shared.Is404(err) {
 				resp.Diagnostics.AddError(
 					"Error deleting IP Pool range:",
 					"API error: "+err.Error(),
@@ -454,7 +455,7 @@ func (r *ipPoolResource) Delete(
 		oxide.SystemIpPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting IP Pool:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_ip_pool.go
+++ b/internal/provider/resource_ip_pool.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_ip_pool_silo_link.go
+++ b/internal/provider/resource_ip_pool_silo_link.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_ip_pool_silo_link.go
+++ b/internal/provider/resource_ip_pool_silo_link.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -136,7 +137,7 @@ func (r *ipPoolSiloLinkResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -189,7 +190,7 @@ func (r *ipPoolSiloLinkResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -205,7 +206,7 @@ func (r *ipPoolSiloLinkResource) Read(
 
 	links, err := r.client.SystemIpPoolSiloList(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -269,7 +270,7 @@ func (r *ipPoolSiloLinkResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -322,7 +323,7 @@ func (r *ipPoolSiloLinkResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -335,7 +336,7 @@ func (r *ipPoolSiloLinkResource) Delete(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
 	if err := r.client.SystemIpPoolSiloUnlink(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting link:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceIPPoolSiloLinkConfig struct {
@@ -97,13 +98,13 @@ resource "oxide_ip_pool_silo_link" "{{.BlockName2}}" {
 func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 	t.Skip("skipping test until there is a silo datasource to retrieve the ID.")
 
-	ipPoolName := NewResourceName()
-	blockName := NewBlockName("ip_pool")
-	blockName2 := NewBlockName("ip_pool")
-	supportBlockName := NewBlockName("support")
+	ipPoolName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("ip_pool")
+	blockName2 := sharedtest.NewBlockName("ip_pool")
+	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
 	resourceName2 := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceIPPoolSiloLinkConfig{
 			BlockName:        blockName,
 			SupportBlockName: supportBlockName,
@@ -115,14 +116,14 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceIPPoolSiloLinkConfigUpdate{
 			BlockName:         blockName,
 			IPPoolName:        ipPoolName,
 			BlockName2:        blockName2,
-			IPPoolName2:       NewResourceName(),
+			IPPoolName2:       sharedtest.NewResourceName(),
 			SupportBlockName:  supportBlockName,
-			SupportBlockName2: NewBlockName("support"),
+			SupportBlockName2: sharedtest.NewBlockName("support"),
 		},
 		resourceIPPoolSiloLinkUpdateConfigTpl,
 	)
@@ -131,8 +132,8 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccIPPoolSiloLinkDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -179,7 +180,7 @@ func checkResourceIPPoolSiloLinkUpdate(resourceName, resourceName2 string) resou
 }
 
 func testAccIPPoolSiloLinkDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_ip_pool_silo_link_test.go
+++ b/internal/provider/resource_ip_pool_silo_link_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceIPPoolSiloLinkConfig struct {
@@ -96,13 +97,13 @@ resource "oxide_ip_pool_silo_link" "{{.BlockName2}}" {
 func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 	t.Skip("skipping test until there is a silo datasource to retrieve the ID.")
 
-	ipPoolName := newResourceName()
-	blockName := newBlockName("ip_pool")
-	blockName2 := newBlockName("ip_pool")
-	supportBlockName := newBlockName("support")
+	ipPoolName := NewResourceName()
+	blockName := NewBlockName("ip_pool")
+	blockName2 := NewBlockName("ip_pool")
+	supportBlockName := NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
 	resourceName2 := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceIPPoolSiloLinkConfig{
 			BlockName:        blockName,
 			SupportBlockName: supportBlockName,
@@ -114,14 +115,14 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceIPPoolSiloLinkConfigUpdate{
 			BlockName:         blockName,
 			IPPoolName:        ipPoolName,
 			BlockName2:        blockName2,
-			IPPoolName2:       newResourceName(),
+			IPPoolName2:       NewResourceName(),
 			SupportBlockName:  supportBlockName,
-			SupportBlockName2: newBlockName("support"),
+			SupportBlockName2: NewBlockName("support"),
 		},
 		resourceIPPoolSiloLinkUpdateConfigTpl,
 	)
@@ -130,8 +131,8 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccIPPoolSiloLinkDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -178,7 +179,7 @@ func checkResourceIPPoolSiloLinkUpdate(resourceName, resourceName2 string) resou
 }
 
 func testAccIPPoolSiloLinkDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -201,7 +202,7 @@ func testAccIPPoolSiloLinkDestroy(s *terraform.State) error {
 		}
 
 		links, err := client.SystemIpPoolSiloList(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccSiloResourceIpPool_full(t *testing.T) {
@@ -19,8 +20,8 @@ func TestAccSiloResourceIpPool_full(t *testing.T) {
 	resourceName2 := "oxide_ip_pool.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccIPPoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -175,7 +176,7 @@ func checkResourceIPPoolRanges(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccIPPoolDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -191,7 +192,7 @@ func testAccIPPoolDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool"},
 		)
-		if err == nil || !is404(err) {
+		if err == nil || !shared.Is404(err) {
 			return fmt.Errorf("ip_pool (%v) still exists", &res.Name)
 		}
 
@@ -199,7 +200,7 @@ func testAccIPPoolDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool2"},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		return fmt.Errorf("ip_pool (%v) still exists", &res2.Name)

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_ip_pool_test.go
+++ b/internal/provider/resource_ip_pool_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccSiloResourceIpPool_full(t *testing.T) {
@@ -20,8 +21,8 @@ func TestAccSiloResourceIpPool_full(t *testing.T) {
 	resourceName2 := "oxide_ip_pool.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccIPPoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -176,7 +177,7 @@ func checkResourceIPPoolRanges(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccIPPoolDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -133,7 +134,7 @@ func (r *projectResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -187,7 +188,7 @@ func (r *projectResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -200,7 +201,7 @@ func (r *projectResource) Read(
 	}
 	project, err := r.client.ProjectView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -252,7 +253,7 @@ func (r *projectResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -307,7 +308,7 @@ func (r *projectResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -322,7 +323,7 @@ func (r *projectResource) Delete(
 		Subnet:  oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, paramsSubnet); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting default subnet:",
 				"API error: "+err.Error(),
@@ -341,7 +342,7 @@ func (r *projectResource) Delete(
 		Vpc:     oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcDelete(ctx, paramsVPC); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting default VPC:",
 				"API error: "+err.Error(),
@@ -359,7 +360,7 @@ func (r *projectResource) Delete(
 		Project: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.ProjectDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting project:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceProjectConfig struct {
@@ -41,10 +42,10 @@ resource "oxide_project" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceProject_full(t *testing.T) {
-	projectName := newResourceName()
-	blockName := newBlockName("project")
+	projectName := NewResourceName()
+	blockName := NewBlockName("project")
 	resourceName := fmt.Sprintf("oxide_project.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceProjectConfig{
 			BlockName:   blockName,
 			ProjectName: projectName,
@@ -56,7 +57,7 @@ func TestAccCloudResourceProject_full(t *testing.T) {
 	}
 
 	projectNameUpdated := projectName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceProjectConfig{
 			BlockName:   blockName,
 			ProjectName: projectNameUpdated,
@@ -68,8 +69,8 @@ func TestAccCloudResourceProject_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccProjectDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -118,7 +119,7 @@ func checkResourceProjectUpdate(resourceName, projectName string) resource.TestC
 }
 
 func testAccProjectDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -136,7 +137,7 @@ func testAccProjectDestroy(s *terraform.State) error {
 			Project: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.ProjectView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		return fmt.Errorf("project (%v) still exists", &res.Name)

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceProjectConfig struct {
@@ -42,10 +43,10 @@ resource "oxide_project" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceProject_full(t *testing.T) {
-	projectName := NewResourceName()
-	blockName := NewBlockName("project")
+	projectName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("project")
 	resourceName := fmt.Sprintf("oxide_project.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceProjectConfig{
 			BlockName:   blockName,
 			ProjectName: projectName,
@@ -57,7 +58,7 @@ func TestAccCloudResourceProject_full(t *testing.T) {
 	}
 
 	projectNameUpdated := projectName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceProjectConfig{
 			BlockName:   blockName,
 			ProjectName: projectNameUpdated,
@@ -69,8 +70,8 @@ func TestAccCloudResourceProject_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccProjectDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +120,7 @@ func checkResourceProjectUpdate(resourceName, projectName string) resource.TestC
 }
 
 func testAccProjectDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_silo.go
+++ b/internal/provider/resource_silo.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_silo.go
+++ b/internal/provider/resource_silo.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Compile-time assertions to check that siloResource implements the necessary
@@ -125,7 +126,7 @@ func (r *siloResource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages the creation of an Oxide silo.
 
 -> Only the ''quotas'' attribute supports in-place modification. Changes to other
@@ -307,7 +308,7 @@ func (r *siloResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -384,7 +385,7 @@ func (r *siloResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -399,7 +400,7 @@ func (r *siloResource) Read(
 
 	silo, err := r.client.SiloView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -464,7 +465,7 @@ func (r *siloResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -537,7 +538,7 @@ func (r *siloResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -551,7 +552,7 @@ func (r *siloResource) Delete(
 	}
 
 	if err := r.client.SiloDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting silo:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_silo_saml_identity_provider.go
+++ b/internal/provider/resource_silo_saml_identity_provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_silo_saml_identity_provider.go
+++ b/internal/provider/resource_silo_saml_identity_provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -218,7 +219,7 @@ func (r *siloSamlIdentityProvider) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -311,7 +312,7 @@ func (r *siloSamlIdentityProvider) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -326,7 +327,7 @@ func (r *siloSamlIdentityProvider) Read(
 
 	idpConfig, err := r.client.SamlIdentityProviderView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_silo_saml_identity_provider_test.go
+++ b/internal/provider/resource_silo_saml_identity_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceSiloIdentifyProviderConfig struct {
@@ -99,19 +100,19 @@ resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockNa
 `
 
 func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
-	siloBlockName := newBlockName("silo")
-	siloName := newResourceName()
-	siloSamlIdentityProviderBlockName := newBlockName("silo-idp")
-	siloSamlIdentityProviderName := newResourceName()
+	siloBlockName := NewBlockName("silo")
+	siloName := NewResourceName()
+	siloSamlIdentityProviderBlockName := NewBlockName("silo-idp")
+	siloSamlIdentityProviderName := NewResourceName()
 
 	siloSamlIdentityProviderResourceID := fmt.Sprintf(
 		"oxide_silo_saml_identity_provider.%s",
 		siloSamlIdentityProviderBlockName,
 	)
 
-	siloDNSName := testAccSiloDNSName()
+	siloDNSName := SiloDNSName()
 
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceSiloIdentifyProviderConfig{
 			SiloBlockName:                     siloBlockName,
 			SiloDNSName:                       siloDNSName,
@@ -129,8 +130,8 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -178,7 +179,7 @@ func checkResourceSiloSamlIdentityProvider(
 }
 
 func testAccSiloSamlIdentityProviderDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -197,7 +198,7 @@ func testAccSiloSamlIdentityProviderDestroy(s *terraform.State) error {
 		}
 
 		res, err := client.SamlIdentityProviderView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_silo_saml_identity_provider_test.go
+++ b/internal/provider/resource_silo_saml_identity_provider_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceSiloIdentifyProviderConfig struct {
@@ -100,19 +101,19 @@ resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockNa
 `
 
 func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
-	siloBlockName := NewBlockName("silo")
-	siloName := NewResourceName()
-	siloSamlIdentityProviderBlockName := NewBlockName("silo-idp")
-	siloSamlIdentityProviderName := NewResourceName()
+	siloBlockName := sharedtest.NewBlockName("silo")
+	siloName := sharedtest.NewResourceName()
+	siloSamlIdentityProviderBlockName := sharedtest.NewBlockName("silo-idp")
+	siloSamlIdentityProviderName := sharedtest.NewResourceName()
 
 	siloSamlIdentityProviderResourceID := fmt.Sprintf(
 		"oxide_silo_saml_identity_provider.%s",
 		siloSamlIdentityProviderBlockName,
 	)
 
-	siloDNSName := SiloDNSName()
+	siloDNSName := sharedtest.SiloDNSName()
 
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceSiloIdentifyProviderConfig{
 			SiloBlockName:                     siloBlockName,
 			SiloDNSName:                       siloDNSName,
@@ -130,8 +131,8 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -179,7 +180,7 @@ func checkResourceSiloSamlIdentityProvider(
 }
 
 func testAccSiloSamlIdentityProviderDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_silo_saml_identity_provider_test.go
+++ b/internal/provider/resource_silo_saml_identity_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_silo_test.go
+++ b/internal/provider/resource_silo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_silo_test.go
+++ b/internal/provider/resource_silo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceSiloConfig struct {
@@ -135,13 +136,13 @@ resource "oxide_silo" "{{.BlockName}}" {
 `
 
 func TestAccSiloResourceSilo_full(t *testing.T) {
-	siloName := newResourceName()
-	blockName := newBlockName("silo")
+	siloName := NewResourceName()
+	blockName := NewBlockName("silo")
 	resourceName := fmt.Sprintf("oxide_silo.%s", blockName)
 
-	dnsName := testAccSiloDNSName()
+	dnsName := SiloDNSName()
 
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceSiloConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -153,7 +154,7 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceSiloConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -169,8 +170,8 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -234,7 +235,7 @@ func checkResourceSiloUpdate(resourceName string, siloName string) resource.Test
 }
 
 func testAccSiloDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -253,7 +254,7 @@ func testAccSiloDestroy(s *terraform.State) error {
 		}
 
 		res, err := client.SiloView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_silo_test.go
+++ b/internal/provider/resource_silo_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceSiloConfig struct {
@@ -136,13 +137,13 @@ resource "oxide_silo" "{{.BlockName}}" {
 `
 
 func TestAccSiloResourceSilo_full(t *testing.T) {
-	siloName := NewResourceName()
-	blockName := NewBlockName("silo")
+	siloName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("silo")
 	resourceName := fmt.Sprintf("oxide_silo.%s", blockName)
 
-	dnsName := SiloDNSName()
+	dnsName := sharedtest.SiloDNSName()
 
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceSiloConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -154,7 +155,7 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceSiloConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -170,8 +171,8 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -235,7 +236,7 @@ func checkResourceSiloUpdate(resourceName string, siloName string) resource.Test
 }
 
 func testAccSiloDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_snapshot.go
+++ b/internal/provider/resource_snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -158,7 +159,7 @@ func (r *snapshotResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -232,7 +233,7 @@ func (r *snapshotResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -245,7 +246,7 @@ func (r *snapshotResource) Read(
 	}
 	snapshot, err := r.client.SnapshotView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -303,7 +304,7 @@ func (r *snapshotResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -315,7 +316,7 @@ func (r *snapshotResource) Delete(
 		Snapshot: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.SnapshotDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting snapshot:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_snapshot.go
+++ b/internal/provider/resource_snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_snapshot_test.go
+++ b/internal/provider/resource_snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_snapshot_test.go
+++ b/internal/provider/resource_snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceSnapshotConfig struct {
@@ -56,11 +57,11 @@ resource "oxide_snapshot" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceSnapshot_full(t *testing.T) {
-	diskName := newResourceName()
-	snapshotName := newResourceName()
-	blockName := newBlockName("snapshot")
+	diskName := NewResourceName()
+	snapshotName := NewResourceName()
+	blockName := NewBlockName("snapshot")
 	resourceName := fmt.Sprintf("oxide_snapshot.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceSnapshotConfig{
 			BlockName:        blockName,
 			SnapshotName:     snapshotName,
@@ -75,8 +76,8 @@ func TestAccCloudResourceSnapshot_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -110,7 +111,7 @@ func checkResourceSnapshot(resourceName, snapshotName string) resource.TestCheck
 }
 
 func testAccSnapshotDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -130,7 +131,7 @@ func testAccSnapshotDestroy(s *terraform.State) error {
 
 		res, err := client.SnapshotView(ctx, params)
 
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_snapshot_test.go
+++ b/internal/provider/resource_snapshot_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceSnapshotConfig struct {
@@ -57,11 +58,11 @@ resource "oxide_snapshot" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceSnapshot_full(t *testing.T) {
-	diskName := NewResourceName()
-	snapshotName := NewResourceName()
-	blockName := NewBlockName("snapshot")
+	diskName := sharedtest.NewResourceName()
+	snapshotName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("snapshot")
 	resourceName := fmt.Sprintf("oxide_snapshot.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceSnapshotConfig{
 			BlockName:        blockName,
 			SnapshotName:     snapshotName,
@@ -76,8 +77,8 @@ func TestAccCloudResourceSnapshot_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -111,7 +112,7 @@ func checkResourceSnapshot(resourceName, snapshotName string) resource.TestCheck
 }
 
 func testAccSnapshotDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -95,7 +96,7 @@ This resource manages SSH keys.
 			},
 			"name": schema.StringAttribute{
 				Required: true,
-				MarkdownDescription: replaceBackticks(`
+				MarkdownDescription: shared.ReplaceBackticks(`
 Name of the SSH key. Names must begin with a lower case ASCII letter, be
 composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and ''-'',
 and may not end with a ''-''. Names cannot be a UUID though they may contain a
@@ -154,7 +155,7 @@ func (r *sshKeyResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -211,7 +212,7 @@ func (r *sshKeyResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,7 +225,7 @@ func (r *sshKeyResource) Read(
 	}
 	sshKey, err := r.client.CurrentUserSshKeyView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -286,7 +287,7 @@ func (r *sshKeyResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -298,7 +299,7 @@ func (r *sshKeyResource) Delete(
 		SshKey: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.CurrentUserSshKeyDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting SSH key:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceSSHKeyConfig struct {
@@ -38,12 +39,12 @@ resource "oxide_ssh_key" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceSSHKey_full(t *testing.T) {
-	sshKeyName := NewResourceName()
+	sshKeyName := sharedtest.NewResourceName()
 	description := "An SSH key."
 	publicKey := "ssh-ed25519 AAAA"
-	blockName := NewBlockName("ssh_key")
+	blockName := sharedtest.NewBlockName("ssh_key")
 	resourceName := fmt.Sprintf("oxide_ssh_key.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceSSHKeyConfig{
 			BlockName:   blockName,
 			Name:        sshKeyName,
@@ -57,8 +58,8 @@ func TestAccCloudResourceSSHKey_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -91,7 +92,7 @@ func checkResourceSSHKey(resourceName, sshKeyName string) resource.TestCheckFunc
 }
 
 func testAccSSHKeyDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceSSHKeyConfig struct {
@@ -37,12 +38,12 @@ resource "oxide_ssh_key" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceSSHKey_full(t *testing.T) {
-	sshKeyName := newResourceName()
+	sshKeyName := NewResourceName()
 	description := "An SSH key."
 	publicKey := "ssh-ed25519 AAAA"
-	blockName := newBlockName("ssh_key")
+	blockName := NewBlockName("ssh_key")
 	resourceName := fmt.Sprintf("oxide_ssh_key.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceSSHKeyConfig{
 			BlockName:   blockName,
 			Name:        sshKeyName,
@@ -56,8 +57,8 @@ func TestAccCloudResourceSSHKey_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -90,7 +91,7 @@ func checkResourceSSHKey(resourceName, sshKeyName string) resource.TestCheckFunc
 }
 
 func testAccSSHKeyDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -109,7 +110,7 @@ func testAccSSHKeyDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.CurrentUserSshKeyView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_subnet_pool.go
+++ b/internal/provider/resource_subnet_pool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -144,7 +145,7 @@ func (r *subnetPoolResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -199,7 +200,7 @@ func (r *subnetPoolResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -211,7 +212,7 @@ func (r *subnetPoolResource) Read(
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 	})
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -264,7 +265,7 @@ func (r *subnetPoolResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -320,7 +321,7 @@ func (r *subnetPoolResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -333,7 +334,7 @@ func (r *subnetPoolResource) Delete(
 		oxide.SystemSubnetPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_subnet_pool.go
+++ b/internal/provider/resource_subnet_pool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_subnet_pool_member.go
+++ b/internal/provider/resource_subnet_pool_member.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_subnet_pool_member.go
+++ b/internal/provider/resource_subnet_pool_member.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -166,7 +167,7 @@ func (r *subnetPoolMemberResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -243,7 +244,7 @@ func (r *subnetPoolMemberResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +261,7 @@ func (r *subnetPoolMemberResource) Read(
 		},
 	)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Pool doesn't exist, remove resource from state
 			resp.State.RemoveResource(ctx)
 			return
@@ -335,7 +336,7 @@ func (r *subnetPoolMemberResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -364,7 +365,7 @@ func (r *subnetPoolMemberResource) Delete(
 		// rather than 404. Handle both cases for idempotent deletes.
 		//
 		// TODO: Switch to a 404 in omicron.
-		if !is404(err) && !strings.Contains(err.Error(), "does not exist") {
+		if !shared.Is404(err) && !strings.Contains(err.Error(), "does not exist") {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool member:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_subnet_pool_member_test.go
+++ b/internal/provider/resource_subnet_pool_member_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccResourceSubnetPoolMember_full(t *testing.T) {
@@ -20,12 +21,12 @@ func TestAccResourceSubnetPoolMember_full(t *testing.T) {
 	memberResourceName := "oxide_subnet_pool_member.test"
 	member2ResourceName := "oxide_subnet_pool_member.test2"
 
-	subnet1 := NextSubnetCIDR(t)
-	subnet2 := NextSubnetCIDR(t)
+	subnet1 := sharedtest.NextSubnetCIDR(t)
+	subnet2 := sharedtest.NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			// Create pool and one member
@@ -134,13 +135,13 @@ func TestAccResourceSubnetPoolMember_parallel(t *testing.T) {
 	member2ResourceName := "oxide_subnet_pool_member.m2"
 	member3ResourceName := "oxide_subnet_pool_member.m3"
 
-	sub1 := NextSubnetCIDR(t)
-	sub2 := NextSubnetCIDR(t)
-	sub3 := NextSubnetCIDR(t)
+	sub1 := sharedtest.NextSubnetCIDR(t)
+	sub2 := sharedtest.NextSubnetCIDR(t)
+	sub3 := sharedtest.NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			// Create pool and three members in parallel (no depends_on between members)
@@ -194,11 +195,11 @@ func TestAccResourceSubnetPoolMember_disappears(t *testing.T) {
 	poolResourceName := "oxide_subnet_pool.test"
 	memberResourceName := "oxide_subnet_pool_member.test"
 
-	subnet := NextSubnetCIDR(t)
+	subnet := sharedtest.NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -225,7 +226,7 @@ func testAccSubnetPoolMemberDisappears(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -263,7 +264,7 @@ resource "oxide_subnet_pool_member" "test" {
 }
 
 func testAccSubnetPoolMemberDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_subnet_pool_member_test.go
+++ b/internal/provider/resource_subnet_pool_member_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_subnet_pool_member_test.go
+++ b/internal/provider/resource_subnet_pool_member_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccResourceSubnetPoolMember_full(t *testing.T) {
@@ -19,12 +20,12 @@ func TestAccResourceSubnetPoolMember_full(t *testing.T) {
 	memberResourceName := "oxide_subnet_pool_member.test"
 	member2ResourceName := "oxide_subnet_pool_member.test2"
 
-	subnet1 := nextSubnetCIDR(t)
-	subnet2 := nextSubnetCIDR(t)
+	subnet1 := NextSubnetCIDR(t)
+	subnet2 := NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			// Create pool and one member
@@ -133,13 +134,13 @@ func TestAccResourceSubnetPoolMember_parallel(t *testing.T) {
 	member2ResourceName := "oxide_subnet_pool_member.m2"
 	member3ResourceName := "oxide_subnet_pool_member.m3"
 
-	sub1 := nextSubnetCIDR(t)
-	sub2 := nextSubnetCIDR(t)
-	sub3 := nextSubnetCIDR(t)
+	sub1 := NextSubnetCIDR(t)
+	sub2 := NextSubnetCIDR(t)
+	sub3 := NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			// Create pool and three members in parallel (no depends_on between members)
@@ -193,11 +194,11 @@ func TestAccResourceSubnetPoolMember_disappears(t *testing.T) {
 	poolResourceName := "oxide_subnet_pool.test"
 	memberResourceName := "oxide_subnet_pool_member.test"
 
-	subnet := nextSubnetCIDR(t)
+	subnet := NextSubnetCIDR(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolMemberDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -224,7 +225,7 @@ func testAccSubnetPoolMemberDisappears(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -262,7 +263,7 @@ resource "oxide_subnet_pool_member" "test" {
 }
 
 func testAccSubnetPoolMemberDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -280,7 +281,7 @@ func testAccSubnetPoolMemberDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemSubnetPoolMemberListParams{Pool: oxide.NameOrId(poolID)},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			// Pool doesn't exist, so member is definitely gone
 			continue
 		}

--- a/internal/provider/resource_subnet_pool_silo_link.go
+++ b/internal/provider/resource_subnet_pool_silo_link.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_subnet_pool_silo_link.go
+++ b/internal/provider/resource_subnet_pool_silo_link.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -144,7 +145,7 @@ func (r *subnetPoolSiloLinkResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -197,7 +198,7 @@ func (r *subnetPoolSiloLinkResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -209,7 +210,7 @@ func (r *subnetPoolSiloLinkResource) Read(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	})
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -264,7 +265,7 @@ func (r *subnetPoolSiloLinkResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -317,7 +318,7 @@ func (r *subnetPoolSiloLinkResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -330,7 +331,7 @@ func (r *subnetPoolSiloLinkResource) Delete(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
 	if err := r.client.SystemSubnetPoolSiloUnlink(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool silo link:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccResourceSubnetPoolSiloLink_full(t *testing.T) {
@@ -21,8 +22,8 @@ func TestAccResourceSubnetPoolSiloLink_full(t *testing.T) {
 	linkResourceName := "oxide_subnet_pool_silo_link.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			// Create pool and link.
 			{
@@ -118,8 +119,8 @@ func TestAccResourceSubnetPoolSiloLink_disappears(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceSubnetPoolSiloLinkDisappearsConfig,
@@ -143,7 +144,7 @@ func testAccSubnetPoolSiloLinkDisappears(resourceName string) resource.TestCheck
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -176,7 +177,7 @@ resource "oxide_subnet_pool_silo_link" "test" {
 `
 
 func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
-	siloDNSName := SiloDNSName()
+	siloDNSName := sharedtest.SiloDNSName()
 
 	link1ResourceName := "oxide_subnet_pool_silo_link.link1"
 	link2ResourceName := "oxide_subnet_pool_silo_link.link2"
@@ -185,8 +186,8 @@ func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -320,7 +321,7 @@ func testAccLinksDestroyed(poolResourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", poolResourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -21,8 +21,8 @@ func TestAccResourceSubnetPoolSiloLink_full(t *testing.T) {
 	linkResourceName := "oxide_subnet_pool_silo_link.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			// Create pool and link.
 			{
@@ -118,8 +118,8 @@ func TestAccResourceSubnetPoolSiloLink_disappears(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceSubnetPoolSiloLinkDisappearsConfig,
@@ -143,7 +143,7 @@ func testAccSubnetPoolSiloLinkDisappears(resourceName string) resource.TestCheck
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ resource "oxide_subnet_pool_silo_link" "test" {
 `
 
 func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
-	siloDNSName := testAccSiloDNSName()
+	siloDNSName := SiloDNSName()
 
 	link1ResourceName := "oxide_subnet_pool_silo_link.link1"
 	link2ResourceName := "oxide_subnet_pool_silo_link.link2"
@@ -185,8 +185,8 @@ func TestAccResourceSubnetPoolSiloLink_multiSiloImport(t *testing.T) {
 	// so run all related tests in series:
 	// https://github.com/oxidecomputer/omicron/issues/9851
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -320,7 +320,7 @@ func testAccLinksDestroyed(poolResourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", poolResourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_subnet_pool_silo_link_test.go
+++ b/internal/provider/resource_subnet_pool_silo_link_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 

--- a/internal/provider/resource_subnet_pool_test.go
+++ b/internal/provider/resource_subnet_pool_test.go
@@ -12,14 +12,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccResourceSubnetPool_full(t *testing.T) {
 	resourceName := "oxide_subnet_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			// Create
@@ -95,8 +96,8 @@ func TestAccResourceSubnetPool_disappears(t *testing.T) {
 	resourceName := "oxide_subnet_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -122,7 +123,7 @@ func testAccSubnetPoolDisappears(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := newTestClient()
+		client, err := NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -143,7 +144,7 @@ resource "oxide_subnet_pool" "test" {
 `
 
 func testAccSubnetPoolDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -159,7 +160,7 @@ func testAccSubnetPoolDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SubnetPoolViewParams{Pool: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		if err == nil {

--- a/internal/provider/resource_subnet_pool_test.go
+++ b/internal/provider/resource_subnet_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_subnet_pool_test.go
+++ b/internal/provider/resource_subnet_pool_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -13,14 +13,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 func TestAccResourceSubnetPool_full(t *testing.T) {
 	resourceName := "oxide_subnet_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			// Create
@@ -96,8 +97,8 @@ func TestAccResourceSubnetPool_disappears(t *testing.T) {
 	resourceName := "oxide_subnet_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSubnetPoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -123,7 +124,7 @@ func testAccSubnetPoolDisappears(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		client, err := NewTestClient()
+		client, err := sharedtest.NewTestClient()
 		if err != nil {
 			return err
 		}
@@ -144,7 +145,7 @@ resource "oxide_subnet_pool" "test" {
 `
 
 func testAccSubnetPoolDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_switch_port_settings.go
+++ b/internal/provider/resource_switch_port_settings.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_switch_port_settings.go
+++ b/internal/provider/resource_switch_port_settings.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 var (
@@ -552,7 +553,7 @@ func (r *switchPortSettingsResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -607,7 +608,7 @@ func (r *switchPortSettingsResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -687,7 +688,7 @@ func (r *switchPortSettingsResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -742,7 +743,7 @@ func (r *switchPortSettingsResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -756,7 +757,7 @@ func (r *switchPortSettingsResource) Delete(
 		oxide.NetworkingSwitchPortSettingsDeleteParams{
 			PortSettings: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting Switch Port Settings:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_switch_port_settings_test.go
+++ b/internal/provider/resource_switch_port_settings_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_switch_port_settings_test.go
+++ b/internal/provider/resource_switch_port_settings_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 // TestAccSiloResourceSwitchPortSettings_full tests whether Terraform
@@ -158,11 +159,11 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
   ]
 }
 `
-	switchPortSettingsName := NewResourceName()
-	blockName := NewBlockName("switch-port-settings")
+	switchPortSettingsName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("switch-port-settings")
 	resourceName := fmt.Sprintf("oxide_switch_port_settings.%s", blockName)
 
-	initialConfig, err := ParsedAccConfig(
+	initialConfig, err := sharedtest.ParsedAccConfig(
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
@@ -173,7 +174,7 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
 		t.Errorf("error parsing initial config template data: %e", err)
 	}
 
-	updateConfig, err := ParsedAccConfig(
+	updateConfig, err := sharedtest.ParsedAccConfig(
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
@@ -186,9 +187,9 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			PreCheck(t)
+			sharedtest.PreCheck(t)
 		},
-		ProtoV6ProviderFactories: ProviderFactories(),
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccSwitchPortSettingsDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -344,7 +345,7 @@ func checkResourceSwitchPortSettingsUpdate(
 }
 
 func testAccSwitchPortSettingsDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_switch_port_settings_test.go
+++ b/internal/provider/resource_switch_port_settings_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // TestAccSiloResourceSwitchPortSettings_full tests whether Terraform
@@ -157,11 +158,11 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
   ]
 }
 `
-	switchPortSettingsName := newResourceName()
-	blockName := newBlockName("switch-port-settings")
+	switchPortSettingsName := NewResourceName()
+	blockName := NewBlockName("switch-port-settings")
 	resourceName := fmt.Sprintf("oxide_switch_port_settings.%s", blockName)
 
-	initialConfig, err := parsedAccConfig(
+	initialConfig, err := ParsedAccConfig(
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
@@ -172,7 +173,7 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
 		t.Errorf("error parsing initial config template data: %e", err)
 	}
 
-	updateConfig, err := parsedAccConfig(
+	updateConfig, err := ParsedAccConfig(
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
@@ -185,9 +186,9 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			PreCheck(t)
 		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccSwitchPortSettingsDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -343,7 +344,7 @@ func checkResourceSwitchPortSettingsUpdate(
 }
 
 func testAccSwitchPortSettingsDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -361,7 +362,7 @@ func testAccSwitchPortSettingsDestroy(s *terraform.State) error {
 				Port: oxide.NameOrId(rs.Primary.Attributes["id"]),
 			},
 		)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_vpc.go
+++ b/internal/provider/resource_vpc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -160,7 +161,7 @@ func (r *vpcResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -220,7 +221,7 @@ func (r *vpcResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -233,7 +234,7 @@ func (r *vpcResource) Read(
 	}
 	vpc, err := r.client.VpcView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -285,7 +286,7 @@ func (r *vpcResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -343,7 +344,7 @@ func (r *vpcResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -357,7 +358,7 @@ func (r *vpcResource) Delete(
 		Subnet: oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, paramsSubnet); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting default subnet:",
 				"API error: "+err.Error(),
@@ -375,7 +376,7 @@ func (r *vpcResource) Delete(
 		Vpc: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting VPC:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_vpc.go
+++ b/internal/provider/resource_vpc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -157,7 +158,7 @@ func (r *vpcFirewallRulesResource) Schema(
 	// TODO: Make sure users can define a single block per VPC ID, not many, is this even possible?
 	resp.Schema = schema.Schema{
 		Version: 2,
-		MarkdownDescription: replaceBackticks(`
+		MarkdownDescription: shared.ReplaceBackticks(`
 This resource manages VPC firewall rules.
 
 !> Firewall rules defined by this resource are considered exhaustive and will
@@ -252,7 +253,7 @@ rules when updating this resource.
 											"value": schema.StringAttribute{
 												// Important, if the name of the associated instance
 												// is changed Terraform will not be able to sync
-												MarkdownDescription: replaceBackticks(`
+												MarkdownDescription: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -366,7 +367,7 @@ Depending on the type, it will be one of the following:
 									"value": schema.StringAttribute{
 										// Important, if the name of the associated instance is
 										// changed Terraform will not be able to sync
-										MarkdownDescription: replaceBackticks(`
+										MarkdownDescription: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -420,7 +421,7 @@ func (r *vpcFirewallRulesResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -502,7 +503,7 @@ func (r *vpcFirewallRulesResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -515,7 +516,7 @@ func (r *vpcFirewallRulesResource) Read(
 	}
 	firewallRules, err := r.client.VpcFirewallRulesView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -585,7 +586,7 @@ func (r *vpcFirewallRulesResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -667,7 +668,7 @@ func (r *vpcFirewallRulesResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_firewall_rules.go
+++ b/internal/provider/resource_vpc_firewall_rules.go
@@ -38,7 +38,7 @@ var (
 )
 
 var (
-	vpcFirewallRuleNameRegexp = regexp.MustCompile(`^[a-z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$`)
+	VPCFirewallRuleNameRegexp = regexp.MustCompile(`^[a-z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$`)
 )
 
 // NewVPCFirewallRulesResource is a helper function to simplify the provider implementation.
@@ -187,7 +187,7 @@ rules when updating this resource.
 				Validators: []validator.Map{
 					mapvalidator.KeysAre(
 						stringvalidator.RegexMatches(
-							vpcFirewallRuleNameRegexp,
+							VPCFirewallRuleNameRegexp,
 							`Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. They can be at most 63 characters long.`,
 						),
 					),

--- a/internal/provider/resource_vpc_firewall_rules_test.go
+++ b/internal/provider/resource_vpc_firewall_rules_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -18,7 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -403,43 +405,43 @@ resource "oxide_vpc_firewall_rules" "test" {
 `
 
 func TestAccCloudResourceFirewallRules_full(t *testing.T) {
-	vpcName := NewResourceName()
+	vpcName := sharedtest.NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceFirewallRulesConfig{VPCName: vpcName}
 
-	config, err := ParsedAccConfig(tplData, resourceFirewallRulesConfigTpl)
+	config, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesConfigTpl)
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl)
+	configUpdate, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl)
 	if err != nil {
 		t.Errorf("error parsing update config template data: %e", err)
 	}
 
-	configUpdate2, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl2)
+	configUpdate2, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl2)
 	if err != nil {
 		t.Errorf("error parsing update config 2 template data: %e", err)
 	}
 
-	configUpdate3, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl3)
+	configUpdate3, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl3)
 	if err != nil {
 		t.Errorf("error parsing update config 3 template data: %e", err)
 	}
 
-	configUpdate4, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl4)
+	configUpdate4, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl4)
 	if err != nil {
 		t.Errorf("error parsing update config 4 template data: %e", err)
 	}
 
-	configUpdate5, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
+	configUpdate5, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
 	if err != nil {
 		t.Errorf("error parsing update config 5 template data: %e", err)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -471,22 +473,22 @@ func TestAccCloudResourceFirewallRules_full(t *testing.T) {
 }
 
 func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
-	vpcName := NewResourceName()
+	vpcName := sharedtest.NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceFirewallRulesConfig{VPCName: vpcName}
 
-	configV1, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTplV1)
+	configV1, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTplV1)
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configV2, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
+	configV2, err := sharedtest.ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
 	if err != nil {
 		t.Errorf("error parsing update config template data: %e", err)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { PreCheck(t) },
+		PreCheck:     func() { sharedtest.PreCheck(t) },
 		CheckDestroy: testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			// Initial state with v1 of oxide_vpc_firewall_rules.
@@ -503,7 +505,7 @@ func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
 			// Upgrade provider to use the latest version of oxide_vpc_firewall_rules.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: ProviderFactories(),
+				ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 				Config:                   configV2,
 				Check:                    checkResourceFirewallRulesUpdate5(resourceName),
 			},
@@ -516,10 +518,10 @@ func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
 // {"icmp_type": null}}`, which isn't valid. To fix, we now skip setting the nested field entirely
 // if the user hasn't set the ICMP type or code.
 func TestAccCloudResourceFirewallRules_icmp_no_filter(t *testing.T) {
-	vpcName := NewResourceName()
+	vpcName := sharedtest.NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceFirewallRulesConfig{VPCName: vpcName},
 		resourceFirewallRulesIcmpNoFilterConfigTpl,
 	)
@@ -528,8 +530,8 @@ func TestAccCloudResourceFirewallRules_icmp_no_filter(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -809,7 +811,7 @@ func checkResourceFirewallRulesV1(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccFirewallRulesDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -887,7 +889,7 @@ func TestFirewallRules_name(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.valid, vpcFirewallRuleNameRegexp.MatchString(tc.value))
+			require.Equal(t, tc.valid, provider.VPCFirewallRuleNameRegexp.MatchString(tc.value))
 		})
 	}
 }
@@ -906,7 +908,7 @@ func TestFirewallRules_v0_upgrade(t *testing.T) {
 		}
 
 		respPath := filepath.Join("test-fixtures", "resource_vpc_firewall_rules", respFile)
-		f, err := testFixtures.ReadFile(respPath)
+		f, err := provider.TestFixtures.ReadFile(respPath)
 		if err != nil {
 			t.Errorf("failed to read file %q: %v", respPath, err)
 			http.Error(w, "failed to read file", http.StatusInternalServerError)
@@ -1146,7 +1148,7 @@ resource "oxide_vpc_firewall_rules" "test" {
 			// Upgrade to current version and R16.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: ProviderFactories(),
+				ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 				PreConfig: func() {
 					version.Store(16)
 				},
@@ -1173,7 +1175,7 @@ resource "oxide_vpc_firewall_rules" "test" {
 			// Upgrade to current version.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: ProviderFactories(),
+				ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 				PreConfig: func() {
 					version.Store(16)
 				},

--- a/internal/provider/resource_vpc_firewall_rules_test.go
+++ b/internal/provider/resource_vpc_firewall_rules_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/stretchr/testify/require"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
-	"github.com/stretchr/testify/require"
 )
 
 type resourceFirewallRulesConfig struct {

--- a/internal/provider/resource_vpc_firewall_rules_test.go
+++ b/internal/provider/resource_vpc_firewall_rules_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/stretchr/testify/require"
 )
 
@@ -402,43 +403,43 @@ resource "oxide_vpc_firewall_rules" "test" {
 `
 
 func TestAccCloudResourceFirewallRules_full(t *testing.T) {
-	vpcName := newResourceName()
+	vpcName := NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceFirewallRulesConfig{VPCName: vpcName}
 
-	config, err := parsedAccConfig(tplData, resourceFirewallRulesConfigTpl)
+	config, err := ParsedAccConfig(tplData, resourceFirewallRulesConfigTpl)
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl)
+	configUpdate, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl)
 	if err != nil {
 		t.Errorf("error parsing update config template data: %e", err)
 	}
 
-	configUpdate2, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl2)
+	configUpdate2, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl2)
 	if err != nil {
 		t.Errorf("error parsing update config 2 template data: %e", err)
 	}
 
-	configUpdate3, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl3)
+	configUpdate3, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl3)
 	if err != nil {
 		t.Errorf("error parsing update config 3 template data: %e", err)
 	}
 
-	configUpdate4, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl4)
+	configUpdate4, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl4)
 	if err != nil {
 		t.Errorf("error parsing update config 4 template data: %e", err)
 	}
 
-	configUpdate5, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
+	configUpdate5, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
 	if err != nil {
 		t.Errorf("error parsing update config 5 template data: %e", err)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -470,22 +471,22 @@ func TestAccCloudResourceFirewallRules_full(t *testing.T) {
 }
 
 func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
-	vpcName := newResourceName()
+	vpcName := NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceFirewallRulesConfig{VPCName: vpcName}
 
-	configV1, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTplV1)
+	configV1, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTplV1)
 	if err != nil {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configV2, err := parsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
+	configV2, err := ParsedAccConfig(tplData, resourceFirewallRulesUpdateConfigTpl5)
 	if err != nil {
 		t.Errorf("error parsing update config template data: %e", err)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { PreCheck(t) },
 		CheckDestroy: testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			// Initial state with v1 of oxide_vpc_firewall_rules.
@@ -502,7 +503,7 @@ func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
 			// Upgrade provider to use the latest version of oxide_vpc_firewall_rules.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+				ProtoV6ProviderFactories: ProviderFactories(),
 				Config:                   configV2,
 				Check:                    checkResourceFirewallRulesUpdate5(resourceName),
 			},
@@ -515,10 +516,10 @@ func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
 // {"icmp_type": null}}`, which isn't valid. To fix, we now skip setting the nested field entirely
 // if the user hasn't set the ICMP type or code.
 func TestAccCloudResourceFirewallRules_icmp_no_filter(t *testing.T) {
-	vpcName := newResourceName()
+	vpcName := NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceFirewallRulesConfig{VPCName: vpcName},
 		resourceFirewallRulesIcmpNoFilterConfigTpl,
 	)
@@ -527,8 +528,8 @@ func TestAccCloudResourceFirewallRules_icmp_no_filter(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccFirewallRulesDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -808,7 +809,7 @@ func checkResourceFirewallRulesV1(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccFirewallRulesDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -827,7 +828,7 @@ func testAccFirewallRulesDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcFirewallRulesView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 
@@ -1145,7 +1146,7 @@ resource "oxide_vpc_firewall_rules" "test" {
 			// Upgrade to current version and R16.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+				ProtoV6ProviderFactories: ProviderFactories(),
 				PreConfig: func() {
 					version.Store(16)
 				},
@@ -1172,7 +1173,7 @@ resource "oxide_vpc_firewall_rules" "test" {
 			// Upgrade to current version.
 			{
 				ExternalProviders:        map[string]resource.ExternalProvider{},
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+				ProtoV6ProviderFactories: ProviderFactories(),
 				PreConfig: func() {
 					version.Store(16)
 				},

--- a/internal/provider/resource_vpc_internet_gateway.go
+++ b/internal/provider/resource_vpc_internet_gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_internet_gateway.go
+++ b/internal/provider/resource_vpc_internet_gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -152,7 +153,7 @@ func (r *vpcInternetGatewayResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -209,7 +210,7 @@ func (r *vpcInternetGatewayResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -222,7 +223,7 @@ func (r *vpcInternetGatewayResource) Read(
 	}
 	vpcInternetGateway, err := r.client.InternetGatewayView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -281,7 +282,7 @@ func (r *vpcInternetGatewayResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -294,7 +295,7 @@ func (r *vpcInternetGatewayResource) Update(
 	}
 	vpcInternetGateway, err := r.client.InternetGatewayView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -332,7 +333,7 @@ func (r *vpcInternetGatewayResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -349,7 +350,7 @@ func (r *vpcInternetGatewayResource) Delete(
 		Cascade: state.CascadeDelete.ValueBoolPointer(),
 	}
 	if err := r.client.InternetGatewayDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC internet gateway:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_vpc_internet_gateway_test.go
+++ b/internal/provider/resource_vpc_internet_gateway_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceVPCInternetGatewayConfig struct {
@@ -69,13 +70,13 @@ resource "oxide_vpc_internet_gateway" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
-	vpcName := newResourceName()
-	internetGatewayName := newResourceName()
-	blockName := newBlockName("internet_gateway")
-	supportBlockName := newBlockName("support")
-	vpcBlockName := newBlockName("vpc")
+	vpcName := NewResourceName()
+	internetGatewayName := NewResourceName()
+	blockName := NewBlockName("internet_gateway")
+	supportBlockName := NewBlockName("support")
+	vpcBlockName := NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_internet_gateway.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceVPCInternetGatewayConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -89,7 +90,7 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceVPCInternetGatewayConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -104,8 +105,8 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccVPCInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -161,7 +162,7 @@ func checkResourceVPCInternetGatewayUpdate(
 }
 
 func testAccVPCInternetGatewayDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -179,7 +180,7 @@ func testAccVPCInternetGatewayDestroy(s *terraform.State) error {
 			Gateway: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.InternetGatewayView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		return fmt.Errorf("internet gateway (%v) still exists", &res.Name)

--- a/internal/provider/resource_vpc_internet_gateway_test.go
+++ b/internal/provider/resource_vpc_internet_gateway_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_vpc_internet_gateway_test.go
+++ b/internal/provider/resource_vpc_internet_gateway_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceVPCInternetGatewayConfig struct {
@@ -70,13 +71,13 @@ resource "oxide_vpc_internet_gateway" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
-	vpcName := NewResourceName()
-	internetGatewayName := NewResourceName()
-	blockName := NewBlockName("internet_gateway")
-	supportBlockName := NewBlockName("support")
-	vpcBlockName := NewBlockName("vpc")
+	vpcName := sharedtest.NewResourceName()
+	internetGatewayName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("internet_gateway")
+	supportBlockName := sharedtest.NewBlockName("support")
+	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_internet_gateway.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceVPCInternetGatewayConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -90,7 +91,7 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceVPCInternetGatewayConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -105,8 +106,8 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccVPCInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -162,7 +163,7 @@ func checkResourceVPCInternetGatewayUpdate(
 }
 
 func testAccVPCInternetGatewayDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_vpc_router.go
+++ b/internal/provider/resource_vpc_router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -144,7 +145,7 @@ func (r *vpcRouterResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -202,7 +203,7 @@ func (r *vpcRouterResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -215,7 +216,7 @@ func (r *vpcRouterResource) Read(
 	}
 	vpcRouter, err := r.client.VpcRouterView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -269,7 +270,7 @@ func (r *vpcRouterResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -325,7 +326,7 @@ func (r *vpcRouterResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -337,7 +338,7 @@ func (r *vpcRouterResource) Delete(
 		Router: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcRouterDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC router:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_vpc_router.go
+++ b/internal/provider/resource_vpc_router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_router_route.go
+++ b/internal/provider/resource_vpc_router_route.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_router_route.go
+++ b/internal/provider/resource_vpc_router_route.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -127,7 +128,7 @@ This resource manages VPC router routes.
 						},
 					},
 					"value": schema.StringAttribute{
-						MarkdownDescription: replaceBackticks(`
+						MarkdownDescription: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -157,7 +158,7 @@ Depending on the type, it will be one of the following:
 						},
 					},
 					"value": schema.StringAttribute{
-						Description: replaceBackticks(`
+						Description: shared.ReplaceBackticks(`
 Depending on the type, it will be one of the following:
   - ''vpc'': Name of the VPC.
   - ''subnet'': Name of the VPC subnet.
@@ -218,7 +219,7 @@ func (r *vpcRouterRouteResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -302,7 +303,7 @@ func (r *vpcRouterRouteResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -315,7 +316,7 @@ func (r *vpcRouterRouteResource) Read(
 	}
 	vpcRouterRoute, err := r.client.VpcRouterRouteView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -385,7 +386,7 @@ func (r *vpcRouterRouteResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -468,7 +469,7 @@ func (r *vpcRouterRouteResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -480,7 +481,7 @@ func (r *vpcRouterRouteResource) Delete(
 		Route: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcRouterRouteDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC router route:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_vpc_router_route_test.go
+++ b/internal/provider/resource_vpc_router_route_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_vpc_router_route_test.go
+++ b/internal/provider/resource_vpc_router_route_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceVPCRouterRouteConfig struct {
@@ -136,15 +137,15 @@ resource "oxide_vpc_router_route" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
-	vpcName := newResourceName()
-	routerName := newResourceName()
-	routerRouteName := newResourceName()
-	routerBlockName := newBlockName("router")
-	blockName := newBlockName("route")
-	supportBlockName := newBlockName("support")
-	vpcBlockName := newBlockName("vpc")
+	vpcName := NewResourceName()
+	routerName := NewResourceName()
+	routerRouteName := NewResourceName()
+	routerBlockName := NewBlockName("router")
+	blockName := NewBlockName("route")
+	supportBlockName := NewBlockName("support")
+	vpcBlockName := NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -161,7 +162,7 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	routerRouteNameUpdated := routerRouteName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -177,14 +178,14 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	vpcNameDrop := newResourceName()
-	routerNameDrop := newResourceName()
-	routerRouteNameDrop := newResourceName()
-	routerBlockNameDrop := newBlockName("router")
-	supportBlockNameDrop := newBlockName("support")
-	vpcBlockNameDrop := newBlockName("vpc")
+	vpcNameDrop := NewResourceName()
+	routerNameDrop := NewResourceName()
+	routerRouteNameDrop := NewResourceName()
+	routerBlockNameDrop := NewBlockName("router")
+	supportBlockNameDrop := NewBlockName("support")
+	vpcBlockNameDrop := NewBlockName("vpc")
 	resourceNameDrop := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	configDrop, err := parsedAccConfig(
+	configDrop, err := ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcNameDrop,
 			SupportBlockName:   supportBlockNameDrop,
@@ -201,8 +202,8 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccVPCRouterRouteDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -310,7 +311,7 @@ func checkResourceVPCRouterRouteTargetDrop(resourceName, routerName string) reso
 }
 
 func testAccVPCRouterRouteDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -328,7 +329,7 @@ func testAccVPCRouterRouteDestroy(s *terraform.State) error {
 			Router: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.VpcRouterView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		return fmt.Errorf("router (%v) still exists", &res.Name)

--- a/internal/provider/resource_vpc_router_route_test.go
+++ b/internal/provider/resource_vpc_router_route_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceVPCRouterRouteConfig struct {
@@ -137,15 +138,15 @@ resource "oxide_vpc_router_route" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
-	vpcName := NewResourceName()
-	routerName := NewResourceName()
-	routerRouteName := NewResourceName()
-	routerBlockName := NewBlockName("router")
-	blockName := NewBlockName("route")
-	supportBlockName := NewBlockName("support")
-	vpcBlockName := NewBlockName("vpc")
+	vpcName := sharedtest.NewResourceName()
+	routerName := sharedtest.NewResourceName()
+	routerRouteName := sharedtest.NewResourceName()
+	routerBlockName := sharedtest.NewBlockName("router")
+	blockName := sharedtest.NewBlockName("route")
+	supportBlockName := sharedtest.NewBlockName("support")
+	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -162,7 +163,7 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	routerRouteNameUpdated := routerRouteName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -178,14 +179,14 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	vpcNameDrop := NewResourceName()
-	routerNameDrop := NewResourceName()
-	routerRouteNameDrop := NewResourceName()
-	routerBlockNameDrop := NewBlockName("router")
-	supportBlockNameDrop := NewBlockName("support")
-	vpcBlockNameDrop := NewBlockName("vpc")
+	vpcNameDrop := sharedtest.NewResourceName()
+	routerNameDrop := sharedtest.NewResourceName()
+	routerRouteNameDrop := sharedtest.NewResourceName()
+	routerBlockNameDrop := sharedtest.NewBlockName("router")
+	supportBlockNameDrop := sharedtest.NewBlockName("support")
+	vpcBlockNameDrop := sharedtest.NewBlockName("vpc")
 	resourceNameDrop := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	configDrop, err := ParsedAccConfig(
+	configDrop, err := sharedtest.ParsedAccConfig(
 		resourceVPCRouterRouteConfig{
 			VPCName:            vpcNameDrop,
 			SupportBlockName:   supportBlockNameDrop,
@@ -202,8 +203,8 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccVPCRouterRouteDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -311,7 +312,7 @@ func checkResourceVPCRouterRouteTargetDrop(resourceName, routerName string) reso
 }
 
 func testAccVPCRouterRouteDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_vpc_router_test.go
+++ b/internal/provider/resource_vpc_router_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceVPCRouterConfig struct {
@@ -68,13 +69,13 @@ resource "oxide_vpc_router" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCRouter_full(t *testing.T) {
-	vpcName := newResourceName()
-	routerName := newResourceName()
-	blockName := newBlockName("router")
-	supportBlockName := newBlockName("support")
-	vpcBlockName := newBlockName("vpc")
+	vpcName := NewResourceName()
+	routerName := NewResourceName()
+	blockName := NewBlockName("router")
+	supportBlockName := NewBlockName("support")
+	vpcBlockName := NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router.%s", blockName)
-	config, err := parsedAccConfig(
+	config, err := ParsedAccConfig(
 		resourceVPCRouterConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -89,7 +90,7 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 	}
 
 	routerNameUpdated := routerName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceVPCRouterConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -104,8 +105,8 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccVPCRouterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -154,7 +155,7 @@ func checkResourceVPCRouterUpdate(resourceName, routerName string) resource.Test
 }
 
 func testAccVPCRouterDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -172,7 +173,7 @@ func testAccVPCRouterDestroy(s *terraform.State) error {
 			Router: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.VpcRouterView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 		return fmt.Errorf("router (%v) still exists", &res.Name)

--- a/internal/provider/resource_vpc_router_test.go
+++ b/internal/provider/resource_vpc_router_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_vpc_router_test.go
+++ b/internal/provider/resource_vpc_router_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceVPCRouterConfig struct {
@@ -69,13 +70,13 @@ resource "oxide_vpc_router" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPCRouter_full(t *testing.T) {
-	vpcName := NewResourceName()
-	routerName := NewResourceName()
-	blockName := NewBlockName("router")
-	supportBlockName := NewBlockName("support")
-	vpcBlockName := NewBlockName("vpc")
+	vpcName := sharedtest.NewResourceName()
+	routerName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("router")
+	supportBlockName := sharedtest.NewBlockName("support")
+	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router.%s", blockName)
-	config, err := ParsedAccConfig(
+	config, err := sharedtest.ParsedAccConfig(
 		resourceVPCRouterConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -90,7 +91,7 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 	}
 
 	routerNameUpdated := routerName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceVPCRouterConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -105,8 +106,8 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccVPCRouterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -155,7 +156,7 @@ func checkResourceVPCRouterUpdate(resourceName, routerName string) resource.Test
 }
 
 func testAccVPCRouterDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_vpc_subnet.go
+++ b/internal/provider/resource_vpc_subnet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 

--- a/internal/provider/resource_vpc_subnet.go
+++ b/internal/provider/resource_vpc_subnet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -167,7 +168,7 @@ func (r *vpcSubnetResource) Create(
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, defaultTimeout())
+	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -226,7 +227,7 @@ func (r *vpcSubnetResource) Read(
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, defaultTimeout())
+	readTimeout, diags := state.Timeouts.Read(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -239,7 +240,7 @@ func (r *vpcSubnetResource) Read(
 	}
 	subnet, err := r.client.VpcSubnetView(ctx, params)
 	if err != nil {
-		if is404(err) {
+		if shared.Is404(err) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -294,7 +295,7 @@ func (r *vpcSubnetResource) Update(
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultTimeout())
+	updateTimeout, diags := plan.Timeouts.Update(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -350,7 +351,7 @@ func (r *vpcSubnetResource) Delete(
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultTimeout())
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -362,7 +363,7 @@ func (r *vpcSubnetResource) Delete(
 		Subnet: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, params); err != nil {
-		if !is404(err) {
+		if !shared.Is404(err) {
 			resp.Diagnostics.AddError(
 				"Error deleting VPC subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/resource_vpc_subnet_test.go
+++ b/internal/provider/resource_vpc_subnet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_vpc_subnet_test.go
+++ b/internal/provider/resource_vpc_subnet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type vpcSubnetTestConfig struct {
@@ -54,7 +55,7 @@ resource "oxide_vpc_subnet" "test" {
 
 func buildVPCSubnetConfig(t *testing.T, cfg vpcSubnetTestConfig) string {
 	t.Helper()
-	config, err := parsedAccConfig(cfg, vpcSubnetConfigTpl)
+	config, err := ParsedAccConfig(cfg, vpcSubnetConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -82,8 +83,8 @@ func TestAccCloudResourceVPCSubnet_full(t *testing.T) {
 	ipv6Config.IPv6Block = "fdfe:f6a5:5f06:a643::/64"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccVPCSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -159,7 +160,7 @@ func checkResourceVPCSubnetIPv6(subnetName string) resource.TestCheckFunc {
 }
 
 func testAccVPCSubnetDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -178,7 +179,7 @@ func testAccVPCSubnetDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcSubnetView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/resource_vpc_subnet_test.go
+++ b/internal/provider/resource_vpc_subnet_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type vpcSubnetTestConfig struct {
@@ -55,7 +56,7 @@ resource "oxide_vpc_subnet" "test" {
 
 func buildVPCSubnetConfig(t *testing.T, cfg vpcSubnetTestConfig) string {
 	t.Helper()
-	config, err := ParsedAccConfig(cfg, vpcSubnetConfigTpl)
+	config, err := sharedtest.ParsedAccConfig(cfg, vpcSubnetConfigTpl)
 	if err != nil {
 		t.Fatalf("error parsing config template: %v", err)
 	}
@@ -83,8 +84,8 @@ func TestAccCloudResourceVPCSubnet_full(t *testing.T) {
 	ipv6Config.IPv6Block = "fdfe:f6a5:5f06:a643::/64"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccVPCSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -160,7 +161,7 @@ func checkResourceVPCSubnetIPv6(subnetName string) resource.TestCheckFunc {
 }
 
 func testAccVPCSubnetDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_vpc_test.go
+++ b/internal/provider/resource_vpc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )

--- a/internal/provider/resource_vpc_test.go
+++ b/internal/provider/resource_vpc_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceVPCConfig struct {
@@ -69,11 +70,11 @@ resource "oxide_vpc" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPC_full(t *testing.T) {
-	vpcName := NewResourceName()
-	blockName := NewBlockName("vpc")
+	vpcName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc.%s", blockName)
-	supportBlockName := NewBlockName("support")
-	config, err := ParsedAccConfig(
+	supportBlockName := sharedtest.NewBlockName("support")
+	config, err := sharedtest.ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName,
 			VPCName:          vpcName,
@@ -86,7 +87,7 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 	}
 
 	vpcNameUpdated := vpcName + "-updated"
-	configUpdate, err := ParsedAccConfig(
+	configUpdate, err := sharedtest.ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName,
 			VPCName:          vpcNameUpdated,
@@ -98,10 +99,10 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	blockName2 := NewBlockName("vpc")
+	blockName2 := sharedtest.NewBlockName("vpc")
 	resourceName2 := fmt.Sprintf("oxide_vpc.%s", blockName2)
 	vpcName2 := vpcName + "-2"
-	config2, err := ParsedAccConfig(
+	config2, err := sharedtest.ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName2,
 			VPCName:          vpcName2,
@@ -114,8 +115,8 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { PreCheck(t) },
-		ProtoV6ProviderFactories: ProviderFactories(),
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
 		CheckDestroy:             testAccVPCDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -191,7 +192,7 @@ func checkResourceVPCIPv6(resourceName, vpcName string) resource.TestCheckFunc {
 }
 
 func testAccVPCDestroy(s *terraform.State) error {
-	client, err := NewTestClient()
+	client, err := sharedtest.NewTestClient()
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_vpc_test.go
+++ b/internal/provider/resource_vpc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceVPCConfig struct {
@@ -68,11 +69,11 @@ resource "oxide_vpc" "{{.BlockName}}" {
 `
 
 func TestAccCloudResourceVPC_full(t *testing.T) {
-	vpcName := newResourceName()
-	blockName := newBlockName("vpc")
+	vpcName := NewResourceName()
+	blockName := NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc.%s", blockName)
-	supportBlockName := newBlockName("support")
-	config, err := parsedAccConfig(
+	supportBlockName := NewBlockName("support")
+	config, err := ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName,
 			VPCName:          vpcName,
@@ -85,7 +86,7 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 	}
 
 	vpcNameUpdated := vpcName + "-updated"
-	configUpdate, err := parsedAccConfig(
+	configUpdate, err := ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName,
 			VPCName:          vpcNameUpdated,
@@ -97,10 +98,10 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 		t.Errorf("error parsing config template data: %e", err)
 	}
 
-	blockName2 := newBlockName("vpc")
+	blockName2 := NewBlockName("vpc")
 	resourceName2 := fmt.Sprintf("oxide_vpc.%s", blockName2)
 	vpcName2 := vpcName + "-2"
-	config2, err := parsedAccConfig(
+	config2, err := ParsedAccConfig(
 		resourceVPCConfig{
 			BlockName:        blockName2,
 			VPCName:          vpcName2,
@@ -113,8 +114,8 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProviderFactories(),
 		CheckDestroy:             testAccVPCDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -190,7 +191,7 @@ func checkResourceVPCIPv6(resourceName, vpcName string) resource.TestCheckFunc {
 }
 
 func testAccVPCDestroy(s *terraform.State) error {
-	client, err := newTestClient()
+	client, err := NewTestClient()
 	if err != nil {
 		return err
 	}
@@ -209,7 +210,7 @@ func testAccVPCDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcView(ctx, params)
-		if err != nil && is404(err) {
+		if err != nil && shared.Is404(err) {
 			continue
 		}
 

--- a/internal/provider/shared/planmodifiers.go
+++ b/internal/provider/shared/planmodifiers.go
@@ -1,4 +1,4 @@
-package provider
+package shared
 
 import (
 	"context"

--- a/internal/provider/shared/utils.go
+++ b/internal/provider/shared/utils.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package shared
 
 import (
 	"net"
@@ -15,45 +15,43 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
-// replaceBackticks replaces ” with `. It can be used to defined codeblocks in
+// ReplaceBackticks replaces ” with `. It can be used to defined codeblocks in
 // markdown raw strings.
 //
-//	var mdString = replaceBackticks(`this is a ''code'' block`)
-func replaceBackticks(s string) string {
+//	var mdString = ReplaceBackticks(`this is a ''code'' block`)
+func ReplaceBackticks(s string) string {
 	return strings.ReplaceAll(s, "''", "`")
 }
 
-func is404(err error) bool {
+func Is404(err error) bool {
 	return strings.Contains(err.Error(), "Status: 404")
 }
 
+// IsIPv4 checks if the string is an IP version 4.
 // Original function from https://pkg.go.dev/github.com/asaskevich/govalidator#IsIPv4
 // Shamelessly copied here to avoid importing the entire package
-//
-// isIPv4 checks if the string is an IP version 4.
-func isIPv4(str string) bool {
+func IsIPv4(str string) bool {
 	ip := net.ParseIP(str)
 	return ip != nil && strings.Contains(str, ".")
 }
 
+// IsIPv6 checks if the string is an IP version 6.
 // Original function from https://pkg.go.dev/github.com/asaskevich/govalidator#IsIPv6
 // Shamelessly copied here to avoid importing the entire package
-//
-// isIPv6 checks if the string is an IP version 6.
-func isIPv6(str string) bool {
+func IsIPv6(str string) bool {
 	ip := net.ParseIP(str)
 	return ip != nil && strings.Contains(str, ":")
 }
 
-func defaultTimeout() time.Duration {
+func DefaultTimeout() time.Duration {
 	return 10 * time.Minute
 }
 
-// sliceDiff returns a slice of the elements in `a` that aren't in `b`.
+// SliceDiff returns a slice of the elements in `a` that aren't in `b`.
 // This function is a bit expensive, but given the fact that
 // the expected number of elements is relatively slow
 // it's not a big deal.
-func sliceDiff[S []E, E any](a, b S) S {
+func SliceDiff[S []E, E any](a, b S) S {
 	mb := make(map[any]struct{}, len(b))
 	for _, x := range b {
 		mb[x] = struct{}{}
@@ -68,9 +66,9 @@ func sliceDiff[S []E, E any](a, b S) S {
 	return diff
 }
 
-// sliceDiffByID is similar to [sliceDiff] but takes idFn, which should return
+// SliceDiffByID is similar to [SliceDiff] but takes idFn, which should return
 // a value used to identity slice elements.
-func sliceDiffByID[S []E, E any](a, b S, idFn func(E) any) S {
+func SliceDiffByID[S []E, E any](a, b S, idFn func(E) any) S {
 	mb := make(map[any]struct{}, len(b))
 	for _, x := range b {
 		mb[idFn(x)] = struct{}{}
@@ -85,8 +83,8 @@ func sliceDiffByID[S []E, E any](a, b S, idFn func(E) any) S {
 	return diff
 }
 
-// newNameOrIdList takes a terraform set and converts is into a slice NameOrIds.
-func newNameOrIdList(nameOrIDs types.Set) ([]oxide.NameOrId, diag.Diagnostics) {
+// NewNameOrIdList takes a terraform set and converts is into a slice NameOrIds.
+func NewNameOrIdList(nameOrIDs types.Set) ([]oxide.NameOrId, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var list = []oxide.NameOrId{}
 	for _, item := range nameOrIDs.Elements() {

--- a/internal/provider/shared/utils_test.go
+++ b/internal/provider/shared/utils_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package shared
 
 import (
 	"testing"
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +40,7 @@ func Test_isIPv4(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.IsIPv4(tt.args.str)
+			got := IsIPv4(tt.args.str)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -74,7 +73,7 @@ func Test_isIPv6(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.IsIPv6(tt.args.str)
+			got := IsIPv6(tt.args.str)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -129,12 +128,12 @@ func Test_sliceDiff(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.SliceDiff(tt.args.a, tt.args.b)
+			got := SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name+" by ID", func(t *testing.T) {
-			got := shared.SliceDiffByID(
+			got := SliceDiffByID(
 				tt.args.a, tt.args.b,
 				func(el attr.Value) any {
 					return el.String()
@@ -166,12 +165,12 @@ func Test_sliceDiff_int(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.SliceDiff(tt.args.a, tt.args.b)
+			got := SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name+"by ID", func(t *testing.T) {
-			got := shared.SliceDiffByID(
+			got := SliceDiffByID(
 				tt.args.a, tt.args.b,
 				func(el int) any {
 					return el
@@ -215,12 +214,12 @@ func Test_sliceDiff_model(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.SliceDiff(tt.args.a, tt.args.b)
+			got := SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
-			got := shared.SliceDiffByID(
+			got := SliceDiffByID(
 				tt.args.a, tt.args.b,
 				func(el localModel) any {
 					return el.Name
@@ -257,7 +256,7 @@ func Test_newNameOrIdList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			set := types.SetValueMust(types.StringType, tt.args)
-			got, diags := shared.NewNameOrIdList(set)
+			got, diags := NewNameOrIdList(set)
 			if diags.HasError() {
 				// We know diags can only contain a single error in this function
 				t.Errorf("unexpected error: %s: %s ", diags[0].Summary(), diags[0].Detail())

--- a/internal/provider/sharedtest/sharedtest.go
+++ b/internal/provider/sharedtest/sharedtest.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package sharedtest
 
 import (
 	"bytes"
@@ -18,33 +18,46 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	provider "github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 )
 
 func ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
-		"oxide": providerserver.NewProtocol6WithError(New()),
+		"oxide": providerserver.NewProtocol6WithError(
+			provider.New(),
+		),
 	}
 }
 
 func PreCheck(t *testing.T) {
 	if _, err := NewTestClient(); err != nil {
-		t.Fatalf("failed to create oxide client for acceptance tests: %v", err)
+		t.Fatalf(
+			"failed to create oxide client for acceptance tests: %v",
+			err,
+		)
 	}
 }
 
 func NewTestClient() (*oxide.Client, error) {
 	client, err := oxide.NewClient(
-		oxide.WithUserAgent(fmt.Sprintf("terraform-provider-oxide/%s", Version)),
+		oxide.WithUserAgent(
+			fmt.Sprintf(
+				"terraform-provider-oxide/%s",
+				provider.Version,
+			),
+		),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	return client, nil
-
 }
 
-func ParsedAccConfig(config any, tpl string) (string, error) {
+func ParsedAccConfig(
+	config any,
+	tpl string,
+) (string, error) {
 	var buf bytes.Buffer
 	tmpl, _ := template.New("test").Parse(tpl)
 	err := tmpl.Execute(&buf, config)
@@ -63,22 +76,29 @@ func NewBlockName(resource string) string {
 	return fmt.Sprintf("acc-%s-%s", resource, uuid.New())
 }
 
-// CaptureResourceID captures the resource ID for later comparison.
-// Use with resource.TestCheckResourceAttrPtr to verify updates don't recreate resources.
-func CaptureResourceID(resourceName string, id *string) resource.TestCheckFunc {
+// CaptureResourceID captures the resource ID for later
+// comparison. Use with resource.TestCheckResourceAttrPtr
+// to verify updates don't recreate resources.
+func CaptureResourceID(
+	resourceName string,
+	id *string,
+) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("resource not found: %s", resourceName)
+			return fmt.Errorf(
+				"resource not found: %s",
+				resourceName,
+			)
 		}
 		*id = rs.Primary.ID
 		return nil
 	}
 }
 
-// VerifyResourceIDChanged verifies the resource ID is different from the previously captured
-// ID.
-// Use to confirm a resource was replaced (destroyed and recreated).
+// VerifyResourceIDChanged verifies the resource ID is
+// different from the previously captured ID. Use to confirm
+// a resource was replaced (destroyed and recreated).
 func VerifyResourceIDChanged(
 	resourceName string,
 	previousID *string,
@@ -86,10 +106,17 @@ func VerifyResourceIDChanged(
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("resource not found: %s", resourceName)
+			return fmt.Errorf(
+				"resource not found: %s",
+				resourceName,
+			)
 		}
 		if rs.Primary.ID == *previousID {
-			return fmt.Errorf("resource was not replaced: ID unchanged (%s)", *previousID)
+			return fmt.Errorf(
+				"resource was not replaced: "+
+					"ID unchanged (%s)",
+				*previousID,
+			)
 		}
 		return nil
 	}
@@ -104,13 +131,18 @@ func SiloDNSName() string {
 
 var subnetCounter uint32
 
-// NextSubnetCIDR returns sequential /24 subnet CIDRs from the 10.128.0.0/16 range.
-// TODO: extend if we ever need more than 256 subnets in tests.
+// NextSubnetCIDR returns sequential /24 subnet CIDRs from
+// the 10.128.0.0/16 range.
+// TODO: extend if we ever need more than 256 subnets in
+// tests.
 func NextSubnetCIDR(t *testing.T) string {
 	t.Helper()
 	n := atomic.AddUint32(&subnetCounter, 1) - 1
 	if n > 255 {
-		t.Fatal("NextSubnetCIDR: exhausted all 256 /24 subnets in 10.128.0.0/16")
+		t.Fatal(
+			"NextSubnetCIDR: exhausted all 256 /24" +
+				" subnets in 10.128.0.0/16",
+		)
 	}
 	return fmt.Sprintf("10.128.%d.0/24", n)
 }

--- a/internal/provider/sharedtest/sharedtest.go
+++ b/internal/provider/sharedtest/sharedtest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
+
 	provider "github.com/oxidecomputer/terraform-provider-oxide/internal/provider"
 )
 

--- a/internal/provider/sharedtest/sharedtest_test.go
+++ b/internal/provider/sharedtest/sharedtest_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package provider
+package sharedtest
 
 import (
 	"testing"

--- a/internal/provider/testing.go
+++ b/internal/provider/testing.go
@@ -7,4 +7,4 @@ package provider
 import "embed"
 
 //go:embed test-fixtures
-var testFixtures embed.FS
+var TestFixtures embed.FS

--- a/internal/provider/testutils.go
+++ b/internal/provider/testutils.go
@@ -20,19 +20,19 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
-func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+func ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
 		"oxide": providerserver.NewProtocol6WithError(New()),
 	}
 }
 
-func testAccPreCheck(t *testing.T) {
-	if _, err := newTestClient(); err != nil {
+func PreCheck(t *testing.T) {
+	if _, err := NewTestClient(); err != nil {
 		t.Fatalf("failed to create oxide client for acceptance tests: %v", err)
 	}
 }
 
-func newTestClient() (*oxide.Client, error) {
+func NewTestClient() (*oxide.Client, error) {
 	client, err := oxide.NewClient(
 		oxide.WithUserAgent(fmt.Sprintf("terraform-provider-oxide/%s", Version)),
 	)
@@ -44,7 +44,7 @@ func newTestClient() (*oxide.Client, error) {
 
 }
 
-func parsedAccConfig(config any, tpl string) (string, error) {
+func ParsedAccConfig(config any, tpl string) (string, error) {
 	var buf bytes.Buffer
 	tmpl, _ := template.New("test").Parse(tpl)
 	err := tmpl.Execute(&buf, config)
@@ -55,17 +55,17 @@ func parsedAccConfig(config any, tpl string) (string, error) {
 	return buf.String(), nil
 }
 
-func newResourceName() string {
+func NewResourceName() string {
 	return fmt.Sprintf("acc-terraform-%s", uuid.New())
 }
 
-func newBlockName(resource string) string {
+func NewBlockName(resource string) string {
 	return fmt.Sprintf("acc-%s-%s", resource, uuid.New())
 }
 
-// testAccCaptureResourceID captures the resource ID for later comparison.
+// CaptureResourceID captures the resource ID for later comparison.
 // Use with resource.TestCheckResourceAttrPtr to verify updates don't recreate resources.
-func testAccCaptureResourceID(resourceName string, id *string) resource.TestCheckFunc {
+func CaptureResourceID(resourceName string, id *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -76,10 +76,10 @@ func testAccCaptureResourceID(resourceName string, id *string) resource.TestChec
 	}
 }
 
-// testAccVerifyResourceIDChanged verifies the resource ID is different from the previously captured
+// VerifyResourceIDChanged verifies the resource ID is different from the previously captured
 // ID.
 // Use to confirm a resource was replaced (destroyed and recreated).
-func testAccVerifyResourceIDChanged(
+func VerifyResourceIDChanged(
 	resourceName string,
 	previousID *string,
 ) resource.TestCheckFunc {
@@ -95,7 +95,7 @@ func testAccVerifyResourceIDChanged(
 	}
 }
 
-func testAccSiloDNSName() string {
+func SiloDNSName() string {
 	if v := os.Getenv("OXIDE_TEST_SILO_DNS_NAME"); v != "" {
 		return v
 	}
@@ -104,13 +104,13 @@ func testAccSiloDNSName() string {
 
 var subnetCounter uint32
 
-// nextSubnetCIDR returns sequential /24 subnet CIDRs from the 10.128.0.0/16 range.
+// NextSubnetCIDR returns sequential /24 subnet CIDRs from the 10.128.0.0/16 range.
 // TODO: extend if we ever need more than 256 subnets in tests.
-func nextSubnetCIDR(t *testing.T) string {
+func NextSubnetCIDR(t *testing.T) string {
 	t.Helper()
 	n := atomic.AddUint32(&subnetCounter, 1) - 1
 	if n > 255 {
-		t.Fatal("nextSubnetCIDR: exhausted all 256 /24 subnets in 10.128.0.0/16")
+		t.Fatal("NextSubnetCIDR: exhausted all 256 /24 subnets in 10.128.0.0/16")
 	}
 	return fmt.Sprintf("10.128.%d.0/24", n)
 }

--- a/internal/provider/testutils_test.go
+++ b/internal/provider/testutils_test.go
@@ -22,10 +22,10 @@ func Test_newResourceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			name1 := newResourceName()
-			name2 := newResourceName()
-			name3 := newResourceName()
-			name4 := newResourceName()
+			name1 := NewResourceName()
+			name2 := NewResourceName()
+			name3 := NewResourceName()
+			name4 := NewResourceName()
 			assert.NotEqual(t, name1, name2, name3, name4)
 			assert.Contains(t, name1, tt.want)
 			assert.Contains(t, name2, tt.want)
@@ -47,10 +47,10 @@ func Test_newBlockName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			name1 := newBlockName("vpc")
-			name2 := newBlockName("vpc")
-			name3 := newBlockName("vpc")
-			name4 := newBlockName("vpc")
+			name1 := NewBlockName("vpc")
+			name2 := NewBlockName("vpc")
+			name3 := NewBlockName("vpc")
+			name4 := NewBlockName("vpc")
 			assert.NotEqual(t, name1, name2, name3, name4)
 			assert.Contains(t, name1, tt.want)
 			assert.Contains(t, name2, tt.want)

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +41,7 @@ func Test_isIPv4(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isIPv4(tt.args.str)
+			got := shared.IsIPv4(tt.args.str)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -73,7 +74,7 @@ func Test_isIPv6(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isIPv6(tt.args.str)
+			got := shared.IsIPv6(tt.args.str)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -128,12 +129,12 @@ func Test_sliceDiff(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sliceDiff(tt.args.a, tt.args.b)
+			got := shared.SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name+" by ID", func(t *testing.T) {
-			got := sliceDiffByID(
+			got := shared.SliceDiffByID(
 				tt.args.a, tt.args.b,
 				func(el attr.Value) any {
 					return el.String()
@@ -165,12 +166,12 @@ func Test_sliceDiff_int(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sliceDiff(tt.args.a, tt.args.b)
+			got := shared.SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name+"by ID", func(t *testing.T) {
-			got := sliceDiffByID(
+			got := shared.SliceDiffByID(
 				tt.args.a, tt.args.b,
 				func(el int) any {
 					return el
@@ -182,28 +183,31 @@ func Test_sliceDiff_int(t *testing.T) {
 }
 
 func Test_sliceDiff_model(t *testing.T) {
+	type localModel struct {
+		Name types.String
+	}
 	type args struct {
-		a []instanceResourceNICModel
-		b []instanceResourceNICModel
+		a []localModel
+		b []localModel
 	}
 	tests := []struct {
 		name string
 		args args
-		want []instanceResourceNICModel
+		want []localModel
 	}{
 		{
 			name: "success",
 			args: args{
-				a: []instanceResourceNICModel{
+				a: []localModel{
 					{Name: types.StringValue("bib")},
 					{Name: types.StringValue("bob")},
 					{Name: types.StringValue("bub")},
 				},
-				b: []instanceResourceNICModel{
+				b: []localModel{
 					{Name: types.StringValue("bub")},
 				},
 			},
-			want: []instanceResourceNICModel{
+			want: []localModel{
 				{Name: types.StringValue("bib")},
 				{Name: types.StringValue("bob")},
 			},
@@ -211,14 +215,14 @@ func Test_sliceDiff_model(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sliceDiff(tt.args.a, tt.args.b)
+			got := shared.SliceDiff(tt.args.a, tt.args.b)
 			assert.Equal(t, tt.want, got)
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
-			got := sliceDiffByID(
+			got := shared.SliceDiffByID(
 				tt.args.a, tt.args.b,
-				func(el instanceResourceNICModel) any {
+				func(el localModel) any {
 					return el.Name
 				},
 			)
@@ -253,7 +257,7 @@ func Test_newNameOrIdList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			set := types.SetValueMust(types.StringType, tt.args)
-			got, diags := newNameOrIdList(set)
+			got, diags := shared.NewNameOrIdList(set)
 			if diags.HasError() {
 				// We know diags can only contain a single error in this function
 				t.Errorf("unexpected error: %s: %s ", diags[0].Summary(), diags[0].Detail())


### PR DESCRIPTION
Refactored the repository according to phase 1 from SSE-266.

* Created the `internal/provider/shared` package and moved `utils.go` and `planmodifiers.go` within, exporting the necessary identifiers for use by other packages.

* Exported identifiers in `testutils.go` for use by other packages.

Part of SSE-266.