### PR TITLE
ci: update and fix tests

### DIFF
--- a/.github/workflows/acceptance-sim.yml
+++ b/.github/workflows/acceptance-sim.yml
@@ -40,6 +40,9 @@ jobs:
           go-version-file: 'go.mod'
       - uses: docker/setup-compose-action@v2
       - uses: astral-sh/setup-uv@v7
+        with:
+          # We don't have any Python dependencies to cache.
+          enable-cache: false
       # Look up the version of oxide.rs corresponding to the requested omicron version. We'll cache
       # the resulting binary, so that we only build the CLI for a given oxide.rs commit once, and
       # always use the latest oxide.rs version corresponding to the relevant omicron version.
@@ -115,7 +118,7 @@ jobs:
           docker compose exec -T omicron-dev sh -c 'tar -cf - /tmp/omicron-dev*.log' | tar -xf -
           docker compose exec -T mitmproxy sh -c 'tar -cf - /tmp/mitmproxy.log' | tar -xf -
           docker compose logs omicron-dev > ./tmp/omicron-dev.log
-          mv ../internal/provider/terraform.log ./tmp
+          find .. -name terraform.log -exec cat {} \; > ./tmp/terraform.log
           cp ./acc-tests.xml ./tmp
       - name: rerun warn
         if: always()
@@ -129,20 +132,16 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          TESTRAIL_HOST: ${{ secrets.testrail-host }}
-          TESTRAIL_USERNAME: ${{ secrets.testrail-username }}
-          TESTRAIL_API_KEY: ${{ secrets.testrail-api-key }}
-          TESTRAIL_PROJECT: ${{ secrets.testrail-project }}
+          TR_CLI_HOST: ${{ secrets.testrail-host }}
+          TR_CLI_USERNAME: ${{ secrets.testrail-username }}
+          TR_CLI_KEY: ${{ secrets.testrail-api-key }}
+          TR_CLI_PROJECT: ${{ secrets.testrail-project }}
         run: |
           uvx trcli \
-            --host "${TESTRAIL_HOST}" \
-            --username "${TESTRAIL_USERNAME}" \
-            --key "${TESTRAIL_API_KEY}" \
-            --project "${TESTRAIL_PROJECT}" \
             --yes `# Auto-create new test cases.` \
             parse_junit \
               --file './acctest/acc-tests.xml' \
-              --title '${{ matrix.tf-binary }} - ${{ github.run_id }} - ${{ job.check_run_id }}' \
+              --title 'Acceptance Tests (${{ matrix.tf-binary }}) - ${{ github.run_id }} - ${{ job.check_run_id }}' \
               --run-description 'GitHub workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}' \
               --update-existing-cases 'yes' \
               --case-matcher 'auto' \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,19 +17,67 @@ env:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tf-binary:
+          - terraform
+          - tofu
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v4
+        if: matrix.tf-binary == 'terraform'
+        with:
+          terraform_wrapper: false
+      - uses: opentofu/setup-opentofu@v2
+        if: matrix.tf-binary == 'tofu'
+        with:
+          tofu_wrapper: false
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # We don't have any Python dependencies to cache.
+          enable-cache: false
+      - name: set env
+        run: |
+          echo "CHECKPOINT_DISABLE=1" >> "$GITHUB_ENV"
+          echo "TF_ACC_TERRAFORM_PATH=$(which ${{ matrix.tf-binary }})" >> "$GITHUB_ENV"
       - name: build
         run: make build
       - name: test
-        run: make test
+        run: |
+          mkdir ./unittest
+          make test
         env:
           CHECKPOINT_DISABLE: "1"
+          TEST_GOTESTSUM_ARGS: "--rerun-fails-report=./unittest/unit-test-rerun.txt --junitfile=./unittest/unit-tests.xml"
+          # Explicitly skip TestAcc* test to avoid polluting TestRail results
+          # with unnecessary Skipped results.
+          TEST_NAME: "^Test($|[^A]|A$|A[^c]|Ac$|Ac[^c])"
+          TF_ACC_PROVIDER_NAMESPACE: oxidecomputer
       - name: lint
+        if: matrix.tf-binary == 'terraform' # Linting tools require Terraform to be installed.
         run: make lint
+      - name: upload test results to TestRail
+        if: always()
+        continue-on-error: true
+        env:
+          TR_CLI_HOST: ${{ secrets.TESTRAIL_HOST }}
+          TR_CLI_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
+          TR_CLI_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+          TR_CLI_PROJECT: ${{ secrets.TESTRAIL_PROJECT }}
+        run: |
+          uvx trcli \
+            --yes `# Auto-create new test cases.` \
+            parse_junit \
+              --file './unittest/unit-tests.xml' \
+              --title 'Unit Tests (${{ matrix.tf-binary }}) - ${{ github.run_id }} - ${{ job.check_run_id }}' \
+              --run-description 'GitHub workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}' \
+              --update-existing-cases 'yes' \
+              --case-matcher 'auto' \
+              --close-run
 
   # Choose the appropriate omicron version for acceptance tests. For cron jobs, use `main`, since
   # our goal is to detect breaking changes in omicron. Otherwise, look up the omicron version from

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tf/
 acctest/oxide-token
 alpine.qcow2
 alpine.raw
+terraform.log
 
 # Go.
 go.work

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # Acceptance test variables
 TEST_ACC_COUNT ?= 1
-TEST_ACC ?= github.com/oxidecomputer/terraform-provider-oxide/internal/provider
+TEST_ACC ?= github.com/oxidecomputer/terraform-provider-oxide/internal/...
 TEST_ACC_NAME ?= TestAcc
 TEST_ACC_PARALLEL = 6
 TEST_ACC_OMICRON_BRANCH ?=
@@ -50,7 +50,9 @@ install:
 .PHONY: test
 test:
 	@ echo "-> Running unit tests for $(BINARY)"
-	@ $(GO_TOOL) gotestsum --format=testname --hide-summary=skipped -- $(TEST_PACKAGE) $(TEST_ARGS) $(TESTUNITARGS)
+	@ $(GO_TOOL) gotestsum \
+	    --format=testname --hide-summary=skipped --rerun-fails=3 --packages=$(TEST_PACKAGE) $(TEST_GOTESTSUM_ARGS) \
+	    -- $(TEST_PACKAGE) $(TEST_ARGS) $(TESTUNITARGS) -run '$(TEST_NAME)'
 
 .PHONY: docs
 docs:
@@ -143,7 +145,7 @@ testacc-sim-setup: testacc-sim-token testacc-sim-oxide-cli
 testacc:
 	@ echo "-> Running terraform acceptance tests"
 	@ TF_ACC=1 $(GO_TOOL) gotestsum \
-	    --format=testname --rerun-fails=3 --packages=$(TEST_ACC)/... $(TEST_ACC_GOTESTSUM_ARGS) \
+	    --format=testname --rerun-fails=3 --packages=$(TEST_ACC) $(TEST_ACC_GOTESTSUM_ARGS) \
 	    -- $(TEST_ACC) -v -count $(TEST_ACC_COUNT) -parallel $(TEST_ACC_PARALLEL) $(TEST_ACC_ARGS) -timeout 20m -run $(TEST_ACC_NAME)
 
 .PHONY: testacc-local

--- a/internal/provider/sharedtest/sharedtest.go
+++ b/internal/provider/sharedtest/sharedtest.go
@@ -7,6 +7,7 @@ package sharedtest
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"html/template"
 	"os"
 	"sync/atomic"
@@ -133,11 +134,14 @@ func SiloDNSName() string {
 var subnetCounter uint32
 
 // NextSubnetCIDR returns sequential /24 subnet CIDRs from
-// the 10.128.0.0/16 range.
+// the 10.k.0.0/16 range, where k is a hash of the test name.
 // TODO: extend if we ever need more than 256 subnets in
 // tests.
 func NextSubnetCIDR(t *testing.T) string {
 	t.Helper()
+	h := fnv.New32a()
+	h.Write([]byte(t.Name()))
+	k := h.Sum32() % 256
 	n := atomic.AddUint32(&subnetCounter, 1) - 1
 	if n > 255 {
 		t.Fatal(
@@ -145,5 +149,5 @@ func NextSubnetCIDR(t *testing.T) string {
 				" subnets in 10.128.0.0/16",
 		)
 	}
-	return fmt.Sprintf("10.128.%d.0/24", n)
+	return fmt.Sprintf("10.%d.%d.0/24", k, n)
 }


### PR DESCRIPTION
Fix acceptance tests to handle the new project structure.
  - Test all packages by default instead of just `internal`.
  - Collect `terraform.log` files from all packages.
  - Fix subnet assignment to isolate subnet generation per test. The shared `NextSubnetCIDR()` helper now has new state per package.
  - Remove Python dependency cache warning.

Fix and update unit tests.
  - Download Terraform explicitly instead of relying on auto-download. This removes failures in case the Terraform Framework can't find Terraform or if Checkpoint is down. Currently tests are failing with the error `failed to find or install Terraform CLI from [0xc00024e100 0xc00016f560]: unable to verify checksums signature: openpgp: key expired`, maybe because of https://discuss.hashicorp.com/t/hcsec-2026-03-hashicorp-gpg-key-72d7468f-update/77237.
  - Test using OpenTofu.
  - Upload results to TestRail.
