### PR TITLE
misc: explicit resource and data source model types

### DIFF
--- a/internal/provider/address_lot/datasource.go
+++ b/internal/provider/address_lot/datasource.go
@@ -26,7 +26,7 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	Blocks       []DataSourceBlockModel `tfsdk:"blocks"`
+	Blocks       []BlockDataSourceModel `tfsdk:"blocks"`
 	Description  types.String           `tfsdk:"description"`
 	Kind         types.String           `tfsdk:"kind"`
 	Name         types.String           `tfsdk:"name"`
@@ -36,7 +36,7 @@ type DataSourceModel struct {
 	Timeouts     timeouts.Value         `tfsdk:"timeouts"`
 }
 
-type DataSourceBlockModel struct {
+type BlockDataSourceModel struct {
 	ID           types.String `tfsdk:"id"`
 	FirstAddress types.String `tfsdk:"first_address"`
 	LastAddress  types.String `tfsdk:"last_address"`
@@ -168,9 +168,9 @@ func (d *DataSource) Read(
 	state.TimeCreated = types.StringValue(lot.TimeCreated.String())
 	state.TimeModified = types.StringValue(lot.TimeModified.String())
 
-	blockModels := make([]DataSourceBlockModel, len(addressLot.Blocks))
+	blockModels := make([]BlockDataSourceModel, len(addressLot.Blocks))
 	for index, item := range addressLot.Blocks {
-		blockModels[index] = DataSourceBlockModel{
+		blockModels[index] = BlockDataSourceModel{
 			ID:           types.StringValue(item.Id),
 			FirstAddress: types.StringValue(item.FirstAddress),
 			LastAddress:  types.StringValue(item.LastAddress),

--- a/internal/provider/address_lot/resource.go
+++ b/internal/provider/address_lot/resource.go
@@ -40,18 +40,18 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	Blocks       []BlockModel   `tfsdk:"blocks"`
-	Description  types.String   `tfsdk:"description"`
-	Kind         types.String   `tfsdk:"kind"`
-	Name         types.String   `tfsdk:"name"`
-	ID           types.String   `tfsdk:"id"`
-	TimeCreated  types.String   `tfsdk:"time_created"`
-	TimeModified types.String   `tfsdk:"time_modified"`
-	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+type ResourceModel struct {
+	Blocks       []BlockResourceModel `tfsdk:"blocks"`
+	Description  types.String         `tfsdk:"description"`
+	Kind         types.String         `tfsdk:"kind"`
+	Name         types.String         `tfsdk:"name"`
+	ID           types.String         `tfsdk:"id"`
+	TimeCreated  types.String         `tfsdk:"time_created"`
+	TimeModified types.String         `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value       `tfsdk:"timeouts"`
 }
 
-type BlockModel struct {
+type BlockResourceModel struct {
 	ID           types.String `tfsdk:"id"`
 	FirstAddress types.String `tfsdk:"first_address"`
 	LastAddress  types.String `tfsdk:"last_address"`
@@ -176,7 +176,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -227,9 +227,9 @@ func (r *Resource) Create(
 	plan.TimeModified = types.StringValue(lot.Lot.TimeModified.String())
 
 	// Populate blocks with computed values.
-	blockModels := make([]BlockModel, len(lot.Blocks))
+	blockModels := make([]BlockResourceModel, len(lot.Blocks))
 	for index, item := range lot.Blocks {
-		blockModels[index] = BlockModel{
+		blockModels[index] = BlockResourceModel{
 			ID:           types.StringValue(item.Id),
 			FirstAddress: types.StringValue(item.FirstAddress),
 			LastAddress:  types.StringValue(item.LastAddress),
@@ -250,7 +250,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -290,9 +290,9 @@ func (r *Resource) Read(
 	state.TimeCreated = types.StringValue(lot.TimeCreated.String())
 	state.TimeModified = types.StringValue(lot.TimeModified.String())
 
-	blockModels := make([]BlockModel, len(addressLot.Blocks))
+	blockModels := make([]BlockResourceModel, len(addressLot.Blocks))
 	for index, item := range addressLot.Blocks {
-		blockModels[index] = BlockModel{
+		blockModels[index] = BlockResourceModel{
 			ID:           types.StringValue(item.Id),
 			FirstAddress: types.StringValue(item.FirstAddress),
 			LastAddress:  types.StringValue(item.LastAddress),
@@ -328,7 +328,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/anti_affinity_group/resource.go
+++ b/internal/provider/anti_affinity_group/resource.go
@@ -39,7 +39,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description   types.String   `tfsdk:"description"`
 	FailureDomain types.String   `tfsdk:"failure_domain"`
 	ID            types.String   `tfsdk:"id"`
@@ -158,7 +158,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -218,7 +218,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -278,8 +278,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -342,7 +342,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/disk/datasource.go
+++ b/internal/provider/disk/datasource.go
@@ -35,26 +35,26 @@ type DataSource struct {
 
 // DataSourceModel are the attributes that are supported on this data source.
 type DataSourceModel struct {
-	ID           types.String   `tfsdk:"id"`
-	Name         types.String   `tfsdk:"name"`
-	Description  types.String   `tfsdk:"description"`
-	BlockSize    types.Int64    `tfsdk:"block_size"`
-	DevicePath   types.String   `tfsdk:"device_path"`
-	ProjectName  types.String   `tfsdk:"project_name"`
-	ProjectID    types.String   `tfsdk:"project_id"`
-	Size         types.Int64    `tfsdk:"size"`
-	State        *StateModel    `tfsdk:"state"`
-	ImageID      types.String   `tfsdk:"image_id"`
-	SnapshotID   types.String   `tfsdk:"snapshot_id"`
-	DiskType     types.String   `tfsdk:"disk_type"`
-	ReadOnly     types.Bool     `tfsdk:"read_only"`
-	TimeCreated  types.String   `tfsdk:"time_created"`
-	TimeModified types.String   `tfsdk:"time_modified"`
-	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+	ID           types.String          `tfsdk:"id"`
+	Name         types.String          `tfsdk:"name"`
+	Description  types.String          `tfsdk:"description"`
+	BlockSize    types.Int64           `tfsdk:"block_size"`
+	DevicePath   types.String          `tfsdk:"device_path"`
+	ProjectName  types.String          `tfsdk:"project_name"`
+	ProjectID    types.String          `tfsdk:"project_id"`
+	Size         types.Int64           `tfsdk:"size"`
+	State        *StateDataSourceModel `tfsdk:"state"`
+	ImageID      types.String          `tfsdk:"image_id"`
+	SnapshotID   types.String          `tfsdk:"snapshot_id"`
+	DiskType     types.String          `tfsdk:"disk_type"`
+	ReadOnly     types.Bool            `tfsdk:"read_only"`
+	TimeCreated  types.String          `tfsdk:"time_created"`
+	TimeModified types.String          `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value        `tfsdk:"timeouts"`
 }
 
-// StateModel are the attributes for the disk state.
-type StateModel struct {
+// StateDataSourceModel are the attributes for the disk state.
+type StateDataSourceModel struct {
 	State    types.String `tfsdk:"state"`
 	Instance types.String `tfsdk:"instance"`
 }
@@ -224,7 +224,7 @@ func (d *DataSource) Read(
 	}
 
 	// Set disk state
-	state.State = &StateModel{
+	state.State = &StateDataSourceModel{
 		State: types.StringValue(string(disk.State.State())),
 	}
 	switch v := disk.State.Value.(type) {

--- a/internal/provider/disk/resource.go
+++ b/internal/provider/disk/resource.go
@@ -45,7 +45,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	BlockSize        types.Int64    `tfsdk:"block_size"`
 	Description      types.String   `tfsdk:"description"`
 	DevicePath       types.String   `tfsdk:"device_path"`
@@ -249,7 +249,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -343,7 +343,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -421,7 +421,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -474,7 +474,7 @@ func (v *LocalSourceValidator) ValidateResource(
 	req resource.ValidateConfigRequest,
 	resp *resource.ValidateConfigResponse,
 ) {
-	var config Model
+	var config ResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -532,7 +532,7 @@ func (v *ReadOnlySourceValidator) ValidateResource(
 	req resource.ValidateConfigRequest,
 	resp *resource.ValidateConfigResponse,
 ) {
-	var config Model
+	var config ResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/external_subnet/resource.go
+++ b/internal/provider/external_subnet/resource.go
@@ -45,7 +45,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	ID                 types.String       `tfsdk:"id"`
 	Name               types.String       `tfsdk:"name"`
 	Description        types.String       `tfsdk:"description"`
@@ -217,7 +217,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -323,7 +323,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -386,8 +386,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -453,7 +453,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/external_subnet_attachment/resource.go
+++ b/internal/provider/external_subnet_attachment/resource.go
@@ -38,7 +38,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	ID               types.String   `tfsdk:"id"`
 	ExternalSubnetID types.String   `tfsdk:"external_subnet_id"`
 	InstanceID       types.String   `tfsdk:"instance_id"`
@@ -124,7 +124,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -181,7 +181,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -242,7 +242,7 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -261,7 +261,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/floating_ip/resource.go
+++ b/internal/provider/floating_ip/resource.go
@@ -25,9 +25,9 @@ import (
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
-// Model represents the Terraform configuration and state for
+// ResourceModel represents the Terraform configuration and state for
 // the Oxide floating IP resource.
-type Model struct {
+type ResourceModel struct {
 	ID           types.String      `tfsdk:"id"`
 	Name         types.String      `tfsdk:"name"`
 	Description  types.String      `tfsdk:"description"`
@@ -196,7 +196,7 @@ func (f *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -284,7 +284,7 @@ func (f *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -347,8 +347,8 @@ func (f *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -414,7 +414,7 @@ func (f *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/image/datasource.go
+++ b/internal/provider/image/datasource.go
@@ -33,22 +33,22 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	ID           types.String                `tfsdk:"id"`
-	ProjectName  types.String                `tfsdk:"project_name"`
-	ProjectID    types.String                `tfsdk:"project_id"`
-	Timeouts     timeouts.Value              `tfsdk:"timeouts"`
-	BlockSize    types.Int64                 `tfsdk:"block_size"`
-	Description  types.String                `tfsdk:"description"`
-	Digest       *imageDataSourceDigestModel `tfsdk:"digest"`
-	Name         types.String                `tfsdk:"name"`
-	OS           types.String                `tfsdk:"os"`
-	Size         types.Int64                 `tfsdk:"size"`
-	TimeCreated  types.String                `tfsdk:"time_created"`
-	TimeModified types.String                `tfsdk:"time_modified"`
-	Version      types.String                `tfsdk:"version"`
+	ID           types.String           `tfsdk:"id"`
+	ProjectName  types.String           `tfsdk:"project_name"`
+	ProjectID    types.String           `tfsdk:"project_id"`
+	Timeouts     timeouts.Value         `tfsdk:"timeouts"`
+	BlockSize    types.Int64            `tfsdk:"block_size"`
+	Description  types.String           `tfsdk:"description"`
+	Digest       *DigestDataSourceModel `tfsdk:"digest"`
+	Name         types.String           `tfsdk:"name"`
+	OS           types.String           `tfsdk:"os"`
+	Size         types.Int64            `tfsdk:"size"`
+	TimeCreated  types.String           `tfsdk:"time_created"`
+	TimeModified types.String           `tfsdk:"time_modified"`
+	Version      types.String           `tfsdk:"version"`
 }
 
-type imageDataSourceDigestModel struct {
+type DigestDataSourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
@@ -207,7 +207,7 @@ func (d *DataSource) Read(
 			)
 			return
 		}
-		digestState := imageDataSourceDigestModel{
+		digestState := DigestDataSourceModel{
 			Type:  types.StringValue(string(image.Digest.Type())),
 			Value: types.StringValue(sha256.Value),
 		}

--- a/internal/provider/image/resource.go
+++ b/internal/provider/image/resource.go
@@ -38,7 +38,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	BlockSize        types.Int64    `tfsdk:"block_size"`
 	Description      types.String   `tfsdk:"description"`
 	Digest           types.Object   `tfsdk:"digest"`
@@ -54,7 +54,7 @@ type Model struct {
 	Timeouts         timeouts.Value `tfsdk:"timeouts"`
 }
 
-type imageResourceDigestModel struct {
+type DigestResourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
@@ -197,7 +197,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -252,7 +252,7 @@ func (r *Resource) Create(
 		plan.BlockSize = types.Int64Value(int64(image.BlockSize))
 	}
 
-	// Parse imageResourceDigestModel into types.Object
+	// Parse DigestResourceModel into types.Object
 	attributeTypes := map[string]attr.Type{
 		"type":  types.StringType,
 		"value": types.StringType,
@@ -268,7 +268,7 @@ func (r *Resource) Create(
 			)
 			return
 		}
-		dm := imageResourceDigestModel{
+		dm := DigestResourceModel{
 			Type:  types.StringValue(string(image.Digest.Type())),
 			Value: types.StringValue(sha256.Value),
 		}
@@ -293,7 +293,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -351,7 +351,7 @@ func (r *Resource) Read(
 		state.ProjectID = types.StringValue(image.ProjectId)
 	}
 
-	// Parse imageResourceDigestModel into types.Object
+	// Parse DigestResourceModel into types.Object
 	attributeTypes := map[string]attr.Type{
 		"type":  types.StringType,
 		"value": types.StringType,
@@ -367,7 +367,7 @@ func (r *Resource) Read(
 			)
 			return
 		}
-		dm := imageResourceDigestModel{
+		dm := DigestResourceModel{
 			Type:  types.StringValue(string(image.Digest.Type())),
 			Value: types.StringValue(sha256.Value),
 		}
@@ -403,7 +403,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/images/datasource.go
+++ b/internal/provider/images/datasource.go
@@ -34,26 +34,26 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	ID        types.String   `tfsdk:"id"`
-	ProjectID types.String   `tfsdk:"project_id"`
-	Timeouts  timeouts.Value `tfsdk:"timeouts"`
-	Images    []ImageModel   `tfsdk:"images"`
+	ID        types.String           `tfsdk:"id"`
+	ProjectID types.String           `tfsdk:"project_id"`
+	Timeouts  timeouts.Value         `tfsdk:"timeouts"`
+	Images    []ImageDataSourceModel `tfsdk:"images"`
 }
 
-type ImageModel struct {
-	BlockSize    types.Int64  `tfsdk:"block_size"`
-	Description  types.String `tfsdk:"description"`
-	Digest       DigestModel  `tfsdk:"digest"`
-	ID           types.String `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	OS           types.String `tfsdk:"os"`
-	Size         types.Int64  `tfsdk:"size"`
-	TimeCreated  types.String `tfsdk:"time_created"`
-	TimeModified types.String `tfsdk:"time_modified"`
-	Version      types.String `tfsdk:"version"`
+type ImageDataSourceModel struct {
+	BlockSize    types.Int64           `tfsdk:"block_size"`
+	Description  types.String          `tfsdk:"description"`
+	Digest       DigestDataSourceModel `tfsdk:"digest"`
+	ID           types.String          `tfsdk:"id"`
+	Name         types.String          `tfsdk:"name"`
+	OS           types.String          `tfsdk:"os"`
+	Size         types.Int64           `tfsdk:"size"`
+	TimeCreated  types.String          `tfsdk:"time_created"`
+	TimeModified types.String          `tfsdk:"time_modified"`
+	Version      types.String          `tfsdk:"version"`
 }
 
-type DigestModel struct {
+type DigestDataSourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
@@ -209,7 +209,7 @@ func (d *DataSource) Read(
 
 	// Map response body to model
 	for _, image := range images.Items {
-		imageState := ImageModel{
+		imageState := ImageDataSourceModel{
 			BlockSize:    types.Int64Value(int64(image.BlockSize)),
 			Description:  types.StringValue(image.Description),
 			ID:           types.StringValue(image.Id),
@@ -230,7 +230,7 @@ func (d *DataSource) Read(
 				)
 				return
 			}
-			imageState.Digest = DigestModel{
+			imageState.Digest = DigestDataSourceModel{
 				Type:  types.StringValue(string(image.Digest.Type())),
 				Value: types.StringValue(sha256.Value),
 			}

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -54,38 +54,38 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	AntiAffinityGroups        types.Set        `tfsdk:"anti_affinity_groups"`
-	AutoRestartPolicy         types.String     `tfsdk:"auto_restart_policy"`
-	BootDiskID                types.String     `tfsdk:"boot_disk_id"`
-	Description               types.String     `tfsdk:"description"`
-	DiskAttachments           types.Set        `tfsdk:"disk_attachments"`
-	ExternalIPs               *ExternalIPModel `tfsdk:"external_ips"`
-	Hostname                  types.String     `tfsdk:"hostname"`
-	ID                        types.String     `tfsdk:"id"`
-	Memory                    types.Int64      `tfsdk:"memory"`
-	Name                      types.String     `tfsdk:"name"`
-	NetworkInterfaces         []NICModel       `tfsdk:"network_interfaces"`
-	AttachedNetworkInterfaces types.Map        `tfsdk:"attached_network_interfaces"`
-	NCPUs                     types.Int64      `tfsdk:"ncpus"`
-	ProjectID                 types.String     `tfsdk:"project_id"`
-	SSHPublicKeys             types.Set        `tfsdk:"ssh_public_keys"`
-	StartOnCreate             types.Bool       `tfsdk:"start_on_create"`
-	TimeCreated               types.String     `tfsdk:"time_created"`
-	TimeModified              types.String     `tfsdk:"time_modified"`
-	Timeouts                  timeouts.Value   `tfsdk:"timeouts"`
-	UserData                  types.String     `tfsdk:"user_data"`
+type ResourceModel struct {
+	AntiAffinityGroups        types.Set                `tfsdk:"anti_affinity_groups"`
+	AutoRestartPolicy         types.String             `tfsdk:"auto_restart_policy"`
+	BootDiskID                types.String             `tfsdk:"boot_disk_id"`
+	Description               types.String             `tfsdk:"description"`
+	DiskAttachments           types.Set                `tfsdk:"disk_attachments"`
+	ExternalIPs               *ExternalIPResourceModel `tfsdk:"external_ips"`
+	Hostname                  types.String             `tfsdk:"hostname"`
+	ID                        types.String             `tfsdk:"id"`
+	Memory                    types.Int64              `tfsdk:"memory"`
+	Name                      types.String             `tfsdk:"name"`
+	NetworkInterfaces         []NICResourceModel       `tfsdk:"network_interfaces"`
+	AttachedNetworkInterfaces types.Map                `tfsdk:"attached_network_interfaces"`
+	NCPUs                     types.Int64              `tfsdk:"ncpus"`
+	ProjectID                 types.String             `tfsdk:"project_id"`
+	SSHPublicKeys             types.Set                `tfsdk:"ssh_public_keys"`
+	StartOnCreate             types.Bool               `tfsdk:"start_on_create"`
+	TimeCreated               types.String             `tfsdk:"time_created"`
+	TimeModified              types.String             `tfsdk:"time_modified"`
+	Timeouts                  timeouts.Value           `tfsdk:"timeouts"`
+	UserData                  types.String             `tfsdk:"user_data"`
 }
 
-type NICModel struct {
-	Name        types.String  `tfsdk:"name"`
-	Description types.String  `tfsdk:"description"`
-	SubnetID    types.String  `tfsdk:"subnet_id"`
-	VPCID       types.String  `tfsdk:"vpc_id"`
-	IPConfig    IPConfigModel `tfsdk:"ip_config"`
+type NICResourceModel struct {
+	Name        types.String          `tfsdk:"name"`
+	Description types.String          `tfsdk:"description"`
+	SubnetID    types.String          `tfsdk:"subnet_id"`
+	VPCID       types.String          `tfsdk:"vpc_id"`
+	IPConfig    IPConfigResourceModel `tfsdk:"ip_config"`
 }
 
-func (nic NICModel) Hash() string {
+func (nic NICResourceModel) Hash() string {
 	h := md5.New()
 
 	// Hash user-provided values to detect changes to the configuration.
@@ -103,65 +103,65 @@ func (nic NICModel) Hash() string {
 	return string(h.Sum(nil))
 }
 
-type IPConfigModel struct {
-	V4 *IPConfigV4Model `tfsdk:"v4"`
-	V6 *IPConfigV6Model `tfsdk:"v6"`
+type IPConfigResourceModel struct {
+	V4 *IPConfigV4ResourceModel `tfsdk:"v4"`
+	V6 *IPConfigV6ResourceModel `tfsdk:"v6"`
 }
 
-type IPConfigV4Model struct {
+type IPConfigV4ResourceModel struct {
 	IP types.String `tfsdk:"ip"`
 }
 
-type IPConfigV6Model struct {
+type IPConfigV6ResourceModel struct {
 	IP types.String `tfsdk:"ip"`
 }
 
-type instanceResourceAttachedNICModel struct {
-	ID           types.String                 `tfsdk:"id"`
-	Name         types.String                 `tfsdk:"name"`
-	Description  types.String                 `tfsdk:"description"`
-	SubnetID     types.String                 `tfsdk:"subnet_id"`
-	VPCID        types.String                 `tfsdk:"vpc_id"`
-	InstanceID   types.String                 `tfsdk:"instance_id"`
-	Primary      types.Bool                   `tfsdk:"primary"`
-	MAC          types.String                 `tfsdk:"mac_address"`
-	IPStack      instanceResourceIPStackModel `tfsdk:"ip_stack"`
-	TimeCreated  types.String                 `tfsdk:"time_created"`
-	TimeModified types.String                 `tfsdk:"time_modified"`
+type AttachedNICResourceModel struct {
+	ID           types.String         `tfsdk:"id"`
+	Name         types.String         `tfsdk:"name"`
+	Description  types.String         `tfsdk:"description"`
+	SubnetID     types.String         `tfsdk:"subnet_id"`
+	VPCID        types.String         `tfsdk:"vpc_id"`
+	InstanceID   types.String         `tfsdk:"instance_id"`
+	Primary      types.Bool           `tfsdk:"primary"`
+	MAC          types.String         `tfsdk:"mac_address"`
+	IPStack      IPStackResourceModel `tfsdk:"ip_stack"`
+	TimeCreated  types.String         `tfsdk:"time_created"`
+	TimeModified types.String         `tfsdk:"time_modified"`
 }
 
-type instanceResourceIPStackModel struct {
-	V4 *instanceResourceIPStackV4Model `tfsdk:"v4"`
-	V6 *instanceResourceIPStackV6Model `tfsdk:"v6"`
+type IPStackResourceModel struct {
+	V4 *IPStackV4ResourceModel `tfsdk:"v4"`
+	V6 *IPStackV6ResourceModel `tfsdk:"v6"`
 }
 
-type instanceResourceIPStackV4Model struct {
+type IPStackV4ResourceModel struct {
 	IP types.String `tfsdk:"ip"`
 }
 
-type instanceResourceIPStackV6Model struct {
+type IPStackV6ResourceModel struct {
 	IP types.String `tfsdk:"ip"`
 }
 
-type ExternalIPModel struct {
-	Ephemeral []EphemeralIPModel `tfsdk:"ephemeral"`
-	Floating  []FloatingIPModel  `tfsdk:"floating"`
+type ExternalIPResourceModel struct {
+	Ephemeral []EphemeralIPResourceModel `tfsdk:"ephemeral"`
+	Floating  []FloatingIPResourceModel  `tfsdk:"floating"`
 }
 
-func (ip *ExternalIPModel) Empty() bool {
+func (ip *ExternalIPResourceModel) Empty() bool {
 	return ip == nil || len(ip.Ephemeral) == 0 && len(ip.Floating) == 0
 }
 
-type EphemeralIPModel struct {
+type EphemeralIPResourceModel struct {
 	PoolID    types.String `tfsdk:"pool_id"`
 	IPVersion types.String `tfsdk:"ip_version"`
 }
 
-type FloatingIPModel struct {
+type FloatingIPResourceModel struct {
 	ID types.String `tfsdk:"id"`
 }
 
-var instanceResourceAttachedNICType = types.ObjectType{}.WithAttributeTypes(
+var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
 	map[string]attr.Type{
 		"id":          types.StringType,
 		"name":        types.StringType,
@@ -330,7 +330,7 @@ This resource manages instances.
 			},
 			// Changes to network_interfaces need to be tracked manually.
 			// When adding a new attribute, check if they also need to be
-			// added to NICModel.Hash() and
+			// added to NICResourceModel.Hash() and
 			// instanceNetworkInterfacesPlanModifier.PlanModifySet().
 			"network_interfaces": schema.SetNestedAttribute{
 				Optional:    true,
@@ -594,9 +594,9 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 				}
 
 				// Migrate network interfaces.
-				var newNICs []NICModel
+				var newNICs []NICResourceModel
 				for _, oldNIC := range oldState.NetworkInterfaces {
-					newNIC := NICModel{
+					newNIC := NICResourceModel{
 						Description: oldNIC.Description,
 						Name:        oldNIC.Name,
 						SubnetID:    oldNIC.SubnetID,
@@ -611,22 +611,22 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 						// have access to it during state migration, so assume
 						// the user has not changed their config and use the
 						// default value from previous versions.
-						newNIC.IPConfig = IPConfigModel{
-							V4: &IPConfigV4Model{
+						newNIC.IPConfig = IPConfigResourceModel{
+							V4: &IPConfigV4ResourceModel{
 								IP: types.StringValue(string(oxide.Ipv4AssignmentTypeAuto)),
 							},
 						}
 					} else {
-						newNIC.IPConfig = IPConfigModel{}
+						newNIC.IPConfig = IPConfigResourceModel{}
 
 						if oldNIC.IPConfig.V4 != nil {
-							newNIC.IPConfig.V4 = &IPConfigV4Model{
+							newNIC.IPConfig.V4 = &IPConfigV4ResourceModel{
 								IP: oldNIC.IPConfig.V4.IP,
 							}
 						}
 
 						if oldNIC.IPConfig.V6 != nil {
-							newNIC.IPConfig.V6 = &IPConfigV6Model{
+							newNIC.IPConfig.V6 = &IPConfigV6ResourceModel{
 								IP: oldNIC.IPConfig.V6.IP,
 							}
 						}
@@ -636,24 +636,24 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 				}
 
 				// Migrate external IPs.
-				var newExtIPs *ExternalIPModel
+				var newExtIPs *ExternalIPResourceModel
 				if oldState.ExternalIPs != nil {
-					newExtIPs = &ExternalIPModel{}
+					newExtIPs = &ExternalIPResourceModel{}
 					for _, ip := range oldState.ExternalIPs.Ephemeral {
 						newExtIPs.Ephemeral = append(
 							newExtIPs.Ephemeral,
-							EphemeralIPModel(ip),
+							EphemeralIPResourceModel(ip),
 						)
 					}
 					for _, ip := range oldState.ExternalIPs.Floating {
 						newExtIPs.Floating = append(
 							newExtIPs.Floating,
-							FloatingIPModel(ip),
+							FloatingIPResourceModel(ip),
 						)
 					}
 				}
 
-				newState := Model{
+				newState := ResourceModel{
 					AntiAffinityGroups:        oldState.AntiAffinityGroups,
 					AutoRestartPolicy:         oldState.AutoRestartPolicy,
 					BootDiskID:                oldState.BootDiskID,
@@ -690,9 +690,9 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 				}
 
 				// Migrate network interfaces.
-				var newNICs []NICModel
+				var newNICs []NICResourceModel
 				for _, oldNIC := range oldState.NetworkInterfaces {
-					newNIC := NICModel{
+					newNIC := NICResourceModel{
 						Description: oldNIC.Description,
 						Name:        oldNIC.Name,
 						SubnetID:    oldNIC.SubnetID,
@@ -705,8 +705,8 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 						// have access to it during state migration, so assume
 						// the user has not changed their config and use the
 						// default value from previous versions.
-						IPConfig: IPConfigModel{
-							V4: &IPConfigV4Model{
+						IPConfig: IPConfigResourceModel{
+							V4: &IPConfigV4ResourceModel{
 								IP: types.StringValue(string(oxide.Ipv4AssignmentTypeAuto)),
 							},
 						},
@@ -715,15 +715,15 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 				}
 
 				// Migrate external IPs.
-				var newExtIPs *ExternalIPModel
+				var newExtIPs *ExternalIPResourceModel
 				if len(oldState.ExternalIPs) > 0 {
-					newExtIPs = &ExternalIPModel{}
+					newExtIPs = &ExternalIPResourceModel{}
 					for _, oldExtIP := range oldState.ExternalIPs {
 						switch oxide.ExternalIpKind(oldExtIP.Type.ValueString()) {
 						case oxide.ExternalIpKindEphemeral:
 							newExtIPs.Ephemeral = append(
 								newExtIPs.Ephemeral,
-								EphemeralIPModel{
+								EphemeralIPResourceModel{
 									PoolID: oldExtIP.ID,
 								},
 							)
@@ -731,7 +731,7 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 						case oxide.ExternalIpKindFloating:
 							newExtIPs.Floating = append(
 								newExtIPs.Floating,
-								FloatingIPModel{
+								FloatingIPResourceModel{
 									ID: oldExtIP.ID,
 								},
 							)
@@ -739,7 +739,7 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					}
 				}
 
-				newState := Model{
+				newState := ResourceModel{
 					AntiAffinityGroups: oldState.AntiAffinityGroups,
 					AutoRestartPolicy:  oldState.AutoRestartPolicy,
 					BootDiskID:         oldState.BootDiskID,
@@ -765,7 +765,7 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					// This is a computed attribute, so leave it as a null map
 					// that is going to be populated when the state is
 					// refreshed.
-					AttachedNetworkInterfaces: types.MapNull(instanceResourceAttachedNICType),
+					AttachedNetworkInterfaces: types.MapNull(AttachedNICType),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -780,7 +780,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -915,7 +915,7 @@ func (r *Resource) Create(
 	plan.TimeModified = types.StringValue(instance.TimeModified.String())
 
 	// Populate Computed attribute values about external IPs.
-	instExternalIPs, diags := newAttachedExternalIPModel(ctx, r.client, plan)
+	instExternalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -934,7 +934,7 @@ func (r *Resource) Create(
 	}
 
 	plan.AttachedNetworkInterfaces, diags = types.MapValueFrom(
-		ctx, instanceResourceAttachedNICType, attachedNICs,
+		ctx, AttachedNICType, attachedNICs,
 	)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -954,7 +954,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -1009,7 +1009,7 @@ func (r *Resource) Read(
 	state.TimeCreated = types.StringValue(instance.TimeCreated.String())
 	state.TimeModified = types.StringValue(instance.TimeModified.String())
 
-	externalIPs, diags := newAttachedExternalIPModel(ctx, r.client, state)
+	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1060,7 +1060,7 @@ func (r *Resource) Read(
 	}
 
 	state.AttachedNetworkInterfaces, diags = types.MapValueFrom(
-		ctx, instanceResourceAttachedNICType, attachedNICs,
+		ctx, AttachedNICType, attachedNICs,
 	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1085,8 +1085,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -1226,12 +1226,12 @@ func (r *Resource) Update(
 	nicsToDelete := shared.SliceDiffByID(
 		state.NetworkInterfaces,
 		plan.NetworkInterfaces,
-		func(e NICModel) any {
+		func(e NICResourceModel) any {
 			return e.Hash()
 		},
 	)
 
-	var attachedNICs map[string]instanceResourceAttachedNICModel
+	var attachedNICs map[string]AttachedNICResourceModel
 	resp.Diagnostics.Append(
 		state.AttachedNetworkInterfaces.ElementsAs(ctx, &attachedNICs, false)...,
 	)
@@ -1239,7 +1239,7 @@ func (r *Resource) Update(
 		return
 	}
 
-	attachedNICToDelete := []instanceResourceAttachedNICModel{}
+	attachedNICToDelete := []AttachedNICResourceModel{}
 	for _, n := range nicsToDelete {
 		if attachedNIC, ok := attachedNICs[n.Name.ValueString()]; ok {
 			attachedNICToDelete = append(attachedNICToDelete, attachedNIC)
@@ -1254,7 +1254,7 @@ func (r *Resource) Update(
 	nicsToCreate := shared.SliceDiffByID(
 		plan.NetworkInterfaces,
 		state.NetworkInterfaces,
-		func(e NICModel) any {
+		func(e NICResourceModel) any {
 			return e.Hash()
 		},
 	)
@@ -1341,7 +1341,7 @@ func (r *Resource) Update(
 
 	// We use the plan here instead of the state to capture the desired IP pool ID
 	// value for the ephemeral external IP rather than the previous value.
-	externalIPs, diags := newAttachedExternalIPModel(ctx, r.client, plan)
+	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1369,7 +1369,7 @@ func (r *Resource) Update(
 	}
 
 	plan.AttachedNetworkInterfaces, diags = types.MapValueFrom(
-		ctx, instanceResourceAttachedNICType, attachedNICs,
+		ctx, AttachedNICType, attachedNICs,
 	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1394,7 +1394,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -1618,7 +1618,7 @@ func newAssociatedAntiAffinityGroupsOnCreateSet(
 func newNetworkInterfaceAttachment(
 	ctx context.Context,
 	client *oxide.Client,
-	model []NICModel,
+	model []NICResourceModel,
 ) (
 	oxide.InstanceNetworkInterfaceAttachment, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -1659,15 +1659,15 @@ func newNetworkInterfaceAttachment(
 func newAttachedNetworkInterfacesModel(
 	ctx context.Context,
 	client *oxide.Client,
-	state Model,
+	state ResourceModel,
 ) (
-	[]NICModel, map[string]instanceResourceAttachedNICModel, diag.Diagnostics) {
+	[]NICResourceModel, map[string]AttachedNICResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	// Store network interfaces from state or plan in a map for quick retrieval
 	// of write-only attribute values that are preserved from the state or plan
 	// instead of read from the API.
-	stateIPConfigs := make(map[string]IPConfigModel)
+	stateIPConfigs := make(map[string]IPConfigResourceModel)
 	for _, nic := range state.NetworkInterfaces {
 		stateIPConfigs[nic.Name.ValueString()] = nic.IPConfig
 	}
@@ -1682,22 +1682,22 @@ func newAttachedNetworkInterfacesModel(
 			"Unable to read instance network interfaces:",
 			"API error: "+err.Error(),
 		)
-		return []NICModel{}, nil, diags
+		return []NICResourceModel{}, nil, diags
 	}
 
-	nicSet := []NICModel{}
-	attachedNICs := make(map[string]instanceResourceAttachedNICModel)
+	nicSet := []NICResourceModel{}
+	attachedNICs := make(map[string]AttachedNICResourceModel)
 	for _, nic := range nics.Items {
-		ipStack, err := newAttachedNetworkInterfacesIPStackModel(nic.IpStack)
+		ipStack, err := newAttachedNetworkInterfacesIPStackResourceModel(nic.IpStack)
 		if err != nil {
 			diags.AddError(
 				"Unable to read instance network interfaces:",
 				"API error: "+err.Error(),
 			)
-			return []NICModel{}, nil, diags
+			return []NICResourceModel{}, nil, diags
 		}
 
-		nicSet = append(nicSet, NICModel{
+		nicSet = append(nicSet, NICResourceModel{
 			Description: types.StringValue(nic.Description),
 			IPConfig:    stateIPConfigs[string(nic.Name)],
 			Name:        types.StringValue(string(nic.Name)),
@@ -1705,7 +1705,7 @@ func newAttachedNetworkInterfacesModel(
 			VPCID:       types.StringValue(nic.VpcId),
 		})
 
-		attachedNICs[string(nic.Name)] = instanceResourceAttachedNICModel{
+		attachedNICs[string(nic.Name)] = AttachedNICResourceModel{
 			ID:           types.StringValue(nic.Id),
 			Name:         types.StringValue(string(nic.Name)),
 			Description:  types.StringValue(nic.Description),
@@ -1720,59 +1720,59 @@ func newAttachedNetworkInterfacesModel(
 		}
 	}
 	if diags.HasError() {
-		return []NICModel{}, nil, diags
+		return []NICResourceModel{}, nil, diags
 	}
 
 	return nicSet, attachedNICs, nil
 }
 
-// newAttachedNetworkInterfacesIPStackModel parses a network interface IP stack
+// newAttachedNetworkInterfacesIPStackResourceModel parses a network interface IP stack
 // from the API to a resource model.
-func newAttachedNetworkInterfacesIPStackModel(
+func newAttachedNetworkInterfacesIPStackResourceModel(
 	stack oxide.PrivateIpStack,
-) (instanceResourceIPStackModel, error) {
+) (IPStackResourceModel, error) {
 	switch s := stack.Value.(type) {
 	case *oxide.PrivateIpStackV4:
-		return instanceResourceIPStackModel{
-			V4: &instanceResourceIPStackV4Model{
+		return IPStackResourceModel{
+			V4: &IPStackV4ResourceModel{
 				IP: types.StringValue(s.Value.Ip),
 			},
 		}, nil
 
 	case *oxide.PrivateIpStackV6:
-		return instanceResourceIPStackModel{
-			V6: &instanceResourceIPStackV6Model{
+		return IPStackResourceModel{
+			V6: &IPStackV6ResourceModel{
 				IP: types.StringValue(s.Value.Ip),
 			},
 		}, nil
 
 	case *oxide.PrivateIpStackDualStack:
-		return instanceResourceIPStackModel{
-			V4: &instanceResourceIPStackV4Model{
+		return IPStackResourceModel{
+			V4: &IPStackV4ResourceModel{
 				IP: types.StringValue(s.Value.V4.Ip),
 			},
-			V6: &instanceResourceIPStackV6Model{
+			V6: &IPStackV6ResourceModel{
 				IP: types.StringValue(s.Value.V6.Ip),
 			},
 		}, nil
 
 	default:
-		return instanceResourceIPStackModel{}, fmt.Errorf(
+		return IPStackResourceModel{}, fmt.Errorf(
 			"unexpected IP stack type %T",
 			stack.Value,
 		)
 	}
 }
 
-// newAttachedExternalIPModel fetches the external IP addresses for the instance
+// newAttachedExternalIPResourceModel fetches the external IP addresses for the instance
 // specified by model, keeping the IP pool ID from the ephemeral external IP
 // from the model if one is present.
-func newAttachedExternalIPModel(
+func newAttachedExternalIPResourceModel(
 	ctx context.Context,
 	client *oxide.Client,
-	model Model,
+	model ResourceModel,
 ) (
-	*ExternalIPModel, diag.Diagnostics) {
+	*ExternalIPResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	externalIPResponse, err := client.InstanceExternalIpList(
@@ -1789,7 +1789,7 @@ func newAttachedExternalIPModel(
 		return nil, diags
 	}
 
-	externalIPs := &ExternalIPModel{}
+	externalIPs := &ExternalIPResourceModel{}
 	for _, ip := range externalIPResponse.Items {
 		switch v := ip.Value.(type) {
 		case *oxide.ExternalIpEphemeral:
@@ -1804,13 +1804,13 @@ func newAttachedExternalIPModel(
 				ipVersion = string(oxide.IpVersionV6)
 			}
 
-			externalIPs.Ephemeral = append(externalIPs.Ephemeral, EphemeralIPModel{
+			externalIPs.Ephemeral = append(externalIPs.Ephemeral, EphemeralIPResourceModel{
 				PoolID:    types.StringValue(v.IpPoolId),
 				IPVersion: types.StringValue(ipVersion),
 			})
 
 		case *oxide.ExternalIpFloating:
-			externalIPs.Floating = append(externalIPs.Floating, FloatingIPModel{
+			externalIPs.Floating = append(externalIPs.Floating, FloatingIPResourceModel{
 				ID: types.StringValue(v.Id),
 			})
 		// Skipped until the schema is updated to support SNAT external IPs.
@@ -1941,7 +1941,7 @@ func FilterBootDiskFromDisks(
 	return filteredDisks
 }
 
-func newExternalIPsOnCreate(externalIPs *ExternalIPModel) []oxide.ExternalIpCreate {
+func newExternalIPsOnCreate(externalIPs *ExternalIPResourceModel) []oxide.ExternalIpCreate {
 	if externalIPs == nil {
 		return nil
 	}
@@ -1981,7 +1981,7 @@ func newExternalIPsOnCreate(externalIPs *ExternalIPModel) []oxide.ExternalIpCrea
 	return ips
 }
 
-func newIPStackCreate(model NICModel) oxide.PrivateIpStackCreate {
+func newIPStackCreate(model NICResourceModel) oxide.PrivateIpStackCreate {
 	if model.IPConfig.V4 != nil && model.IPConfig.V6 != nil {
 		return oxide.PrivateIpStackCreate{
 			Value: &oxide.PrivateIpStackCreateDualStack{
@@ -2005,7 +2005,7 @@ func newIPStackCreate(model NICModel) oxide.PrivateIpStackCreate {
 	}
 }
 
-func newIPStackCreateV4(stack *IPConfigV4Model) oxide.PrivateIpv4StackCreate {
+func newIPStackCreateV4(stack *IPConfigV4ResourceModel) oxide.PrivateIpv4StackCreate {
 	ip := stack.IP.ValueString()
 
 	if ip == string(oxide.Ipv4AssignmentTypeAuto) {
@@ -2023,7 +2023,7 @@ func newIPStackCreateV4(stack *IPConfigV4Model) oxide.PrivateIpv4StackCreate {
 	}
 }
 
-func newIPStackCreateV6(stack *IPConfigV6Model) oxide.PrivateIpv6StackCreate {
+func newIPStackCreateV6(stack *IPConfigV6ResourceModel) oxide.PrivateIpv6StackCreate {
 	ip := stack.IP.ValueString()
 
 	if ip == string(oxide.Ipv6AssignmentTypeAuto) {
@@ -2042,8 +2042,8 @@ func newIPStackCreateV6(stack *IPConfigV6Model) oxide.PrivateIpv6StackCreate {
 }
 
 func newIPStackCreateDualStack(
-	stackV4 *IPConfigV4Model,
-	stackV6 *IPConfigV6Model,
+	stackV4 *IPConfigV4ResourceModel,
+	stackV6 *IPConfigV6ResourceModel,
 ) oxide.PrivateIpStackCreateDualStackValue {
 	return oxide.PrivateIpStackCreateDualStackValue{
 		V4: newIPStackCreateV4(stackV4),
@@ -2054,7 +2054,7 @@ func newIPStackCreateDualStack(
 func createNICs(
 	ctx context.Context,
 	client *oxide.Client,
-	models []NICModel,
+	models []NICResourceModel,
 	instanceID string,
 ) diag.Diagnostics {
 	for _, model := range models {
@@ -2094,13 +2094,13 @@ func createNICs(
 func deleteNICs(
 	ctx context.Context,
 	client *oxide.Client,
-	models []instanceResourceAttachedNICModel,
+	models []AttachedNICResourceModel,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// The API doesn't allow deleting the primary network interface
 	// while other interfaces are still attached, so leave it for last.
-	slices.SortStableFunc(models, func(a, b instanceResourceAttachedNICModel) int {
+	slices.SortStableFunc(models, func(a, b AttachedNICResourceModel) int {
 		if a.Primary.ValueBool() && !b.Primary.ValueBool() {
 			return 1
 		} else if !a.Primary.ValueBool() && b.Primary.ValueBool() {
@@ -2139,8 +2139,8 @@ func attachExternalIPs(
 	ctx context.Context,
 	client *oxide.Client,
 	instanceID string,
-	state *ExternalIPModel,
-	plan *ExternalIPModel,
+	state *ExternalIPResourceModel,
+	plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -2156,14 +2156,14 @@ func attachEphemeralIPs(
 	ctx context.Context,
 	client *oxide.Client,
 	instanceID string,
-	state, plan *ExternalIPModel,
+	state, plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	// No need to attach ephemeral IPs if the plan doesn't have any external IP.
 	if plan == nil {
 		return nil
 	}
 
-	var ipsToAttach []EphemeralIPModel
+	var ipsToAttach []EphemeralIPResourceModel
 	if state == nil {
 		ipsToAttach = plan.Ephemeral
 	} else {
@@ -2221,14 +2221,14 @@ func attachFloatingIPs(
 	ctx context.Context,
 	client *oxide.Client,
 	instanceID string,
-	state, plan *ExternalIPModel,
+	state, plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	// No need to attach floating IPs if the plan doesn't have any external IP.
 	if plan == nil {
 		return nil
 	}
 
-	var ipsToAttach []FloatingIPModel
+	var ipsToAttach []FloatingIPResourceModel
 	if state == nil {
 		ipsToAttach = plan.Floating
 	} else {
@@ -2274,8 +2274,8 @@ func detachExternalIPs(
 	ctx context.Context,
 	client *oxide.Client,
 	instanceID string,
-	state *ExternalIPModel,
-	plan *ExternalIPModel,
+	state *ExternalIPResourceModel,
+	plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -2291,14 +2291,14 @@ func detachEphemeralIPs(
 	ctx context.Context,
 	client *oxide.Client,
 	instanceID string,
-	state, plan *ExternalIPModel,
+	state, plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	// No need to detach ephemeral IPs if the state doesn't have any external IP.
 	if state == nil {
 		return nil
 	}
 
-	var ipsToDetach []EphemeralIPModel
+	var ipsToDetach []EphemeralIPResourceModel
 	if plan == nil {
 		ipsToDetach = state.Ephemeral
 	} else {
@@ -2344,14 +2344,14 @@ func detachEphemeralIPs(
 func detachFloatingIPs(
 	ctx context.Context,
 	client *oxide.Client,
-	state, plan *ExternalIPModel,
+	state, plan *ExternalIPResourceModel,
 ) diag.Diagnostics {
 	// No need to detach floating IPs if the state doesn't have any external IP.
 	if state == nil {
 		return nil
 	}
 
-	var ipsToDetach []FloatingIPModel
+	var ipsToDetach []FloatingIPResourceModel
 	if plan == nil {
 		ipsToDetach = state.Floating
 	} else {
@@ -2647,7 +2647,7 @@ func (f instanceIPConfigValidator) ValidateObject(
 		return
 	}
 
-	var ipConfig *IPConfigModel
+	var ipConfig *IPConfigResourceModel
 	diags := req.ConfigValue.As(ctx, &ipConfig, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty:    true,
 		UnhandledUnknownAsEmpty: true,
@@ -2693,7 +2693,7 @@ func (f instanceExternalIPValidator) ValidateObject(
 		return
 	}
 
-	var externalIPs *ExternalIPModel
+	var externalIPs *ExternalIPResourceModel
 	diags := req.ConfigValue.As(ctx, &externalIPs, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty:    true,
 		UnhandledUnknownAsEmpty: true,

--- a/internal/provider/instance/resource_v1.go
+++ b/internal/provider/instance/resource_v1.go
@@ -303,7 +303,7 @@ This resource manages instances.
 			},
 			// Changes to network_interfaces need to be tracked manually.
 			// When adding a new attribute, check if they also need to be
-			// added to instanceResourceNICModel.Hash() and
+			// added to NICResourceModel.Hash() and
 			// instanceNetworkInterfacesPlanModifier.PlanModifySet().
 			"network_interfaces": schema.SetNestedAttribute{
 				Optional:    true,

--- a/internal/provider/instance_external_ips/datasource.go
+++ b/internal/provider/instance_external_ips/datasource.go
@@ -34,13 +34,13 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	ID          types.String      `tfsdk:"id"`
-	InstanceID  types.String      `tfsdk:"instance_id"`
-	Timeouts    timeouts.Value    `tfsdk:"timeouts"`
-	ExternalIPs []ExternalIPModel `tfsdk:"external_ips"`
+	ID          types.String                `tfsdk:"id"`
+	InstanceID  types.String                `tfsdk:"instance_id"`
+	Timeouts    timeouts.Value              `tfsdk:"timeouts"`
+	ExternalIPs []ExternalIPDataSourceModel `tfsdk:"external_ips"`
 }
 
-type ExternalIPModel struct {
+type ExternalIPDataSourceModel struct {
 	IP   types.String `tfsdk:"ip"`
 	Kind types.String `tfsdk:"kind"`
 }
@@ -162,7 +162,7 @@ func (d *DataSource) Read(
 			)
 			return
 		}
-		externalIPState := ExternalIPModel{
+		externalIPState := ExternalIPDataSourceModel{
 			IP:   types.StringValue(ipAddr),
 			Kind: types.StringValue(string(ip.Kind())),
 		}

--- a/internal/provider/ip_pool/resource.go
+++ b/internal/provider/ip_pool/resource.go
@@ -39,17 +39,17 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	Description  types.String   `tfsdk:"description"`
-	ID           types.String   `tfsdk:"id"`
-	Name         types.String   `tfsdk:"name"`
-	Ranges       []RangeModel   `tfsdk:"ranges"`
-	TimeCreated  types.String   `tfsdk:"time_created"`
-	TimeModified types.String   `tfsdk:"time_modified"`
-	Timeouts     timeouts.Value `tfsdk:"timeouts"`
+type ResourceModel struct {
+	Description  types.String         `tfsdk:"description"`
+	ID           types.String         `tfsdk:"id"`
+	Name         types.String         `tfsdk:"name"`
+	Ranges       []RangeResourceModel `tfsdk:"ranges"`
+	TimeCreated  types.String         `tfsdk:"time_created"`
+	TimeModified types.String         `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value       `tfsdk:"timeouts"`
 }
 
-type RangeModel struct {
+type RangeResourceModel struct {
 	FirstAddress types.String `tfsdk:"first_address"`
 	LastAddress  types.String `tfsdk:"last_address"`
 }
@@ -149,7 +149,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -208,7 +208,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -267,11 +267,11 @@ func (r *Resource) Read(
 
 	// Set the size of the slice to avoid a panic when importing
 	if len(state.Ranges) == 0 && len(ipPoolRanges.Items) != 0 {
-		state.Ranges = make([]RangeModel, len(ipPoolRanges.Items))
+		state.Ranges = make([]RangeResourceModel, len(ipPoolRanges.Items))
 	}
 
 	for index, item := range ipPoolRanges.Items {
-		ipPoolRange := RangeModel{}
+		ipPoolRange := RangeResourceModel{}
 
 		// Extract first/last addresses from the IpRange variant
 		switch v := item.Range.Value.(type) {
@@ -308,8 +308,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -390,7 +390,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -474,7 +474,7 @@ func (r *Resource) Delete(
 func addRanges(
 	ctx context.Context,
 	client *oxide.Client,
-	ranges []RangeModel,
+	ranges []RangeResourceModel,
 	poolID string,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -523,7 +523,7 @@ func addRanges(
 func removeRanges(
 	ctx context.Context,
 	client *oxide.Client,
-	ranges []RangeModel,
+	ranges []RangeResourceModel,
 	poolID string,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics

--- a/internal/provider/ip_pool_silo_link/resource.go
+++ b/internal/provider/ip_pool_silo_link/resource.go
@@ -39,7 +39,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	ID        types.String   `tfsdk:"id"`
 	SiloID    types.String   `tfsdk:"silo_id"`
 	IPPoolID  types.String   `tfsdk:"ip_pool_id"`
@@ -130,7 +130,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -183,7 +183,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -255,8 +255,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -316,7 +316,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/project/resource.go
+++ b/internal/provider/project/resource.go
@@ -37,7 +37,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	ID           types.String   `tfsdk:"id"`
 	Name         types.String   `tfsdk:"name"`
@@ -127,7 +127,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -181,7 +181,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -238,8 +238,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -301,7 +301,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/projects/datasource.go
+++ b/internal/provider/projects/datasource.go
@@ -26,12 +26,12 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	ID       types.String   `tfsdk:"id"`
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
-	Projects []ProjectModel `tfsdk:"projects"`
+	ID       types.String             `tfsdk:"id"`
+	Timeouts timeouts.Value           `tfsdk:"timeouts"`
+	Projects []ProjectDataSourceModel `tfsdk:"projects"`
 }
 
-type ProjectModel struct {
+type ProjectDataSourceModel struct {
 	Description  types.String `tfsdk:"description"`
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
@@ -159,7 +159,7 @@ func (d *DataSource) Read(
 
 	// Map response body to model
 	for _, project := range projects.Items {
-		projectState := ProjectModel{
+		projectState := ProjectDataSourceModel{
 			Description:  types.StringValue(project.Description),
 			ID:           types.StringValue(project.Id),
 			Name:         types.StringValue(string(project.Name)),

--- a/internal/provider/silo/resource.go
+++ b/internal/provider/silo/resource.go
@@ -53,33 +53,33 @@ type Resource struct {
 	client *oxide.Client
 }
 
-// Model represents the Terraform configuration and state for the
+// ResourceModel represents the Terraform configuration and state for the
 // Oxide silo resource.
-type Model struct {
-	ID               types.String          `tfsdk:"id"`
-	Name             types.String          `tfsdk:"name"`
-	Description      types.String          `tfsdk:"description"`
-	Quotas           *QuotasModel          `tfsdk:"quotas"`
-	TlsCertificates  []TlsCertificateModel `tfsdk:"tls_certificates"`
-	Discoverable     types.Bool            `tfsdk:"discoverable"`
-	IdentityMode     types.String          `tfsdk:"identity_mode"`
-	AdminGroupName   types.String          `tfsdk:"admin_group_name"`
-	MappedFleetRoles map[string][]string   `tfsdk:"mapped_fleet_roles"`
-	TimeCreated      types.String          `tfsdk:"time_created"`
-	TimeModified     types.String          `tfsdk:"time_modified"`
-	Timeouts         timeouts.Value        `tfsdk:"timeouts"`
+type ResourceModel struct {
+	ID               types.String                  `tfsdk:"id"`
+	Name             types.String                  `tfsdk:"name"`
+	Description      types.String                  `tfsdk:"description"`
+	Quotas           *QuotasResourceModel          `tfsdk:"quotas"`
+	TlsCertificates  []TlsCertificateResourceModel `tfsdk:"tls_certificates"`
+	Discoverable     types.Bool                    `tfsdk:"discoverable"`
+	IdentityMode     types.String                  `tfsdk:"identity_mode"`
+	AdminGroupName   types.String                  `tfsdk:"admin_group_name"`
+	MappedFleetRoles map[string][]string           `tfsdk:"mapped_fleet_roles"`
+	TimeCreated      types.String                  `tfsdk:"time_created"`
+	TimeModified     types.String                  `tfsdk:"time_modified"`
+	Timeouts         timeouts.Value                `tfsdk:"timeouts"`
 }
 
-// QuotasModel represents quotas for an Oxide silo.
-type QuotasModel struct {
+// QuotasResourceModel represents quotas for an Oxide silo.
+type QuotasResourceModel struct {
 	Cpus    types.Int64 `tfsdk:"cpus"`
 	Memory  types.Int64 `tfsdk:"memory"`
 	Storage types.Int64 `tfsdk:"storage"`
 }
 
-// TlsCertificateModel represents a TLS certificate for an Oxide
+// TlsCertificateResourceModel represents a TLS certificate for an Oxide
 // silo.
-type TlsCertificateModel struct {
+type TlsCertificateResourceModel struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Cert        types.String `tfsdk:"cert"`
@@ -302,7 +302,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -379,7 +379,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -428,7 +428,7 @@ func (r *Resource) Read(
 	state.ID = types.StringValue(silo.Id)
 	state.Name = types.StringValue(string(silo.Name))
 	state.Description = types.StringValue(silo.Description)
-	state.Quotas = &QuotasModel{
+	state.Quotas = &QuotasResourceModel{
 		Cpus:    types.Int64Value(int64(*siloQuotas.Cpus)),
 		Memory:  types.Int64Value(int64(siloQuotas.Memory)),
 		Storage: types.Int64Value(int64(siloQuotas.Storage)),
@@ -453,8 +453,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -512,7 +512,7 @@ func (r *Resource) Update(
 	}
 
 	plan.ID = types.StringValue(siloQuotas.SiloId)
-	plan.Quotas = &QuotasModel{
+	plan.Quotas = &QuotasResourceModel{
 		Cpus:    types.Int64Value(int64(*siloQuotas.Cpus)),
 		Memory:  types.Int64Value(int64(siloQuotas.Memory)),
 		Storage: types.Int64Value(int64(siloQuotas.Storage)),
@@ -532,7 +532,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -583,7 +583,7 @@ func stringMapToFleetRoleMap(mappedFleetRoles map[string][]string) map[string][]
 }
 
 func tlsCertsModelToCertificateCreateSlice(
-	tlsCertificates []TlsCertificateModel,
+	tlsCertificates []TlsCertificateResourceModel,
 ) []oxide.CertificateCreate {
 	var model []oxide.CertificateCreate
 

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -35,30 +35,30 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	ID                    types.String         `tfsdk:"id"`
-	Name                  types.String         `tfsdk:"name"`
-	Description           types.String         `tfsdk:"description"`
-	Silo                  types.String         `tfsdk:"silo"`
-	AcsUrl                types.String         `tfsdk:"acs_url"`
-	IdpEntityId           types.String         `tfsdk:"idp_entity_id"`
-	SloUrl                types.String         `tfsdk:"slo_url"`
-	SpClientId            types.String         `tfsdk:"sp_client_id"`
-	TechnicalContactEmail types.String         `tfsdk:"technical_contact_email"`
-	IdpMetadataSource     *MetadataSourceModel `tfsdk:"idp_metadata_source"`
-	GroupAttributeName    types.String         `tfsdk:"group_attribute_name"`
-	SigningKeypair        *SigningKeypairModel `tfsdk:"signing_keypair"`
-	TimeCreated           types.String         `tfsdk:"time_created"`
-	TimeModified          types.String         `tfsdk:"time_modified"`
-	Timeouts              timeouts.Value       `tfsdk:"timeouts"`
+type ResourceModel struct {
+	ID                    types.String                 `tfsdk:"id"`
+	Name                  types.String                 `tfsdk:"name"`
+	Description           types.String                 `tfsdk:"description"`
+	Silo                  types.String                 `tfsdk:"silo"`
+	AcsUrl                types.String                 `tfsdk:"acs_url"`
+	IdpEntityId           types.String                 `tfsdk:"idp_entity_id"`
+	SloUrl                types.String                 `tfsdk:"slo_url"`
+	SpClientId            types.String                 `tfsdk:"sp_client_id"`
+	TechnicalContactEmail types.String                 `tfsdk:"technical_contact_email"`
+	IdpMetadataSource     *MetadataSourceResourceModel `tfsdk:"idp_metadata_source"`
+	GroupAttributeName    types.String                 `tfsdk:"group_attribute_name"`
+	SigningKeypair        *SigningKeypairResourceModel `tfsdk:"signing_keypair"`
+	TimeCreated           types.String                 `tfsdk:"time_created"`
+	TimeModified          types.String                 `tfsdk:"time_modified"`
+	Timeouts              timeouts.Value               `tfsdk:"timeouts"`
 }
 
-type SigningKeypairModel struct {
+type SigningKeypairResourceModel struct {
 	PrivateKey types.String `tfsdk:"private_key"`
 	PublicCert types.String `tfsdk:"public_cert"`
 }
 
-type MetadataSourceModel struct {
+type MetadataSourceResourceModel struct {
 	Type types.String `tfsdk:"type"`
 	Url  types.String `tfsdk:"url"`
 	Data types.String `tfsdk:"data"`
@@ -213,7 +213,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -306,7 +306,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/snapshot/resource.go
+++ b/internal/provider/snapshot/resource.go
@@ -37,7 +37,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	DiskID       types.String   `tfsdk:"disk_id"`
 	ID           types.String   `tfsdk:"id"`
@@ -152,7 +152,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -226,7 +226,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -297,7 +297,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/ssh_key/resource.go
+++ b/internal/provider/ssh_key/resource.go
@@ -37,8 +37,8 @@ type Resource struct {
 	client *oxide.Client
 }
 
-// Model are the attributes that are supported on this resource.
-type Model struct {
+// ResourceModel are the attributes that are supported on this resource.
+type ResourceModel struct {
 	ID           types.String   `tfsdk:"id"`
 	Name         types.String   `tfsdk:"name"`
 	Description  types.String   `tfsdk:"description"`
@@ -148,7 +148,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model.
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -205,7 +205,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model.
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -280,7 +280,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/subnet_pool/datasource.go
+++ b/internal/provider/subnet_pool/datasource.go
@@ -30,13 +30,13 @@ type DataSourceModel struct {
 	ID           types.String            `tfsdk:"id"`
 	IpVersion    types.String            `tfsdk:"ip_version"`
 	Name         types.String            `tfsdk:"name"`
-	Members      []DataSourceMemberModel `tfsdk:"members"`
+	Members      []MemberDataSourceModel `tfsdk:"members"`
 	Timeouts     timeouts.Value          `tfsdk:"timeouts"`
 	TimeCreated  types.String            `tfsdk:"time_created"`
 	TimeModified types.String            `tfsdk:"time_modified"`
 }
 
-type DataSourceMemberModel struct {
+type MemberDataSourceModel struct {
 	Subnet          types.String `tfsdk:"subnet"`
 	MinPrefixLength types.Int64  `tfsdk:"min_prefix_length"`
 	MaxPrefixLength types.Int64  `tfsdk:"max_prefix_length"`
@@ -196,9 +196,9 @@ func (d *DataSource) Read(
 		map[string]any{"success": true},
 	)
 
-	state.Members = make([]DataSourceMemberModel, len(members))
+	state.Members = make([]MemberDataSourceModel, len(members))
 	for i, member := range members {
-		state.Members[i] = DataSourceMemberModel{
+		state.Members[i] = MemberDataSourceModel{
 			Subnet:          types.StringValue(member.Subnet.String()),
 			MinPrefixLength: types.Int64Value(int64(*member.MinPrefixLength)),
 			MaxPrefixLength: types.Int64Value(int64(*member.MaxPrefixLength)),

--- a/internal/provider/subnet_pool/resource.go
+++ b/internal/provider/subnet_pool/resource.go
@@ -40,7 +40,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	ID           types.String   `tfsdk:"id"`
 	IpVersion    types.String   `tfsdk:"ip_version"`
@@ -138,7 +138,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -193,7 +193,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -250,8 +250,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -314,7 +314,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/subnet_pool_member/resource.go
+++ b/internal/provider/subnet_pool_member/resource.go
@@ -41,7 +41,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	ID              types.String       `tfsdk:"id"`
 	SubnetPoolID    types.String       `tfsdk:"subnet_pool_id"`
 	Subnet          cidrtypes.IPPrefix `tfsdk:"subnet"`
@@ -160,7 +160,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -237,7 +237,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -329,7 +329,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/subnet_pool_silo_link/resource.go
+++ b/internal/provider/subnet_pool_silo_link/resource.go
@@ -39,7 +39,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	ID           types.String   `tfsdk:"id"`
 	SiloID       types.String   `tfsdk:"silo_id"`
 	SubnetPoolID types.String   `tfsdk:"subnet_pool_id"`
@@ -138,7 +138,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -191,7 +191,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -252,8 +252,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -311,7 +311,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/switch_port_settings/resource.go
+++ b/internal/provider/switch_port_settings/resource.go
@@ -33,78 +33,78 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	ID           types.String     `tfsdk:"id"`
-	Name         types.String     `tfsdk:"name"`
-	Description  types.String     `tfsdk:"description"`
-	Addresses    []AddressModel   `tfsdk:"addresses"`
-	BGPPeers     []BGPPeerModel   `tfsdk:"bgp_peers"`
-	Links        []LinkModel      `tfsdk:"links"`
-	PortConfig   *PortConfigModel `tfsdk:"port_config"`
-	Routes       []RouteModel     `tfsdk:"routes"`
-	TimeCreated  types.String     `tfsdk:"time_created"`
-	TimeModified types.String     `tfsdk:"time_modified"`
-	Timeouts     timeouts.Value   `tfsdk:"timeouts"`
+type ResourceModel struct {
+	ID           types.String             `tfsdk:"id"`
+	Name         types.String             `tfsdk:"name"`
+	Description  types.String             `tfsdk:"description"`
+	Addresses    []AddressResourceModel   `tfsdk:"addresses"`
+	BGPPeers     []BGPPeerResourceModel   `tfsdk:"bgp_peers"`
+	Links        []LinkResourceModel      `tfsdk:"links"`
+	PortConfig   *PortConfigResourceModel `tfsdk:"port_config"`
+	Routes       []RouteResourceModel     `tfsdk:"routes"`
+	TimeCreated  types.String             `tfsdk:"time_created"`
+	TimeModified types.String             `tfsdk:"time_modified"`
+	Timeouts     timeouts.Value           `tfsdk:"timeouts"`
 }
 
-type AddressModel struct {
-	Addresses []AddressAddressModel `tfsdk:"addresses"`
-	LinkName  types.String          `tfsdk:"link_name"`
+type AddressResourceModel struct {
+	Addresses []AddressAddressResourceModel `tfsdk:"addresses"`
+	LinkName  types.String                  `tfsdk:"link_name"`
 }
 
-type AddressAddressModel struct {
+type AddressAddressResourceModel struct {
 	Address      cidrtypes.IPPrefix `tfsdk:"address"`
 	AddressLotID types.String       `tfsdk:"address_lot_id"`
 	VlanID       types.Int32        `tfsdk:"vlan_id"`
 }
 
-type BGPPeerModel struct {
-	LinkName types.String       `tfsdk:"link_name"`
-	Peers    []BGPPeerPeerModel `tfsdk:"peers"`
+type BGPPeerResourceModel struct {
+	LinkName types.String               `tfsdk:"link_name"`
+	Peers    []BGPPeerPeerResourceModel `tfsdk:"peers"`
 }
 
-type BGPPeerPeerModel struct {
-	Address                iptypes.IPAddress              `tfsdk:"address"`
-	AllowedExport          *BGPPeerPeerAllowedExportModel `tfsdk:"allowed_export"`
-	AllowedImport          *BGPPeerPeerAllowedImportModel `tfsdk:"allowed_import"`
-	BGPConfig              types.String                   `tfsdk:"bgp_config"`
-	Communities            []types.Int64                  `tfsdk:"communities"`
-	ConnectRetry           types.Int64                    `tfsdk:"connect_retry"`
-	DelayOpen              types.Int64                    `tfsdk:"delay_open"`
-	EnforceFirstAs         types.Bool                     `tfsdk:"enforce_first_as"`
-	HoldTime               types.Int64                    `tfsdk:"hold_time"`
-	IdleHoldTime           types.Int64                    `tfsdk:"idle_hold_time"`
-	InterfaceName          types.String                   `tfsdk:"interface_name"`
-	Keepalive              types.Int64                    `tfsdk:"keepalive"`
-	LocalPref              types.Int64                    `tfsdk:"local_pref"`
-	MD5AuthKey             types.String                   `tfsdk:"md5_auth_key"`
-	MinTTL                 types.Int32                    `tfsdk:"min_ttl"`
-	MultiExitDiscriminator types.Int64                    `tfsdk:"multi_exit_discriminator"`
-	RemoteASN              types.Int64                    `tfsdk:"remote_asn"`
-	VlanID                 types.Int32                    `tfsdk:"vlan_id"`
+type BGPPeerPeerResourceModel struct {
+	Address                iptypes.IPAddress                      `tfsdk:"address"`
+	AllowedExport          *BGPPeerPeerAllowedExportResourceModel `tfsdk:"allowed_export"`
+	AllowedImport          *BGPPeerPeerAllowedImportResourceModel `tfsdk:"allowed_import"`
+	BGPConfig              types.String                           `tfsdk:"bgp_config"`
+	Communities            []types.Int64                          `tfsdk:"communities"`
+	ConnectRetry           types.Int64                            `tfsdk:"connect_retry"`
+	DelayOpen              types.Int64                            `tfsdk:"delay_open"`
+	EnforceFirstAs         types.Bool                             `tfsdk:"enforce_first_as"`
+	HoldTime               types.Int64                            `tfsdk:"hold_time"`
+	IdleHoldTime           types.Int64                            `tfsdk:"idle_hold_time"`
+	InterfaceName          types.String                           `tfsdk:"interface_name"`
+	Keepalive              types.Int64                            `tfsdk:"keepalive"`
+	LocalPref              types.Int64                            `tfsdk:"local_pref"`
+	MD5AuthKey             types.String                           `tfsdk:"md5_auth_key"`
+	MinTTL                 types.Int32                            `tfsdk:"min_ttl"`
+	MultiExitDiscriminator types.Int64                            `tfsdk:"multi_exit_discriminator"`
+	RemoteASN              types.Int64                            `tfsdk:"remote_asn"`
+	VlanID                 types.Int32                            `tfsdk:"vlan_id"`
 }
 
-type BGPPeerPeerAllowedExportModel struct {
+type BGPPeerPeerAllowedExportResourceModel struct {
 	Type  types.String   `tfsdk:"type"`
 	Value []types.String `tfsdk:"value"`
 }
 
-type BGPPeerPeerAllowedImportModel struct {
+type BGPPeerPeerAllowedImportResourceModel struct {
 	Type  types.String   `tfsdk:"type"`
 	Value []types.String `tfsdk:"value"`
 }
 
-type LinkModel struct {
-	Autoneg  types.Bool                       `tfsdk:"autoneg"`
-	FEC      types.String                     `tfsdk:"fec"`
-	LinkName types.String                     `tfsdk:"link_name"`
-	LLDP     *LinkLLDPModel                   `tfsdk:"lldp"`
-	MTU      types.Int32                      `tfsdk:"mtu"`
-	Speed    types.String                     `tfsdk:"speed"`
-	TxEq     *switchPortSettingsLinkTxEqModel `tfsdk:"tx_eq"`
+type LinkResourceModel struct {
+	Autoneg  types.Bool             `tfsdk:"autoneg"`
+	FEC      types.String           `tfsdk:"fec"`
+	LinkName types.String           `tfsdk:"link_name"`
+	LLDP     *LinkLLDPResourceModel `tfsdk:"lldp"`
+	MTU      types.Int32            `tfsdk:"mtu"`
+	Speed    types.String           `tfsdk:"speed"`
+	TxEq     *LinkTxEqResourceModel `tfsdk:"tx_eq"`
 }
 
-type LinkLLDPModel struct {
+type LinkLLDPResourceModel struct {
 	ChassisID         types.String      `tfsdk:"chassis_id"`
 	Enabled           types.Bool        `tfsdk:"enabled"`
 	LinkDescription   types.String      `tfsdk:"link_description"`
@@ -114,7 +114,7 @@ type LinkLLDPModel struct {
 	SystemName        types.String      `tfsdk:"system_name"`
 }
 
-type switchPortSettingsLinkTxEqModel struct {
+type LinkTxEqResourceModel struct {
 	Main  types.Int32 `tfsdk:"main"`
 	Post1 types.Int32 `tfsdk:"post1"`
 	Post2 types.Int32 `tfsdk:"post2"`
@@ -122,16 +122,16 @@ type switchPortSettingsLinkTxEqModel struct {
 	Pre2  types.Int32 `tfsdk:"pre2"`
 }
 
-type PortConfigModel struct {
+type PortConfigResourceModel struct {
 	Geometry types.String `tfsdk:"geometry"`
 }
 
-type RouteModel struct {
-	LinkName types.String                        `tfsdk:"link_name"`
-	Routes   []switchPortSettingsRouteRouteModel `tfsdk:"routes"`
+type RouteResourceModel struct {
+	LinkName types.String              `tfsdk:"link_name"`
+	Routes   []RouteEntryResourceModel `tfsdk:"routes"`
 }
 
-type switchPortSettingsRouteRouteModel struct {
+type RouteEntryResourceModel struct {
 	Dst         types.String      `tfsdk:"dst"`
 	GW          iptypes.IPAddress `tfsdk:"gw"`
 	RIBPriority types.Int32       `tfsdk:"rib_priority"`
@@ -546,7 +546,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model.
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -601,7 +601,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model.
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -676,14 +676,14 @@ func (r *Resource) Update(
 	resp *resource.UpdateResponse,
 ) { // plan is the resource data model for the update request.
 	// Read the Terraform plan data.
-	var plan Model
+	var plan ResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Read the Terraform state data to retreive compute attributes.
-	var state Model
+	var state ResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -738,7 +738,7 @@ func (r *Resource) Delete(
 	resp *resource.DeleteResponse,
 ) {
 	// Read the Terraform state.
-	var state Model
+	var state ResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -803,14 +803,14 @@ func (r *Resource) Delete(
 // from Oxide.
 func toSwitchPortSettingsModel(
 	settings *oxide.SwitchPortSettings,
-) (Model, diag.Diagnostics) {
+) (ResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	model := Model{
+	model := ResourceModel{
 		ID:          types.StringValue(settings.Id),
 		Name:        types.StringValue(string(settings.Name)),
 		Description: types.StringValue(settings.Description),
-		PortConfig: &PortConfigModel{
+		PortConfig: &PortConfigResourceModel{
 			Geometry: types.StringValue(string(settings.Port.Geometry)),
 		},
 		TimeCreated:  types.StringValue(settings.TimeCreated.String()),
@@ -826,15 +826,15 @@ func toSwitchPortSettingsModel(
 			"The API returned an empty array for this required attribute.",
 		)
 	} else {
-		linkToAddrs := make(map[string][]AddressAddressModel)
+		linkToAddrs := make(map[string][]AddressAddressResourceModel)
 		for _, address := range settings.Addresses {
 			link := string(address.InterfaceName)
 
 			if _, ok := linkToAddrs[link]; !ok {
-				linkToAddrs[link] = make([]AddressAddressModel, 0)
+				linkToAddrs[link] = make([]AddressAddressResourceModel, 0)
 			}
 
-			addressModel := AddressAddressModel{
+			addressModel := AddressAddressResourceModel{
 				Address:      cidrtypes.NewIPPrefixValue(address.Address.String()),
 				AddressLotID: types.StringValue(string(address.AddressLotId)),
 				VlanID: func() types.Int32 {
@@ -848,9 +848,9 @@ func toSwitchPortSettingsModel(
 			linkToAddrs[link] = append(linkToAddrs[link], addressModel)
 		}
 
-		addressModels := make([]AddressModel, 0)
+		addressModels := make([]AddressResourceModel, 0)
 		for linkName, addrModels := range linkToAddrs {
-			addressModel := AddressModel{
+			addressModel := AddressResourceModel{
 				Addresses: addrModels,
 				LinkName:  types.StringValue(linkName),
 			}
@@ -864,15 +864,15 @@ func toSwitchPortSettingsModel(
 	// BGP Peers
 	//
 	if len(settings.BgpPeers) > 0 {
-		linkToBGPPeer := make(map[string][]BGPPeerPeerModel)
+		linkToBGPPeer := make(map[string][]BGPPeerPeerResourceModel)
 		for _, bgpPeer := range settings.BgpPeers {
 			link := string(bgpPeer.InterfaceName)
 
 			if _, ok := linkToBGPPeer[link]; !ok {
-				linkToBGPPeer[link] = make([]BGPPeerPeerModel, 0)
+				linkToBGPPeer[link] = make([]BGPPeerPeerResourceModel, 0)
 			}
 
-			bgpPeerModel := BGPPeerPeerModel{
+			bgpPeerModel := BGPPeerPeerResourceModel{
 				Address: func() iptypes.IPAddress {
 					if bgpPeer.Addr == "" {
 						return iptypes.NewIPAddressNull()
@@ -927,7 +927,7 @@ func toSwitchPortSettingsModel(
 				}(),
 			}
 
-			bgpPeerModel.AllowedExport = &BGPPeerPeerAllowedExportModel{
+			bgpPeerModel.AllowedExport = &BGPPeerPeerAllowedExportResourceModel{
 				Type: types.StringValue(string(bgpPeer.AllowedExport.Type())),
 				Value: func() []types.String {
 					if allow, ok := bgpPeer.AllowedExport.AsAllow(); ok {
@@ -944,7 +944,7 @@ func toSwitchPortSettingsModel(
 				}(),
 			}
 
-			bgpPeerModel.AllowedImport = &BGPPeerPeerAllowedImportModel{
+			bgpPeerModel.AllowedImport = &BGPPeerPeerAllowedImportResourceModel{
 				Type: types.StringValue(string(bgpPeer.AllowedImport.Type())),
 				Value: func() []types.String {
 					if allow, ok := bgpPeer.AllowedImport.AsAllow(); ok {
@@ -972,9 +972,9 @@ func toSwitchPortSettingsModel(
 			linkToBGPPeer[link] = append(linkToBGPPeer[link], bgpPeerModel)
 		}
 
-		bgpPeersModels := make([]BGPPeerModel, 0)
+		bgpPeersModels := make([]BGPPeerResourceModel, 0)
 		for linkName, bgpPeers := range linkToBGPPeer {
-			bgpPeerModel := BGPPeerModel{
+			bgpPeerModel := BGPPeerResourceModel{
 				Peers:    bgpPeers,
 				LinkName: types.StringValue(linkName),
 			}
@@ -993,9 +993,9 @@ func toSwitchPortSettingsModel(
 			"The API returned an empty array for this required attribute.",
 		)
 	} else {
-		linkModels := make([]LinkModel, 0)
+		linkModels := make([]LinkResourceModel, 0)
 		for _, link := range settings.Links {
-			linkModel := LinkModel{
+			linkModel := LinkResourceModel{
 				Autoneg: func() types.Bool {
 					if link.Autoneg == nil {
 						return types.BoolNull()
@@ -1019,7 +1019,7 @@ func toSwitchPortSettingsModel(
 			}
 
 			if link.LldpLinkConfig != nil {
-				linkModel.LLDP = &LinkLLDPModel{
+				linkModel.LLDP = &LinkLLDPResourceModel{
 					Enabled: types.BoolPointerValue(link.LldpLinkConfig.Enabled),
 				}
 
@@ -1064,7 +1064,7 @@ func toSwitchPortSettingsModel(
 			}
 
 			if link.TxEqConfig != nil {
-				linkModel.TxEq = &switchPortSettingsLinkTxEqModel{
+				linkModel.TxEq = &LinkTxEqResourceModel{
 					Main: func() types.Int32 {
 						if link.TxEqConfig.Main == nil {
 							return types.Int32Null()
@@ -1108,15 +1108,15 @@ func toSwitchPortSettingsModel(
 	// Routes
 	//
 	if len(settings.Routes) > 0 {
-		linkToRoutes := make(map[string][]switchPortSettingsRouteRouteModel)
+		linkToRoutes := make(map[string][]RouteEntryResourceModel)
 		for _, route := range settings.Routes {
 			link := string(route.InterfaceName)
 
 			if _, ok := linkToRoutes[link]; !ok {
-				linkToRoutes[link] = make([]switchPortSettingsRouteRouteModel, 0)
+				linkToRoutes[link] = make([]RouteEntryResourceModel, 0)
 			}
 
-			routeModel := switchPortSettingsRouteRouteModel{
+			routeModel := RouteEntryResourceModel{
 				Dst: types.StringValue(route.Dst.String()),
 				GW:  iptypes.NewIPAddressValue(route.Gw),
 				RIBPriority: func() types.Int32 {
@@ -1136,9 +1136,9 @@ func toSwitchPortSettingsModel(
 			linkToRoutes[link] = append(linkToRoutes[link], routeModel)
 		}
 
-		routeModels := make([]RouteModel, 0)
+		routeModels := make([]RouteResourceModel, 0)
 		for linkName, rts := range linkToRoutes {
-			routeModel := RouteModel{
+			routeModel := RouteResourceModel{
 				Routes:   rts,
 				LinkName: types.StringValue(linkName),
 			}
@@ -1156,7 +1156,7 @@ func toSwitchPortSettingsModel(
 // [toSwitchPortSettingsModel] since the Oxide `switch_port_settings_create` API
 // request body matches the Terraform schema.
 func toNetworkingSwitchPortSettingsCreateParams(
-	model Model,
+	model ResourceModel,
 ) (oxide.NetworkingSwitchPortSettingsCreateParams, diag.Diagnostics) {
 	params := oxide.NetworkingSwitchPortSettingsCreateParams{
 		Body: &oxide.SwitchPortSettingsCreate{

--- a/internal/provider/system_ip_pools/datasource.go
+++ b/internal/provider/system_ip_pools/datasource.go
@@ -26,12 +26,12 @@ type DataSource struct {
 }
 
 type DataSourceModel struct {
-	ID       types.String   `tfsdk:"id"`
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
-	IpPools  []IpPoolModel  `tfsdk:"ip_pools"`
+	ID       types.String            `tfsdk:"id"`
+	Timeouts timeouts.Value          `tfsdk:"timeouts"`
+	IpPools  []IpPoolDataSourceModel `tfsdk:"ip_pools"`
 }
 
-type IpPoolModel struct {
+type IpPoolDataSourceModel struct {
 	Description  types.String `tfsdk:"description"`
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
@@ -149,7 +149,7 @@ func (d *DataSource) Read(
 	state.ID = types.StringValue(uuid.New().String())
 
 	for _, ipPool := range ipPools {
-		poolState := IpPoolModel{
+		poolState := IpPoolDataSourceModel{
 			Description:  types.StringValue(ipPool.Description),
 			ID:           types.StringValue(ipPool.Id),
 			Name:         types.StringValue(string(ipPool.Name)),

--- a/internal/provider/vpc/resource.go
+++ b/internal/provider/vpc/resource.go
@@ -37,7 +37,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description    types.String   `tfsdk:"description"`
 	DNSName        types.String   `tfsdk:"dns_name"`
 	ID             types.String   `tfsdk:"id"`
@@ -154,7 +154,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -214,7 +214,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -271,8 +271,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -337,7 +337,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/vpc_firewall_rules/resource.go
+++ b/internal/provider/vpc_firewall_rules/resource.go
@@ -52,52 +52,52 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	// This ID is specific to Terraform only
-	ID       types.String         `tfsdk:"id"`
-	Rules    map[string]RuleModel `tfsdk:"rules"`
-	Timeouts timeouts.Value       `tfsdk:"timeouts"`
-	VPCID    types.String         `tfsdk:"vpc_id"`
+	ID       types.String                 `tfsdk:"id"`
+	Rules    map[string]RuleResourceModel `tfsdk:"rules"`
+	Timeouts timeouts.Value               `tfsdk:"timeouts"`
+	VPCID    types.String                 `tfsdk:"vpc_id"`
 
-	// Populated from the same fields within [RuleModel].
+	// Populated from the same fields within [RuleResourceModel].
 	TimeCreated  types.String `tfsdk:"time_created"`
 	TimeModified types.String `tfsdk:"time_modified"`
 }
 
-type RuleModel struct {
-	Action      types.String      `tfsdk:"action"`
-	Description types.String      `tfsdk:"description"`
-	Direction   types.String      `tfsdk:"direction"`
-	Filters     *RuleFiltersModel `tfsdk:"filters"`
-	Name        types.String      `tfsdk:"name"`
-	Priority    types.Int64       `tfsdk:"priority"`
-	Status      types.String      `tfsdk:"status"`
-	Targets     []RuleTargetModel `tfsdk:"targets"`
+type RuleResourceModel struct {
+	Action      types.String              `tfsdk:"action"`
+	Description types.String              `tfsdk:"description"`
+	Direction   types.String              `tfsdk:"direction"`
+	Filters     *RuleFiltersResourceModel `tfsdk:"filters"`
+	Name        types.String              `tfsdk:"name"`
+	Priority    types.Int64               `tfsdk:"priority"`
+	Status      types.String              `tfsdk:"status"`
+	Targets     []RuleTargetResourceModel `tfsdk:"targets"`
 
 	// Used to retrieve the timestamps from the API and populate the same fields
-	// within [Model]. The `tfsdk:"-"` struct field tag is used
+	// within [ResourceModel]. The `tfsdk:"-"` struct field tag is used
 	// to tell Terraform not to populate these values in the schema.
 	TimeCreated  types.String `tfsdk:"-"`
 	TimeModified types.String `tfsdk:"-"`
 }
 
-type RuleTargetModel struct {
+type RuleTargetResourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
 
-type RuleFiltersModel struct {
-	Hosts     []HostFilterModel     `tfsdk:"hosts"`
-	Ports     types.Set             `tfsdk:"ports"`
-	Protocols []ProtocolFilterModel `tfsdk:"protocols"`
+type RuleFiltersResourceModel struct {
+	Hosts     []HostFilterResourceModel     `tfsdk:"hosts"`
+	Ports     types.Set                     `tfsdk:"ports"`
+	Protocols []ProtocolFilterResourceModel `tfsdk:"protocols"`
 }
 
-type HostFilterModel struct {
+type HostFilterResourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
 
-type ProtocolFilterModel struct {
+type ProtocolFilterResourceModel struct {
 	Type     types.String `tfsdk:"type"`
 	IcmpType types.Int32  `tfsdk:"icmp_type"`
 	IcmpCode types.String `tfsdk:"icmp_code"`
@@ -414,7 +414,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -495,7 +495,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -570,8 +570,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -660,7 +660,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -702,7 +702,7 @@ func (r *Resource) Delete(
 // newUpdateBody builds the parameters required by the Oxide
 // vpc_firewall_rules_update API using the specified rules.
 func newUpdateBody(
-	rules map[string]RuleModel,
+	rules map[string]RuleResourceModel,
 ) (*oxide.VpcFirewallRuleUpdateParams, error) {
 	// The make builtin is used to explicitly get an empty slice rather than a zero
 	// value slice for the use case of removing all the firewall rules from a VPC.
@@ -743,17 +743,17 @@ func newUpdateBody(
 }
 
 // newModel translates a slice of [oxide.VpcFirewallRule] into a
-// slice of [RuleModel].
+// slice of [RuleResourceModel].
 func newModel(
 	rules []oxide.VpcFirewallRule,
-) (map[string]RuleModel, diag.Diagnostics) {
+) (map[string]RuleResourceModel, diag.Diagnostics) {
 	// The make builtin is used to explicitly get an empty slice rather than a zero
 	// value slice for the use case of removing all the firewall rules from a VPC.
 	// See the comment within [newUpdateBody] for more information.
-	model := make(map[string]RuleModel)
+	model := make(map[string]RuleResourceModel)
 
 	for _, rule := range rules {
-		m := RuleModel{
+		m := RuleResourceModel{
 			Action:      types.StringValue(string(rule.Action)),
 			Description: types.StringValue(rule.Description),
 			Direction:   types.StringValue(string(rule.Direction)),
@@ -780,12 +780,12 @@ func newModel(
 
 func newFiltersModel(
 	filter oxide.VpcFirewallRuleFilter,
-) (*RuleFiltersModel, diag.Diagnostics) {
+) (*RuleFiltersResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	var hostsModel = []HostFilterModel{}
+	var hostsModel = []HostFilterResourceModel{}
 	for _, h := range filter.Hosts {
-		m := HostFilterModel{
+		m := HostFilterResourceModel{
 			Type:  types.StringValue(string(h.Type())),
 			Value: types.StringValue(h.String()),
 		}
@@ -803,9 +803,9 @@ func newFiltersModel(
 		return nil, diags
 	}
 
-	var protocolModels = []ProtocolFilterModel{}
+	var protocolModels = []ProtocolFilterResourceModel{}
 	for _, protocol := range filter.Protocols {
-		protocolModel := ProtocolFilterModel{
+		protocolModel := ProtocolFilterResourceModel{
 			Type:     types.StringValue(string(protocol.Type())),
 			IcmpCode: types.StringNull(),
 			IcmpType: types.Int32Null(),
@@ -843,7 +843,7 @@ func newFiltersModel(
 		protocolModels = append(protocolModels, protocolModel)
 	}
 
-	model := RuleFiltersModel{}
+	model := RuleFiltersResourceModel{}
 
 	if len(hostsModel) > 0 {
 		model.Hosts = hostsModel
@@ -866,11 +866,11 @@ func newFiltersModel(
 
 func newTargetsModelFromResponse(
 	target []oxide.VpcFirewallRuleTarget,
-) []RuleTargetModel {
-	var model []RuleTargetModel
+) []RuleTargetResourceModel {
+	var model []RuleTargetResourceModel
 
 	for _, t := range target {
-		m := RuleTargetModel{
+		m := RuleTargetResourceModel{
 			Type:  types.StringValue(string(t.Type())),
 			Value: types.StringValue(t.String()),
 		}
@@ -882,7 +882,7 @@ func newTargetsModelFromResponse(
 }
 
 func newFilterTypeFromModel(
-	model *RuleFiltersModel,
+	model *RuleFiltersResourceModel,
 ) (oxide.VpcFirewallRuleFilter, error) {
 	var hosts []oxide.VpcFirewallRuleHostFilter
 	for _, host := range model.Hosts {
@@ -964,7 +964,7 @@ func newFilterTypeFromModel(
 }
 
 func newTargetTypeFromModel(
-	model []RuleTargetModel,
+	model []RuleTargetResourceModel,
 ) ([]oxide.VpcFirewallRuleTarget, error) {
 	var target []oxide.VpcFirewallRuleTarget
 

--- a/internal/provider/vpc_firewall_rules/resource_v0.go
+++ b/internal/provider/vpc_firewall_rules/resource_v0.go
@@ -307,7 +307,7 @@ type modelV00 struct {
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 	VPCID    types.String   `tfsdk:"vpc_id"`
 
-	// Populated from the same fields within [RuleModel].
+	// Populated from the same fields within [RuleResourceModel].
 	TimeCreated  types.String `tfsdk:"time_created"`
 	TimeModified types.String `tfsdk:"time_modified"`
 }
@@ -352,7 +352,7 @@ type ruleModelV00 struct {
 	Targets     []ruleTargetModelV00 `tfsdk:"targets"`
 
 	// Used to retrieve the timestamps from the API and populate the same fields
-	// within [Model]. The `tfsdk:"-"` struct field tag is used
+	// within [ResourceModel]. The `tfsdk:"-"` struct field tag is used
 	// to tell Terraform not to populate these values in the schema.
 	TimeCreated  types.String `tfsdk:"-"`
 	TimeModified types.String `tfsdk:"-"`
@@ -667,18 +667,18 @@ type modelV01 struct {
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 	VPCID    types.String   `tfsdk:"vpc_id"`
 
-	// Populated from the same fields within [RuleModel].
+	// Populated from the same fields within [RuleResourceModel].
 	TimeCreated  types.String `tfsdk:"time_created"`
 	TimeModified types.String `tfsdk:"time_modified"`
 }
 
-func (m modelV01) upgrade() Model {
-	rules := make(map[string]RuleModel, len(m.Rules))
+func (m modelV01) upgrade() ResourceModel {
+	rules := make(map[string]RuleResourceModel, len(m.Rules))
 	for _, r := range m.Rules {
 		rules[r.Name.ValueString()] = r.upgrade()
 	}
 
-	return Model{
+	return ResourceModel{
 		ID:           m.ID,
 		Rules:        rules,
 		Timeouts:     m.Timeouts,
@@ -699,19 +699,19 @@ type ruleModelV01 struct {
 	Targets     []ruleTargetModelV01 `tfsdk:"targets"`
 
 	// Used to retrieve the timestamps from the API and populate the same fields
-	// within [Model]. The `tfsdk:"-"` struct field tag is used
+	// within [ResourceModel]. The `tfsdk:"-"` struct field tag is used
 	// to tell Terraform not to populate these values in the schema.
 	TimeCreated  types.String `tfsdk:"-"`
 	TimeModified types.String `tfsdk:"-"`
 }
 
-func (r ruleModelV01) upgrade() RuleModel {
-	targets := make([]RuleTargetModel, len(r.Targets))
+func (r ruleModelV01) upgrade() RuleResourceModel {
+	targets := make([]RuleTargetResourceModel, len(r.Targets))
 	for i, t := range r.Targets {
-		targets[i] = RuleTargetModel(t)
+		targets[i] = RuleTargetResourceModel(t)
 	}
 
-	return RuleModel{
+	return RuleResourceModel{
 		Action:       r.Action,
 		Description:  r.Description,
 		Direction:    r.Direction,
@@ -731,22 +731,22 @@ type ruleFiltersModelV01 struct {
 	Protocols []protocolFilterModelV01 `tfsdk:"protocols"`
 }
 
-func (f *ruleFiltersModelV01) upgrade() *RuleFiltersModel {
+func (f *ruleFiltersModelV01) upgrade() *RuleFiltersResourceModel {
 	if f == nil {
 		return nil
 	}
 
-	hosts := make([]HostFilterModel, len(f.Hosts))
+	hosts := make([]HostFilterResourceModel, len(f.Hosts))
 	for i, h := range f.Hosts {
-		hosts[i] = HostFilterModel(h)
+		hosts[i] = HostFilterResourceModel(h)
 	}
 
-	protocols := make([]ProtocolFilterModel, len(f.Protocols))
+	protocols := make([]ProtocolFilterResourceModel, len(f.Protocols))
 	for i, p := range f.Protocols {
-		protocols[i] = ProtocolFilterModel(p)
+		protocols[i] = ProtocolFilterResourceModel(p)
 	}
 
-	return &RuleFiltersModel{
+	return &RuleFiltersResourceModel{
 		Hosts:     hosts,
 		Ports:     f.Ports,
 		Protocols: protocols,

--- a/internal/provider/vpc_internet_gateway/resource.go
+++ b/internal/provider/vpc_internet_gateway/resource.go
@@ -38,7 +38,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	CascadeDelete types.Bool     `tfsdk:"cascade_delete"`
 	Description   types.String   `tfsdk:"description"`
 	ID            types.String   `tfsdk:"id"`
@@ -147,7 +147,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -203,7 +203,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -267,8 +267,8 @@ func (r *Resource) Update(
 	// parameter which you only use during delete. This means we only want
 	// to save it as part of the state.
 
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -326,7 +326,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/vpc_router/resource.go
+++ b/internal/provider/vpc_router/resource.go
@@ -37,7 +37,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description  types.String   `tfsdk:"description"`
 	ID           types.String   `tfsdk:"id"`
 	Kind         types.String   `tfsdk:"kind"`
@@ -139,7 +139,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -196,7 +196,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -255,8 +255,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -319,7 +319,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/vpc_router_route/resource.go
+++ b/internal/provider/vpc_router_route/resource.go
@@ -39,25 +39,25 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
-	Description  types.String      `tfsdk:"description"`
-	Destination  *DestinationModel `tfsdk:"destination"`
-	ID           types.String      `tfsdk:"id"`
-	Kind         types.String      `tfsdk:"kind"`
-	Name         types.String      `tfsdk:"name"`
-	Target       *TargetModel      `tfsdk:"target"`
-	TimeCreated  types.String      `tfsdk:"time_created"`
-	TimeModified types.String      `tfsdk:"time_modified"`
-	VPCRouterID  types.String      `tfsdk:"vpc_router_id"`
-	Timeouts     timeouts.Value    `tfsdk:"timeouts"`
+type ResourceModel struct {
+	Description  types.String              `tfsdk:"description"`
+	Destination  *DestinationResourceModel `tfsdk:"destination"`
+	ID           types.String              `tfsdk:"id"`
+	Kind         types.String              `tfsdk:"kind"`
+	Name         types.String              `tfsdk:"name"`
+	Target       *TargetResourceModel      `tfsdk:"target"`
+	TimeCreated  types.String              `tfsdk:"time_created"`
+	TimeModified types.String              `tfsdk:"time_modified"`
+	VPCRouterID  types.String              `tfsdk:"vpc_router_id"`
+	Timeouts     timeouts.Value            `tfsdk:"timeouts"`
 }
 
-type DestinationModel struct {
+type DestinationResourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
 
-type TargetModel struct {
+type TargetResourceModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
@@ -213,7 +213,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -296,7 +296,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -334,12 +334,12 @@ func (r *Resource) Read(
 		map[string]any{"success": true},
 	)
 
-	dm := DestinationModel{
+	dm := DestinationResourceModel{
 		Type:  types.StringValue(string(vpcRouterRoute.Destination.Type())),
 		Value: types.StringValue(vpcRouterRoute.Destination.String()),
 	}
 
-	tm := TargetModel{
+	tm := TargetResourceModel{
 		Type: types.StringValue(string(vpcRouterRoute.Target.Type())),
 	}
 
@@ -371,8 +371,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -462,7 +462,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/provider/vpc_subnet/resource.go
+++ b/internal/provider/vpc_subnet/resource.go
@@ -38,7 +38,7 @@ type Resource struct {
 	client *oxide.Client
 }
 
-type Model struct {
+type ResourceModel struct {
 	Description  types.String         `tfsdk:"description"`
 	ID           types.String         `tfsdk:"id"`
 	IPV4Block    cidrtypes.IPv4Prefix `tfsdk:"ipv4_block"`
@@ -161,7 +161,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan Model
+	var plan ResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -220,7 +220,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -280,8 +280,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan Model
-	var state Model
+	var plan ResourceModel
+	var state ResourceModel
 
 	// Read Terraform plan data into the plan model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -344,7 +344,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var state Model
+	var state ResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)


### PR DESCRIPTION
Updated the model types to be explicit for each resource and data source. Since a given resource and data source now live in the same package, they can conflict on model type names, though it's unlikely. In fact, a case could be made to consolidate models for a resource and data source but that's not a concern for this patch.

This patch ensures the model type for a resource is named `ResourceModel` and the model type for a data source is named `DataSourceModel`. Then, each field for a model that uses a struct type is named with a `ResourceModel` or `DataSourceModel` suffix to show that the field belongs to the resource or data source.

Relates to SSE-266.