### PR TITLE
Update provider attribute docs to match openapi.

### DIFF
--- a/.agents/skills/sync-schema-descriptions/SKILL.md
+++ b/.agents/skills/sync-schema-descriptions/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: sync-schema-descriptions
+description: |
+  Sources Terraform schema descriptions from the pinned oxide.go SDK's Go doc
+  comments, which already mirror the OpenAPI spec. Adapts the text to the TF
+  surface (translating reshaped attribute names, clarifying NameOrId inputs,
+  trimming API-internal paragraphs, and reconciling any divergence between
+  provider and API default behavior) so the descriptions stay accurate and
+  aligned with the version of the SDK the provider actually calls into.
+---
+
+# Sync Schema Descriptions
+
+## Overview
+
+Terraform schema `Description` / `MarkdownDescription` strings are hand-written
+and drift from the canonical descriptions in the OpenAPI spec. The oxide.go
+SDK, pinned via `go.mod`, has the same descriptions baked into Go doc comments
+on each field. This skill walks through sourcing the right description,
+adapting it, and applying the change.
+
+Not every TF attribute maps 1:1 to a single SDK field (e.g. TF's `boot_disk_id`
+corresponds to the SDK's richer `boot_disk`), so blind copying is wrong. The
+skill codifies the adaptation process rather than automating it blindly.
+
+## Workflow
+
+### 1. Resolve the SDK source
+
+    go list -m -f '{{.Dir}}' github.com/oxidecomputer/oxide.go
+
+Descriptions live in `<dir>/oxide/types.go`. Do not use a local checkout of
+the SDK, which might not match the pinned version.
+
+### 2. Identify scope
+
+The user will usually ask about one attribute (e.g. `instance.ssh_public_keys`),
+a whole resource, or all resources. For each in-scope attribute, work through
+steps 3–8.
+
+### 3. Locate the TF attribute
+
+In `internal/provider/<resource>/resource.go` (or `data_source.go`), find the
+schema block and note the current `Description` / `MarkdownDescription`. Find
+the TF model struct field via its `tfsdk:"<attr_name>"` tag.
+
+Do not touch schema-version-compat files (`resource_v0.go`, `resource_v1.go`,
+…). They represent frozen prior schemas kept for state upgrades; descriptions
+there are not rendered to current docs, so the files should stay as they
+were when that version shipped.
+
+### 4. Find the matching SDK field
+
+**Input attributes (set in Create/Update):** grep the Create method for the
+model field. You'll see a line like `params.Body.SshPublicKeys = ...`. The SDK
+struct is the type of `params.Body` (e.g. `oxide.InstanceCreate`); the SDK
+field is the LHS accessor.
+
+**Computed/output attributes (populated in Read):** grep the Read method for
+how `state.<Field>` is set from the API response — e.g.
+`state.TimeCreated = types.StringValue(resp.TimeCreated.String())`. The SDK
+struct is the response type (e.g. `oxide.Instance`), the field is the `resp.<X>`
+accessor.
+
+If the TF attribute has no clean 1:1 SDK counterpart (flattened, split, or
+composed from multiple API fields), stop and surface this to the user — it
+needs a hand-written description, not an adaptation.
+
+### 5. Read the SDK doc comment
+
+Open `<sdk_dir>/oxide/types.go`, find `type <StructName> struct`, and read the
+Go doc comment on the field. Comments are hard-wrapped; reflow them into a
+single logical description.
+
+Also note the field's Go type — it drives adaptation rule (b) below.
+
+### 6. Adapt
+
+**The default is verbatim.** Copy the SDK doc comment's prose into the TF
+description word-for-word. Do not insert em dashes, merge sentences,
+paraphrase verbs, or restructure for flow. The value of sourcing from the SDK
+is fidelity to a single maintained source of truth; editorial drift
+reintroduces exactly the hand-written divergence the skill is meant to
+eliminate.
+
+Only deviate when one of the rules below applies, and only to the extent the
+rule requires. If you aren't sure whether a change is required, keep the
+source wording and ask the operator.
+
+**Do not invent text from sibling attributes.** If the SDK has no usable
+description for a given TF attribute (e.g. the SDK doc comment is a
+tautology like "X is a variant of Y", or the corresponding SDK type/field is
+internal wrapping with no prose), the skill's job is done — the attribute
+needs a hand-written description, which is outside this skill's scope.
+Surface the gap to the operator. Never copy text from a TF sibling
+(`v4` → `v6`, `ephemeral` → `floating`, etc.) and pass it off as adapted; it
+is still hand-written, just plagiarized.
+
+**a. Translate field-name references.** If the comment references an API field
+name that differs in TF (e.g. "set the `boot_disk` attribute"), rewrite it to
+the TF name (`boot_disk_id`). Same for any other cross-referenced field.
+
+**b. `NameOrId` phrasing.** The API accepts both names and IDs for
+`NameOrId` / `[]NameOrId` inputs. The right phrasing depends on what the TF
+attribute represents:
+
+- If the attribute is the resource's own `name` (typically a required
+  top-level attribute on a resource or data source), it stores the name.
+  Describe as "Name of …".
+- If the attribute is a reference to another resource (e.g. `vpc_id`,
+  `disk_attachments`, `boot_disk_id`), the provider writes the resolved ID
+  back into state on Read, so a user who supplies a name will see a
+  perpetual diff (or recreate) on the next plan. Until the provider
+  preserves the user-supplied form, keep descriptions honest: say "ID of
+  …" / "IDs of …" regardless of whether the SDK field type is `string` or
+  `NameOrId`. If the source SDK comment says "name or ID", rewrite to "ID".
+
+**c. Trim non-user-facing paragraphs.** Drop:
+- internal API behavior the TF user can't observe
+- roadmap/hedging language ("currently, …", "in the future, …")
+- information already encoded by the TF schema (e.g. defaults — TF renders
+  those separately)
+
+Keep paragraphs describing user-visible behavior: accepted value forms,
+interactions with other attributes. Paragraphs about omission/defaults need
+verification first — see rule (e).
+
+**d. Preserve TF-specific additions.** If the current TF description contains
+information that isn't in the SDK (e.g. cross-refs to other TF attrs, validator
+behavior), keep it — it usually reflects provider logic that doesn't exist at
+the API level.
+
+**e. Provider defaults may diverge from API defaults.** Any SDK phrase like
+"if not provided, …", "if null, …", or "defaults to …" describes what the
+_API_ does when the field is absent from the request — but the provider may
+not actually omit the field. Helpers like `shared.NewNameOrIdList` return
+`[]T{}` (never nil), and whether that serializes as `[]` or gets dropped
+depends on the SDK struct's JSON tag (`omitempty` / `omitzero` vs. bare). An
+empty list reaching the API is semantically different from an absent field.
+
+If the SDK description includes a default-behavior clause, decide how to
+handle it:
+
+- **Inspect the code.** Trace the provider's Create/Update path for the field
+  and confirm whether a null TF value produces an omitted request field or a
+  zero-value one. If the provider's behavior matches the SDK clause, keep it;
+  if it doesn't, rewrite to describe what the provider actually does.
+- **Ask the operator.** If the behavior isn't clear from the code, or if the
+  mismatch looks like a provider bug worth fixing separately, surface it.
+- **Omit the clause.** When in doubt, drop the default-behavior sentence
+  entirely rather than risk a misleading description.
+
+**f. Add undocumented TF-specific constraints.** Rule (d) is about keeping
+what's already in the current description; this rule is about adding what's
+missing. If the schema has validators or plan modifiers whose effect isn't
+mentioned in the current description, fold a short clause in — the
+framework's auto-generated docs don't surface these. Examples:
+
+- `stringvalidator.LengthBetween(1, 63)` → "Must be 1–63 characters."
+- `stringvalidator.RegexMatches(pattern, "…")` → reuse the validator's
+  message, or describe the pattern.
+- `stringvalidator.OneOf("a", "b", "c")` → "Must be one of `a`, `b`, `c`."
+
+Skip constraints the framework already renders (`Required` / `Optional` /
+`Computed` flags, `Default` values — same reasoning as rule (c)).
+
+### 7. Apply, then hand off for review
+
+Apply all proposed changes with `Edit` to the current `resource.go` /
+`data_source.go` only (never `resource_v*.go`). Run `make fmt` to regenerate
+`docs/resources/*.md` and `docs/data-sources/*.md`, then `make lint` to verify.
+
+Report what was changed in a short summary and tell the operator to review via
+`git diff`. The diff is a better review surface for multi-attribute text
+changes than an in-chat bulleted list.
+
+### 8. Show the provenance table
+
+At the end of the pass, emit a table with one row per touched attribute:
+
+| Attribute | SDK source (field, verbatim) | Provider description (as applied) |
+
+For each row:
+- **SDK source**: the type + field (e.g. `InstanceCreate.Memory`) and the
+  doc-comment prose as it appears in `oxide/types.go`, unedited. For rule (f)
+  additions, use "(none — rule f)" and name the validator.
+- **Provider description**: the final string now in the schema, so the
+  operator can see the adaptation deltas inline without chasing through
+  `git diff` and the SDK side-by-side.
+
+One row per attribute updated — skip attributes left untouched.
+
+Exceptions — pause and surface to the operator **before** editing rather than
+after:
+- Step 4 found no clean 1:1 SDK counterpart (reshaped, split, or composed
+  attribute) — the description needs to be hand-written, not adapted.
+- Rule (e) flagged a behavior-claim mismatch that implies a provider fix is
+  needed rather than a description change. Describe the mismatch and ask
+  whether to narrow the description to match current provider behavior or open
+  a separate issue to fix the provider first.
+
+## Notes
+
+- The SDK pins to a specific Omicron release; the descriptions on disk match
+  the API the provider actually calls at runtime. There is no need to fetch
+  the OpenAPI spec directly.
+- When `go.mod` bumps `oxide.go`, upstream descriptions may change. Re-running
+  this skill after an SDK bump is a reasonable drift-detection pass.

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -140,23 +140,23 @@ resource "oxide_instance" "example" {
 
 ### Required
 
-- `description` (String) Description for the instance.
-- `memory` (Number) Instance memory in bytes.
+- `description` (String) Human-readable free-form text about the instance.
+- `memory` (Number) The amount of RAM (in bytes) to be allocated to the instance.
 - `name` (String) Name of the instance.
-- `ncpus` (Number) Number of CPUs allocated for this instance.
-- `project_id` (String) ID of the project that will contain the instance.
+- `ncpus` (Number) The number of vCPUs to be allocated to the instance.
+- `project_id` (String) ID for the project containing this instance.
 
 ### Optional
 
-- `anti_affinity_groups` (Set of String) IDs of the anti-affinity groups this instance should belong to.
-- `auto_restart_policy` (String) The auto-restart policy for this instance.
-- `boot_disk_id` (String) ID of the disk the instance should be booted from. When provided, this ID must also be present in `disk_attachments`.
-- `disk_attachments` (Set of String) IDs of the disks to be attached to the instance. When multiple disk IDs are provided, set `boot_disk_id` to specify the boot disk for the instance. Otherwise, a boot disk will be chosen randomly.
-- `external_ips` (Attributes) External IP addresses provided to this instance. (see [below for nested schema](#nestedatt--external_ips))
-- `hostname` (String) Hostname of the instance.
-- `network_interfaces` (Attributes Set) Network interface devices attached to the instance. (see [below for nested schema](#nestedatt--network_interfaces))
-- `ssh_public_keys` (Set of String) An allowlist of IDs of the SSH public keys to be transferred to the instance via cloud-init during instance creation.
-- `start_on_create` (Boolean) Whether to start the instance on creation.
+- `anti_affinity_groups` (Set of String) IDs of the anti-affinity groups to which this instance should be added.
+- `auto_restart_policy` (String) The auto-restart policy for this instance. This policy determines whether the instance should be automatically restarted by the control plane on failure. Must be one of `best_effort` or `never`.
+- `boot_disk_id` (String) ID of the disk the instance should be booted from. Specifying a boot disk is optional but recommended to ensure predictable boot behavior. When provided, this ID must also be present in `disk_attachments`.
+- `disk_attachments` (Set of String) IDs of the disks to be attached to the instance. The order of this list does not guarantee a boot order for the instance.
+- `external_ips` (Attributes) External IP addresses provided to this instance. By default, all instances have outbound connectivity, but no inbound connectivity. These external addresses can be used to provide a fixed, known IP address for making inbound connections to the instance. (see [below for nested schema](#nestedatt--external_ips))
+- `hostname` (String) RFC1035-compliant hostname for the instance.
+- `network_interfaces` (Attributes Set) The network interfaces to be created for this instance. (see [below for nested schema](#nestedatt--network_interfaces))
+- `ssh_public_keys` (Set of String) An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation. If an empty list is provided, no public keys will be transmitted to the instance.
+- `start_on_create` (Boolean) Whether to start this instance upon creation.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user_data` (String) User data for instance initialization systems (such as cloud-init).
 Must be a Base64-encoded string, as specified in [RFC 4648 § 4](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
@@ -182,7 +182,7 @@ Optional:
 
 Optional:
 
-- `ip_version` (String) IP version to use when multiple default pools exist. Conflicts with `pool_id`.
+- `ip_version` (String) IP version to use when multiple default pools exist. Must be one of `v4` or `v6`. Conflicts with `pool_id`.
 - `pool_id` (String) ID of the IP pool to allocate from. Conflicts with `ip_version`.
 
 
@@ -201,7 +201,7 @@ Required:
 Required:
 
 - `description` (String) Description for the instance network interface.
-- `ip_config` (Attributes) IP stack to create for the instance network interface. (see [below for nested schema](#nestedatt--network_interfaces--ip_config))
+- `ip_config` (Attributes) The IP stack configuration for this interface. (see [below for nested schema](#nestedatt--network_interfaces--ip_config))
 - `name` (String) Name of the instance network interface.
 - `subnet_id` (String) ID of the VPC subnet in which to create the instance network interface.
 - `vpc_id` (String) ID of the VPC in which to create the instance network interface.
@@ -211,8 +211,8 @@ Required:
 
 Optional:
 
-- `v4` (Attributes) Creates an IPv4 stack for the instance network interface. (see [below for nested schema](#nestedatt--network_interfaces--ip_config--v4))
-- `v6` (Attributes) (see [below for nested schema](#nestedatt--network_interfaces--ip_config--v6))
+- `v4` (Attributes) Configuration for the instance network interface's IPv4 addressing. (see [below for nested schema](#nestedatt--network_interfaces--ip_config--v4))
+- `v6` (Attributes) Configuration for the instance network interface's IPv6 addressing. (see [below for nested schema](#nestedatt--network_interfaces--ip_config--v6))
 
 <a id="nestedatt--network_interfaces--ip_config--v4"></a>
 ### Nested Schema for `network_interfaces.ip_config.v4`
@@ -250,30 +250,30 @@ Read-Only:
 
 - `description` (String) Description of the instance network interface.
 - `id` (String) Unique, immutable, system-controlled identifier of the instance network interface.
-- `instance_id` (String) Instance ID of the network interface.
-- `ip_stack` (Attributes) IP stack of the instance network interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack))
-- `mac_address` (String) MAC address of the instance network interface.
+- `instance_id` (String) ID of the instance to which the network interface belongs.
+- `ip_stack` (Attributes) The VPC-private IP stack for this interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack))
+- `mac_address` (String) MAC address assigned to the instance network interface.
 - `name` (String) Name of the instance network interface.
-- `primary` (Boolean) True if this is the primary network interface for the instance to which it's attached to.
-- `subnet_id` (String) VPC subnet ID of the instance network interface.
+- `primary` (Boolean) True if this interface is the primary for the instance to which it's attached.
+- `subnet_id` (String) ID of the VPC subnet to which the instance network interface belongs.
 - `time_created` (String) Timestamp of when this instance network interface was created.
 - `time_modified` (String) Timestamp of when this instance network interface was last modified.
-- `vpc_id` (String) VPC ID of the instance network interface.
+- `vpc_id` (String) ID of the VPC to which the instance network interface belongs.
 
 <a id="nestedatt--attached_network_interfaces--ip_stack"></a>
 ### Nested Schema for `attached_network_interfaces.ip_stack`
 
 Read-Only:
 
-- `v4` (Attributes) IPv4 stack of the instance network interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack--v4))
-- `v6` (Attributes) IPv6 stack of the instance network interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack--v6))
+- `v4` (Attributes) VPC-private IPv4 stack for the instance network interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack--v4))
+- `v6` (Attributes) VPC-private IPv6 stack for the instance network interface. (see [below for nested schema](#nestedatt--attached_network_interfaces--ip_stack--v6))
 
 <a id="nestedatt--attached_network_interfaces--ip_stack--v4"></a>
 ### Nested Schema for `attached_network_interfaces.ip_stack.v4`
 
 Read-Only:
 
-- `ip` (String) IPv4 address of the instance network interface.
+- `ip` (String) VPC-private IPv4 address for the instance network interface.
 
 
 <a id="nestedatt--attached_network_interfaces--ip_stack--v6"></a>
@@ -281,7 +281,7 @@ Read-Only:
 
 Read-Only:
 
-- `ip` (String) IPv6 address of the instance network interface.
+- `ip` (String) VPC-private IPv6 address for the instance network interface.
 
 ## Import
 

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -239,7 +239,7 @@ This resource manages instances.
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Required:    true,
-				Description: "ID of the project that will contain the instance.",
+				Description: "ID for the project containing this instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -253,7 +253,7 @@ This resource manages instances.
 			},
 			"description": schema.StringAttribute{
 				Required:    true,
-				Description: "Description for the instance.",
+				Description: "Human-readable free-form text about the instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -261,7 +261,7 @@ This resource manages instances.
 			"hostname": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Hostname of the instance.",
+				Description: "RFC1035-compliant hostname for the instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIf(
 						ModifyPlanForHostnameDeprecation, "", "",
@@ -270,15 +270,15 @@ This resource manages instances.
 			},
 			"memory": schema.Int64Attribute{
 				Required:    true,
-				Description: "Instance memory in bytes.",
+				Description: "The amount of RAM (in bytes) to be allocated to the instance.",
 			},
 			"ncpus": schema.Int64Attribute{
 				Required:    true,
-				Description: "Number of CPUs allocated for this instance.",
+				Description: "The number of vCPUs to be allocated to the instance.",
 			},
 			"auto_restart_policy": schema.StringAttribute{
-				Optional:    true,
-				Description: "The auto-restart policy for this instance.",
+				Optional:            true,
+				MarkdownDescription: "The auto-restart policy for this instance. This policy determines whether the instance should be automatically restarted by the control plane on failure. Must be one of `best_effort` or `never`.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						string(oxide.InstanceAutoRestartPolicyBestEffort),
@@ -288,12 +288,12 @@ This resource manages instances.
 			},
 			"anti_affinity_groups": schema.SetAttribute{
 				Optional:    true,
-				Description: "IDs of the anti-affinity groups this instance should belong to.",
+				Description: "IDs of the anti-affinity groups to which this instance should be added.",
 				ElementType: types.StringType,
 			},
 			"boot_disk_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "ID of the disk the instance should be booted from. When provided, this ID must also be present in `disk_attachments`.",
+				MarkdownDescription: "ID of the disk the instance should be booted from. Specifying a boot disk is optional but recommended to ensure predictable boot behavior. When provided, this ID must also be present in `disk_attachments`.",
 				Validators: []validator.String{
 					stringvalidator.AlsoRequires(
 						path.MatchRoot("disk_attachments"),
@@ -304,19 +304,19 @@ This resource manages instances.
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
-				Description: "Whether to start the instance on creation.",
+				Description: "Whether to start this instance upon creation.",
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"disk_attachments": schema.SetAttribute{
 				Optional:            true,
-				MarkdownDescription: "IDs of the disks to be attached to the instance. When multiple disk IDs are provided, set `boot_disk_id` to specify the boot disk for the instance. Otherwise, a boot disk will be chosen randomly.",
+				MarkdownDescription: "IDs of the disks to be attached to the instance. The order of this list does not guarantee a boot order for the instance.",
 				ElementType:         types.StringType,
 			},
 			"ssh_public_keys": schema.SetAttribute{
 				Optional:    true,
-				Description: "An allowlist of IDs of the SSH public keys to be transferred to the instance via cloud-init during instance creation.",
+				Description: "An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation. If an empty list is provided, no public keys will be transmitted to the instance.",
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.RequiresReplace(),
@@ -334,7 +334,7 @@ This resource manages instances.
 			// instanceNetworkInterfacesPlanModifier.PlanModifySet().
 			"network_interfaces": schema.SetNestedAttribute{
 				Optional:    true,
-				Description: "Network interface devices attached to the instance.",
+				Description: "The network interfaces to be created for this instance.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -377,14 +377,14 @@ This resource manages instances.
 						},
 						"ip_config": schema.SingleNestedAttribute{
 							Required:    true,
-							Description: "IP stack to create for the instance network interface.",
+							Description: "The IP stack configuration for this interface.",
 							Validators: []validator.Object{
 								instanceIPConfigValidator{},
 							},
 							Attributes: map[string]schema.Attribute{
 								"v4": schema.SingleNestedAttribute{
 									Optional:    true,
-									Description: "Creates an IPv4 stack for the instance network interface.",
+									Description: "Configuration for the instance network interface's IPv4 addressing.",
 									Attributes: map[string]schema.Attribute{
 										"ip": schema.StringAttribute{
 											Required: true,
@@ -396,7 +396,8 @@ This resource manages instances.
 									},
 								},
 								"v6": schema.SingleNestedAttribute{
-									Optional: true,
+									Optional:    true,
+									Description: "Configuration for the instance network interface's IPv6 addressing.",
 									Attributes: map[string]schema.Attribute{
 										"ip": schema.StringAttribute{
 											Required: true,
@@ -431,45 +432,45 @@ This resource manages instances.
 						},
 						"subnet_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "VPC subnet ID of the instance network interface.",
+							Description: "ID of the VPC subnet to which the instance network interface belongs.",
 						},
 						"vpc_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "VPC ID of the instance network interface.",
+							Description: "ID of the VPC to which the instance network interface belongs.",
 						},
 						"instance_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "Instance ID of the network interface.",
+							Description: "ID of the instance to which the network interface belongs.",
 						},
 						"primary": schema.BoolAttribute{
 							Computed:    true,
-							Description: "True if this is the primary network interface for the instance to which it's attached to.",
+							Description: "True if this interface is the primary for the instance to which it's attached.",
 						},
 						"mac_address": schema.StringAttribute{
 							Computed:    true,
-							Description: "MAC address of the instance network interface.",
+							Description: "MAC address assigned to the instance network interface.",
 						},
 						"ip_stack": schema.SingleNestedAttribute{
 							Computed:    true,
-							Description: "IP stack of the instance network interface.",
+							Description: "The VPC-private IP stack for this interface.",
 							Attributes: map[string]schema.Attribute{
 								"v4": schema.SingleNestedAttribute{
 									Computed:    true,
-									Description: "IPv4 stack of the instance network interface.",
+									Description: "VPC-private IPv4 stack for the instance network interface.",
 									Attributes: map[string]schema.Attribute{
 										"ip": schema.StringAttribute{
 											Computed:    true,
-											Description: "IPv4 address of the instance network interface.",
+											Description: "VPC-private IPv4 address for the instance network interface.",
 										},
 									},
 								},
 								"v6": schema.SingleNestedAttribute{
 									Computed:    true,
-									Description: "IPv6 stack of the instance network interface.",
+									Description: "VPC-private IPv6 stack for the instance network interface.",
 									Attributes: map[string]schema.Attribute{
 										"ip": schema.StringAttribute{
 											Computed:    true,
-											Description: "IPv6 address of the instance network interface.",
+											Description: "VPC-private IPv6 address for the instance network interface.",
 										},
 									},
 								},
@@ -488,7 +489,7 @@ This resource manages instances.
 			},
 			"external_ips": schema.SingleNestedAttribute{
 				Optional:    true,
-				Description: "External IP addresses provided to this instance.",
+				Description: "External IP addresses provided to this instance. By default, all instances have outbound connectivity, but no inbound connectivity. These external addresses can be used to provide a fixed, known IP address for making inbound connections to the instance.",
 				Validators: []validator.Object{
 					instanceExternalIPValidator{},
 					objectvalidator.AlsoRequires(path.MatchRoot("network_interfaces")),
@@ -515,7 +516,7 @@ This resource manages instances.
 								"ip_version": schema.StringAttribute{
 									Optional:            true,
 									Computed:            true,
-									MarkdownDescription: "IP version to use when multiple default pools exist. Conflicts with `pool_id`.",
+									MarkdownDescription: "IP version to use when multiple default pools exist. Must be one of `v4` or `v6`. Conflicts with `pool_id`.",
 									Validators: []validator.String{
 										stringvalidator.ConflictsWith(
 											path.MatchRelative().AtParent().AtName("pool_id"),


### PR DESCRIPTION
Our resource attribute descriptions are generally very similar to the corresponding field descriptions in openapi. Sometimes, these descriptions diverge over time. This patch reconciles attribute descriptions for the instance resource, and adds a skill to reconcile descriptions in the future. We propose this as a skill for an agent rather than a deterministic program because descriptions *should* diverge between provider and openapi when behavior differs, or when we can't map provider to openapi 1:1.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
