### PR TITLE
Load `silo_saml_identity_provider` resource into state if it already exists

### DIFF
--- a/.changelog/0.20.0.toml
+++ b/.changelog/0.20.0.toml
@@ -1,0 +1,3 @@
+[[enhancements]]
+title = "support adoption for the silo_saml_identity_provider"
+description = "the silo_saml_identity_provider (create-only resource) can now be removed from tf state and added back without issue [#766](https://github.com/oxidecomputer/terraform-provider-oxide/pull/766)."

--- a/.changelog/0.20.0.toml
+++ b/.changelog/0.20.0.toml
@@ -1,3 +1,3 @@
 [[enhancements]]
-title = "support adoption for the silo_saml_identity_provider"
+title = "Load `silo_saml_identity_provider` resource into state if it already exists"
 description = "the silo_saml_identity_provider (create-only resource) can now be removed from tf state and added back without issue [#766](https://github.com/oxidecomputer/terraform-provider-oxide/pull/766)."

--- a/.changelog/0.20.0.toml
+++ b/.changelog/0.20.0.toml
@@ -1,3 +1,3 @@
 [[enhancements]]
 title = "Load `silo_saml_identity_provider` resource into state if it already exists"
-description = "the silo_saml_identity_provider (create-only resource) can now be removed from tf state and added back without issue [#766](https://github.com/oxidecomputer/terraform-provider-oxide/pull/766)."
+description = "The `silo_saml_identity_provider` (create-only resource) can now be removed from state and added back without issue [#766](https://github.com/oxidecomputer/terraform-provider-oxide/pull/766)."

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/oxidecomputer/oxide.go v0.9.0
+	github.com/oxidecomputer/oxide.go v0.9.1-0.20260511232442-93d8204aae4d
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/oxidecomputer/oxide.go v0.9.0 h1:BwwRLsXomk43q+qQLWgksu8FhJJMftp85XQT5CDDCuw=
-github.com/oxidecomputer/oxide.go v0.9.0/go.mod h1:I36KqKtLBuKdi9HeXRwP2FHc7s98+HvYgFozvfyKnpE=
+github.com/oxidecomputer/oxide.go v0.9.1-0.20260511232442-93d8204aae4d h1:d3lF516b5QzBkxmK1iMQwDsSmoHVDAqmMNkvkvCfmsU=
+github.com/oxidecomputer/oxide.go v0.9.1-0.20260511232442-93d8204aae4d/go.mod h1:6KXHuYsXMOR1DS3uRE+wI6DPVQnS16tEDkj8miqXQcY=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/sharedtest/sharedtest.go
+++ b/internal/provider/sharedtest/sharedtest.go
@@ -61,12 +61,13 @@ func ParsedAccConfig(
 	tpl string,
 ) (string, error) {
 	var buf bytes.Buffer
-	tmpl, _ := template.New("test").Parse(tpl)
-	err := tmpl.Execute(&buf, config)
+	tmpl, err := template.New("test").Parse(tpl)
 	if err != nil {
 		return "", err
 	}
-
+	if err := tmpl.Execute(&buf, config); err != nil {
+		return "", err
+	}
 	return buf.String(), nil
 }
 

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -391,7 +391,8 @@ func (r *Resource) Read(
 	)
 
 	// GroupAttributeName is Optional so we need to handle the case where it is not set in the
-	// remote Oxide control plane and take whatever value the configuration has (Null or empty string)
+	// remote Oxide control plane and take whatever value the configuration has (Null or empty
+	// string)
 	if idpConfig.GroupAttributeName != "" {
 		state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
 	}
@@ -469,13 +470,21 @@ func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics
 	}{
 		{path.Root("acs_url"), m.AcsUrl.ValueString(), remote.AcsUrl},
 		{path.Root("description"), m.Description.ValueString(), remote.Description},
-		{path.Root("group_attribute_name"), m.GroupAttributeName.ValueString(), remote.GroupAttributeName},
+		{
+			path.Root("group_attribute_name"),
+			m.GroupAttributeName.ValueString(),
+			remote.GroupAttributeName,
+		},
 		{path.Root("idp_entity_id"), m.IdpEntityId.ValueString(), remote.IdpEntityId},
 		{path.Root("name"), m.Name.ValueString(), string(remote.Name)},
 		{path.Root("signing_keypair").AtName("public_cert"), signingPublicCert, remote.PublicCert},
 		{path.Root("slo_url"), m.SloUrl.ValueString(), remote.SloUrl},
 		{path.Root("sp_client_id"), m.SpClientId.ValueString(), remote.SpClientId},
-		{path.Root("technical_contact_email"), m.TechnicalContactEmail.ValueString(), remote.TechnicalContactEmail},
+		{
+			path.Root("technical_contact_email"),
+			m.TechnicalContactEmail.ValueString(),
+			remote.TechnicalContactEmail,
+		},
 	}
 
 	var diagnostics diag.Diagnostics

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -304,37 +304,38 @@ func (r *Resource) Create(
 		// Diff the remote state with the configuration before adopting the resource
 		// If any parameters differ, diagnostics are returned and we should abort to display
 		// errors to the user.
-		diagnostics := plan.Diff(idpConfig)
-		if diagnostics.HasError() {
+		if diagnostics := plan.Diff(idpConfig); diagnostics.HasError() {
 			resp.Diagnostics.Append(diagnostics...)
 			return
 		}
 
 		// group_attribute_name is Optional. Diff treats null and "" as
-		// equivalent, but state must match the canonical representation
-		// Terraform's plan layer uses for an Optional StringAttribute —
-		// otherwise the next refresh-plan reports a phantom drift between
-		// state ("") and config (null). When the remote is empty, force the
-		// plan field to StringNull() regardless of which empty form the user
-		// wrote in config.
+		// equivalent, but state must match between the remote state and configuration.
+		// Otherwise the next refresh-plan reports a phantom drift between
+		// state ("") and config (null). When the remote is empty, take whatever
+		// empty value the configuration has ("" or null).
 		if idpConfig.GroupAttributeName != "" {
 			plan.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
-		} else {
-			plan.GroupAttributeName = types.StringNull()
 		}
+
+		tflog.Trace(
+			ctx,
+			fmt.Sprintf("adopted SAML identity provider with ID: %v", idpConfig.Id),
+			map[string]any{"success": true},
+		)
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating SAML identity provider",
 			"API error: "+err.Error(),
 		)
 		return
+	} else {
+		tflog.Trace(
+			ctx,
+			fmt.Sprintf("created SAML identity provider with ID: %v", idpConfig.Id),
+			map[string]any{"success": true},
+		)
 	}
-
-	tflog.Trace(
-		ctx,
-		fmt.Sprintf("created SAML identity provider with ID: %v", idpConfig.Id),
-		map[string]any{"success": true},
-	)
 
 	plan.ID = types.StringValue(idpConfig.Id)
 	plan.TimeCreated = types.StringValue(idpConfig.TimeCreated.String())
@@ -392,7 +393,7 @@ func (r *Resource) Read(
 
 	// GroupAttributeName is Optional so we need to handle the case where it is not set in the
 	// remote Oxide control plane and take whatever value the configuration has (Null or empty
-	// string)
+	// string). So we only set state with the remote value if the remote value is not empty.
 	if idpConfig.GroupAttributeName != "" {
 		state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
 	}
@@ -461,8 +462,6 @@ func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics
 		signingPublicCert = m.SigningKeypair.PublicCert.ValueString()
 	}
 
-	// group_attribute_name is optional; ValueString() collapses null and ""
-	// so a remote-empty value matches an unset configuration.
 	checks := []struct {
 		path      path.Path
 		configVal string
@@ -470,6 +469,8 @@ func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics
 	}{
 		{path.Root("acs_url"), m.AcsUrl.ValueString(), remote.AcsUrl},
 		{path.Root("description"), m.Description.ValueString(), remote.Description},
+		// group_attribute_name is optional; ValueString() collapses null and ""
+		// so a remote-empty value matches an unset configuration.
 		{
 			path.Root("group_attribute_name"),
 			m.GroupAttributeName.ValueString(),

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -497,8 +497,8 @@ func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics
 			c.path,
 			"Error adopting SAML identity provider",
 			fmt.Sprintf(
-				"%q configuration does not match the state (remote=%q configuration=%q)",
-				c.path, c.remoteVal, c.configVal,
+				"%q value does not match remote value %q.\nUpdate your configuration file to ensure this resource matches your SAML IdP configuration.",
+				c.path, c.remoteVal,
 			),
 		)
 	}

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -280,6 +281,11 @@ func (r *Resource) Create(
 	idpConfig, err := r.client.SamlIdentityProviderCreate(ctx, params)
 	// if the IDP already exists, then try to adopt it
 	if errors.Is(err, oxide.ErrObjectAlreadyExists) {
+		// Read the remote state from the Oxide Control Plane.
+		// The response does not include all parameters from the Create.
+		// The idp_metadata_source and the signing_keypair.private_key attributes are not returned
+		// from the API on a read. In those cases, the plan includes the user-provided values from
+		// the configuration.
 		idpConfig, err = r.client.SamlIdentityProviderView(
 			ctx,
 			oxide.SamlIdentityProviderViewParams{
@@ -295,38 +301,27 @@ func (r *Resource) Create(
 			return
 		}
 
-		// The idp_metadata_source and the signing_keypair.private_key attributes are not returned
-		// from the API on a read. In those cases, the plan includes the user-provided values from
-		// the configuration.
-		plan.AcsUrl = types.StringValue(idpConfig.AcsUrl)
-		plan.Description = types.StringValue(idpConfig.Description)
-		// When the server returns a non-empty group_attribute_name, use it. Otherwise the
-		// configuration must agree (null or empty string); a configured non-empty value is a
-		// mismatch we can't reconcile since the resource is immutable.
+		// Diff the remote state with the configuration before adopting the resource
+		// If any parameters differ, diagnostics are returned and we should abort to display
+		// errors to the user.
+		diagnostics := plan.Diff(idpConfig)
+		if diagnostics.HasError() {
+			resp.Diagnostics.Append(diagnostics...)
+			return
+		}
+
+		// group_attribute_name is Optional. Diff treats null and "" as
+		// equivalent, but state must match the canonical representation
+		// Terraform's plan layer uses for an Optional StringAttribute —
+		// otherwise the next refresh-plan reports a phantom drift between
+		// state ("") and config (null). When the remote is empty, force the
+		// plan field to StringNull() regardless of which empty form the user
+		// wrote in config.
 		if idpConfig.GroupAttributeName != "" {
 			plan.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
-		} else if plan.GroupAttributeName.ValueString() != "" {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("group_attribute_name"),
-				"Error adopting SAML identity provider",
-				fmt.Sprintf(
-					"group_attribute_name configuration does not match the state (server=%q configuration=%q)",
-					idpConfig.GroupAttributeName,
-					plan.GroupAttributeName.ValueString(),
-				),
-			)
-			return
 		} else {
 			plan.GroupAttributeName = types.StringNull()
 		}
-		plan.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
-		plan.Name = types.StringValue(string(idpConfig.Name))
-		if plan.SigningKeypair != nil {
-			plan.SigningKeypair.PublicCert = types.StringValue(idpConfig.PublicCert)
-		}
-		plan.SloUrl = types.StringValue(idpConfig.SloUrl)
-		plan.SpClientId = types.StringValue(idpConfig.SpClientId)
-		plan.TechnicalContactEmail = types.StringValue(idpConfig.TechnicalContactEmail)
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating SAML identity provider",
@@ -395,14 +390,17 @@ func (r *Resource) Read(
 		map[string]any{"success": true},
 	)
 
+	// GroupAttributeName is Optional so we need to handle the case where it is not set in the
+	// remote Oxide control plane and take whatever value the configuration has (Null or empty string)
+	if idpConfig.GroupAttributeName != "" {
+		state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+	}
+
 	state.ID = types.StringValue(idpConfig.Id)
 	state.TimeCreated = types.StringValue(idpConfig.TimeCreated.String())
 	state.TimeModified = types.StringValue(idpConfig.TimeModified.String())
 	state.AcsUrl = types.StringValue(idpConfig.AcsUrl)
 	state.Description = types.StringValue(idpConfig.Description)
-	if idpConfig.GroupAttributeName != "" {
-		state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
-	}
 	state.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
 	state.Name = types.StringValue(string(idpConfig.Name))
 	state.SloUrl = types.StringValue(idpConfig.SloUrl)
@@ -447,4 +445,52 @@ func (r *Resource) Delete(
 		"This resource represents immutable silo SAML identity provider configuration. The resource will be removed from Terraform state but not from Oxide. "+
 			"You can add the resource to your Terraform configuration later by matching the resource attributes from Oxide.",
 	)
+}
+
+// Diff returns diagnostics for any attributes that differ between the
+// configuration (m) and the remote IdP state. It only compares
+// attributes the Oxide API returns on read; idp_metadata_source and
+// signing_keypair.private_key are not returned and therefore cannot be diffed.
+func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics {
+	// signing_keypair is optional; when the block is absent, treat the
+	// public_cert as the empty string so the comparison flags a mismatch
+	// when the remote IdP has a cert configured.
+	var signingPublicCert string
+	if m.SigningKeypair != nil {
+		signingPublicCert = m.SigningKeypair.PublicCert.ValueString()
+	}
+
+	// group_attribute_name is optional; ValueString() collapses null and ""
+	// so a remote-empty value matches an unset configuration.
+	checks := []struct {
+		path      path.Path
+		configVal string
+		remoteVal string
+	}{
+		{path.Root("acs_url"), m.AcsUrl.ValueString(), remote.AcsUrl},
+		{path.Root("description"), m.Description.ValueString(), remote.Description},
+		{path.Root("group_attribute_name"), m.GroupAttributeName.ValueString(), remote.GroupAttributeName},
+		{path.Root("idp_entity_id"), m.IdpEntityId.ValueString(), remote.IdpEntityId},
+		{path.Root("name"), m.Name.ValueString(), string(remote.Name)},
+		{path.Root("signing_keypair").AtName("public_cert"), signingPublicCert, remote.PublicCert},
+		{path.Root("slo_url"), m.SloUrl.ValueString(), remote.SloUrl},
+		{path.Root("sp_client_id"), m.SpClientId.ValueString(), remote.SpClientId},
+		{path.Root("technical_contact_email"), m.TechnicalContactEmail.ValueString(), remote.TechnicalContactEmail},
+	}
+
+	var diagnostics diag.Diagnostics
+	for _, c := range checks {
+		if c.configVal == c.remoteVal {
+			continue
+		}
+		diagnostics.AddAttributeError(
+			c.path,
+			"Error adopting SAML identity provider",
+			fmt.Sprintf(
+				"%q configuration does not match the state (remote=%q configuration=%q)",
+				c.path, c.remoteVal, c.configVal,
+			),
+		)
+	}
+	return diagnostics
 }

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -280,24 +280,41 @@ func (r *Resource) Create(
 	idpConfig, err := r.client.SamlIdentityProviderCreate(ctx, params)
 	// if the IDP already exists, then try to adopt it
 	if errors.Is(err, oxide.ErrObjectAlreadyExists) {
-		var viewErr error
-		idpConfig, viewErr = r.client.SamlIdentityProviderView(
+		idpConfig, err = r.client.SamlIdentityProviderView(
 			ctx,
 			oxide.SamlIdentityProviderViewParams{
 				Silo:     oxide.NameOrId(plan.Silo.ValueString()),
 				Provider: oxide.NameOrId(plan.Name.ValueString()),
 			},
 		)
-		if viewErr != nil {
+		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error adopting SAML identity provider",
-				fmt.Sprintf("Create API error: %s, View API error: %s", err, viewErr),
+				fmt.Sprintf("View API error: %s", err),
 			)
 			return
 		}
+
+		// The idp_metadata_source and the signing_keypair.private_key attributes are not returned
+		// from the API on a read. In those cases, the plan includes the user-provided values from
+		// the configuration.
 		plan.AcsUrl = types.StringValue(idpConfig.AcsUrl)
 		plan.Description = types.StringValue(idpConfig.Description)
-		plan.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+		// When the server returns a non-empty group_attribute_name, use it. Otherwise the
+		// configuration must agree (null or empty string); a configured non-empty value is a
+		// mismatch we can't reconcile since the resource is immutable.
+		if idpConfig.GroupAttributeName != "" {
+			plan.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+		} else if plan.GroupAttributeName.ValueString() != "" {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("group_attribute_name"),
+				"Error adopting SAML identity provider",
+				fmt.Sprintf("group_attribute_name configuration does not match the state (server=%q configuration=%q)", idpConfig.GroupAttributeName, plan.GroupAttributeName.ValueString()),
+			)
+			return
+		} else {
+			plan.GroupAttributeName = types.StringNull()
+		}
 		plan.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
 		plan.Name = types.StringValue(string(idpConfig.Name))
 		if plan.SigningKeypair != nil {
@@ -379,7 +396,9 @@ func (r *Resource) Read(
 	state.TimeModified = types.StringValue(idpConfig.TimeModified.String())
 	state.AcsUrl = types.StringValue(idpConfig.AcsUrl)
 	state.Description = types.StringValue(idpConfig.Description)
-	state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+	if idpConfig.GroupAttributeName != "" {
+		state.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+	}
 	state.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
 	state.Name = types.StringValue(string(idpConfig.Name))
 	state.SloUrl = types.StringValue(idpConfig.SloUrl)
@@ -421,6 +440,7 @@ func (r *Resource) Delete(
 ) {
 	resp.Diagnostics.AddWarning(
 		"The oxide_silo_saml_identity_provider resource does not support deletion.",
-		"This resource represents immutable silo SAML identity provider configuration. The resource will be removed from Terraform state but not from Oxide.",
+		"This resource represents immutable silo SAML identity provider configuration. The resource will be removed from Terraform state but not from Oxide. "+
+			"You can add the resource to your Terraform configuration later by matching the resource attributes from Oxide.",
 	)
 }

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -309,7 +309,11 @@ func (r *Resource) Create(
 			resp.Diagnostics.AddAttributeError(
 				path.Root("group_attribute_name"),
 				"Error adopting SAML identity provider",
-				fmt.Sprintf("group_attribute_name configuration does not match the state (server=%q configuration=%q)", idpConfig.GroupAttributeName, plan.GroupAttributeName.ValueString()),
+				fmt.Sprintf(
+					"group_attribute_name configuration does not match the state (server=%q configuration=%q)",
+					idpConfig.GroupAttributeName,
+					plan.GroupAttributeName.ValueString(),
+				),
 			)
 			return
 		} else {

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -498,7 +498,8 @@ func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics
 			"Error adopting SAML identity provider",
 			fmt.Sprintf(
 				"%q value does not match remote value %q.\nUpdate your configuration file to ensure this resource matches your SAML IdP configuration.",
-				c.path, c.remoteVal,
+				c.path,
+				c.remoteVal,
 			),
 		)
 	}

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -6,6 +6,7 @@ package silosamlidp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -277,7 +278,35 @@ func (r *Resource) Create(
 	}
 
 	idpConfig, err := r.client.SamlIdentityProviderCreate(ctx, params)
-	if err != nil {
+	// if the IDP already exists, then try to adopt it
+	if errors.Is(err, oxide.ErrObjectAlreadyExists) {
+		var viewErr error
+		idpConfig, viewErr = r.client.SamlIdentityProviderView(
+			ctx,
+			oxide.SamlIdentityProviderViewParams{
+				Silo:     oxide.NameOrId(plan.Silo.ValueString()),
+				Provider: oxide.NameOrId(plan.Name.ValueString()),
+			},
+		)
+		if viewErr != nil {
+			resp.Diagnostics.AddError(
+				"Error adopting SAML identity provider",
+				fmt.Sprintf("Create API error: %s, View API error: %s", err, viewErr),
+			)
+			return
+		}
+		plan.AcsUrl = types.StringValue(idpConfig.AcsUrl)
+		plan.Description = types.StringValue(idpConfig.Description)
+		plan.GroupAttributeName = types.StringValue(idpConfig.GroupAttributeName)
+		plan.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
+		plan.Name = types.StringValue(string(idpConfig.Name))
+		if plan.SigningKeypair != nil {
+			plan.SigningKeypair.PublicCert = types.StringValue(idpConfig.PublicCert)
+		}
+		plan.SloUrl = types.StringValue(idpConfig.SloUrl)
+		plan.SpClientId = types.StringValue(idpConfig.SpClientId)
+		plan.TechnicalContactEmail = types.StringValue(idpConfig.TechnicalContactEmail)
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating SAML identity provider",
 			"API error: "+err.Error(),

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -29,6 +29,7 @@ type resourceConfig struct {
 	SiloName                          string
 	SiloSamlIdentityProviderBlockName string
 	SiloSamlIdentityProviderName      string
+	RemoveSamlIdentityProvider        bool
 }
 
 var resourceConfigTpl = `
@@ -83,7 +84,7 @@ resource "oxide_silo" "{{.SiloBlockName}}" {
     },
   ]
 }
-
+{{ if not .RemoveSamlIdentityProvider }}
 resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockName}}" {
   silo                    = oxide_silo.{{.SiloBlockName}}.id
   name                    = "{{.SiloSamlIdentityProviderName}}"
@@ -100,6 +101,7 @@ resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockNa
     data = "PG1kOkVudGl0eURlc2NyaXB0b3IKCXhtbG5zPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6bWV0YWRhdGEiCgl4bWxuczptZD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm1ldGFkYXRhIgoJeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIKCXhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIiBlbnRpdHlJRD0iaHR0cHM6Ly9leGFtcGxlLmNvbSI+Cgk8bWQ6SURQU1NPRGVzY3JpcHRvciBXYW50QXV0aG5SZXF1ZXN0c1NpZ25lZD0idHJ1ZSIgcHJvdG9jb2xTdXBwb3J0RW51bWVyYXRpb249InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCI+CgkJPG1kOktleURlc2NyaXB0b3IgdXNlPSJzaWduaW5nIj4KCQkJPGRzOktleUluZm8+CgkJCQk8ZHM6S2V5TmFtZT5xWlc3N3I2Vy1NQVhCQURPWkdfb0lVeGlWSmhzWHJGa2tEUlFlQWREYzhjPC9kczpLZXlOYW1lPgoJCQkJPGRzOlg1MDlEYXRhPgoJCQkJCTxkczpYNTA5Q2VydGlmaWNhdGU+TUlJQ3VUQ0NBYUVDQmdHVUdOYUluekFOQmdrcWhraUc5dzBCQVFzRkFEQWdNUjR3SEFZRFZRUUREQlZrWlcxdkxUQXdaakF6WWpoaFpEUmpaVFExT0RJd0hoY05NalF4TWpNd01UZ3pNREF3V2hjTk16UXhNak13TVRnek1UUXdXakFnTVI0d0hBWURWUVFEREJWa1pXMXZMVEF3WmpBellqaGhaRFJqWlRRMU9ESXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDc04yR2Y4Z040b0hHSVI3NXZTaDBZakc0ejFyNytLSGx2cG84QnZmRm9hVk5QR255NHNOMVJGdlI5V25pOVMvM0lXRHNjaDV3NTZnMnk3MFNYcmloUWVKZUptUHhucVd1cUFuSDVLeUgxcjFZeVNqK3pHRGJpRHJyM3pBNlYvdFErUHlJZ0R1cUEvaGg1cmxoRndwOEdQRndnZFBCNTEyK2x5MmR5bTkzQ1BrdDdTdk1KQXhlOHFWYWZPTU9nVEIzcUdiT25jSDdYd1BMMnlhTUhKYUlsTFMwSHh5Ti81S1RrUk5aZERwb25JTFYvajlZT2hZSDdJRDl3c3Y2dlR2NnM3Y3BST0dPMmdFOUVPM1pzTTlwUWlxMjN0RGlTUjloY3BvT2piOElyc0VzMXYxZDlkUGRTV2xybSt4L0U1THlZb1VVT1RUdnlpWDdrU0dPVVFMbS9BZ01CQUFFd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFHTGhBSXlITURVSk9QNkttNzRIYjhUSncxdVh4bVJXRjBRcDBza1BtcUxFSEdRYVpic0R4YVBNYzR0ZDI2TUY0R2dMZ2FNZXVnQlkwZk12d0ErMGJDR0EwY2hLVWpJQUwybEg0UGpzVG15cGliVWMySDFlU1BsOTNoYlBzaTFPSm85bTRvblVHcmg3Z3hHWWJ5Tm85R0tBemgvMmZyZVNRbE82K1pmZkdmSlhabEtTT3pnangzcUVYOTc1N2t1Q3VYWVdtQ3hGbmROd0h2ZjdOTVJENUlQOHRYeEN4a09sbUFBZjRKbUlBbnNsNVp1KzR6K0NuZE1vNkYxMjFsT0t4Tkt2Y0ZYaHFQaHJyd1krZlFreEpXdWprVGp2dTRTN1FsM0dOMzVDWURZdDg5a2drL212VmVCaHVRd1pBR3dWRzE3RnlsN3BNRlFyTGtUQ2ErQmJyY1U9PC9kczpYNTA5Q2VydGlmaWNhdGU+CgkJCQk8L2RzOlg1MDlEYXRhPgoJCQk8L2RzOktleUluZm8+CgkJPC9tZDpLZXlEZXNjcmlwdG9yPgoJCTxtZDpBcnRpZmFjdFJlc29sdXRpb25TZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpTT0FQIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIgaW5kZXg9IjAiLz4KCQk8bWQ6U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLVJlZGlyZWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLUFydGlmYWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpTT0FQIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvbWQ6TmFtZUlERm9ybWF0PgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50PC9tZDpOYW1lSURGb3JtYXQ+CgkJPG1kOk5hbWVJREZvcm1hdD51cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoxLjE6bmFtZWlkLWZvcm1hdDp1bnNwZWNpZmllZDwvbWQ6TmFtZUlERm9ybWF0PgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9tZDpOYW1lSURGb3JtYXQ+CgkJPG1kOlNpbmdsZVNpZ25PblNlcnZpY2UgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1SZWRpcmVjdCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6U09BUCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1BcnRpZmFjdCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCTwvbWQ6SURQU1NPRGVzY3JpcHRvcj4KPC9tZDpFbnRpdHlEZXNjcmlwdG9yPgo="
   }
 }
+{{ end }}
 `
 
 func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
@@ -144,6 +146,85 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+				Check: checkResource(
+					siloSamlIdentityProviderResourceID,
+					siloSamlIdentityProviderName,
+				),
+			},
+		},
+	})
+}
+
+func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
+	siloBlockName := sharedtest.NewBlockName("silo")
+	siloName := sharedtest.NewResourceName()
+	siloSamlIdentityProviderBlockName := sharedtest.NewBlockName("silo-idp")
+	siloSamlIdentityProviderName := sharedtest.NewResourceName()
+
+	siloSamlIdentityProviderResourceID := fmt.Sprintf(
+		"oxide_silo_saml_identity_provider.%s",
+		siloSamlIdentityProviderBlockName,
+	)
+
+	siloDNSName := sharedtest.SiloDNSName()
+
+	initialConfig, err := sharedtest.ParsedAccConfig(
+		resourceConfig{
+			SiloBlockName:                     siloBlockName,
+			SiloDNSName:                       siloDNSName,
+			SiloName:                          siloName,
+			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
+			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+		},
+		resourceConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %v", err)
+	}
+
+	noSAMLConfig, err := sharedtest.ParsedAccConfig(
+		resourceConfig{
+			SiloBlockName:                     siloBlockName,
+			SiloDNSName:                       siloDNSName,
+			SiloName:                          siloName,
+			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
+			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+			RemoveSamlIdentityProvider:        true,
+		},
+		resourceConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing no SAML config template data: %v", err)
+	}
+
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"tls": {
+				Source: "hashicorp/tls",
+			},
+		},
+		CheckDestroy: testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: checkResource(
+					siloSamlIdentityProviderResourceID,
+					siloSamlIdentityProviderName,
+				),
+			},
+			// remove SAML IDP
+			{
+				Config: noSAMLConfig,
+				Check:  testAccResourceDestroy,
+			},
+			// adopt existing SAML IDP
+			{
+				Config: initialConfig,
 				Check: checkResource(
 					siloSamlIdentityProviderResourceID,
 					siloSamlIdentityProviderName,

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -204,44 +204,41 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		t.Fatalf("error parsing no SAML config template data: %v", err)
 	}
 
-	t.Run("simple-adoption", func(t *testing.T) {
-		// Silo creation and deletion can cause database contention in nexus,
-		// so run all related tests in series:
-		// https://github.com/oxidecomputer/omicron/issues/9851
-		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { sharedtest.PreCheck(t) },
-			ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
-			ExternalProviders: map[string]resource.ExternalProvider{
-				"tls": {
-					Source: "hashicorp/tls",
-				},
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"tls": {
+				Source: "hashicorp/tls",
 			},
-			CheckDestroy: testAccResourceDestroy,
-			Steps: []resource.TestStep{
-				{
-					Config: initialConfig,
-					Check: checkResource(
-						siloSamlIdentityProviderResourceID,
-						siloSamlIdentityProviderName,
-					),
-				},
-				// remove SAML IDP
-				{
-					Config: noSAMLConfig,
-					Check:  testAccResourceDestroy,
-				},
-				// adopt existing SAML IDP
-				{
-					Config: initialConfig,
-					Check: checkResource(
-						siloSamlIdentityProviderResourceID,
-						siloSamlIdentityProviderName,
-					),
-				},
+		},
+		CheckDestroy: testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: checkResource(
+					siloSamlIdentityProviderResourceID,
+					siloSamlIdentityProviderName,
+				),
 			},
-		})
+			// remove SAML IDP
+			{
+				Config: noSAMLConfig,
+				Check:  testAccResourceDestroy,
+			},
+			// adopt existing SAML IDP
+			{
+				Config: initialConfig,
+				Check: checkResource(
+					siloSamlIdentityProviderResourceID,
+					siloSamlIdentityProviderName,
+				),
+			},
+		},
 	})
-
 }
 
 func TestAccSiloResourceSiloSamlIdentityProvider_adoptMismatch(t *testing.T) {

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -271,7 +271,10 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 				// no group_attribute_name
 				{
 					Config: noGroupAttributeNameConfig,
-					Check:  resource.TestCheckNoResourceAttr(siloSamlIdentityProviderResourceID, "group_attribute_name"),
+					Check: resource.TestCheckNoResourceAttr(
+						siloSamlIdentityProviderResourceID,
+						"group_attribute_name",
+					),
 				},
 				// remove SAML IDP
 				{

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -11,6 +11,7 @@ package silosamlidp_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -24,12 +25,13 @@ import (
 )
 
 type resourceConfig struct {
-	SiloBlockName                     string
-	SiloDNSName                       string
-	SiloName                          string
-	SiloSamlIdentityProviderBlockName string
-	SiloSamlIdentityProviderName      string
-	RemoveSamlIdentityProvider        bool
+	SiloBlockName                              string
+	SiloDNSName                                string
+	SiloName                                   string
+	SiloSamlIdentityProviderBlockName          string
+	SiloSamlIdentityProviderName               string
+	SkipSamlIdentityProviderGroupAttributeName bool
+	SkipSamlIdentityProvider                   bool
 }
 
 var resourceConfigTpl = `
@@ -84,12 +86,14 @@ resource "oxide_silo" "{{.SiloBlockName}}" {
     },
   ]
 }
-{{ if not .RemoveSamlIdentityProvider }}
+{{ if not .SkipSamlIdentityProvider }}
 resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockName}}" {
   silo                    = oxide_silo.{{.SiloBlockName}}.id
   name                    = "{{.SiloSamlIdentityProviderName}}"
   description             = "Managed by Terraform."
+  {{ if not .SkipSamlIdentityProviderGroupAttributeName }}
   group_attribute_name    = "example"
+  {{ end }}
   idp_entity_id           = "example"
   acs_url                 = "https://example.com"
   slo_url                 = "https://example.com"
@@ -128,7 +132,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		resourceConfigTpl,
 	)
 	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
+		t.Errorf("error parsing config template data: %v", err)
 	}
 
 	// Silo creation and deletion can cause database contention in nexus,
@@ -189,7 +193,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 			SiloName:                          siloName,
 			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
 			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
-			RemoveSamlIdentityProvider:        true,
+			SkipSamlIdentityProvider:          true,
 		},
 		resourceConfigTpl,
 	)
@@ -197,41 +201,92 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		t.Errorf("error parsing no SAML config template data: %v", err)
 	}
 
-	// Silo creation and deletion can cause database contention in nexus,
-	// so run all related tests in series:
-	// https://github.com/oxidecomputer/omicron/issues/9851
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { sharedtest.PreCheck(t) },
-		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"tls": {
-				Source: "hashicorp/tls",
-			},
+	noGroupAttributeNameConfig, err := sharedtest.ParsedAccConfig(
+		resourceConfig{
+			SiloBlockName:                     siloBlockName,
+			SiloDNSName:                       siloDNSName,
+			SiloName:                          siloName,
+			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
+			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+			SkipSamlIdentityProviderGroupAttributeName: true,
 		},
-		CheckDestroy: testAccResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: initialConfig,
-				Check: checkResource(
-					siloSamlIdentityProviderResourceID,
-					siloSamlIdentityProviderName,
-				),
+		resourceConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing different group_attribute_name config template data: %v", err)
+	}
+
+	t.Run("simple-adoption", func(t *testing.T) {
+		// Silo creation and deletion can cause database contention in nexus,
+		// so run all related tests in series:
+		// https://github.com/oxidecomputer/omicron/issues/9851
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { sharedtest.PreCheck(t) },
+			ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"tls": {
+					Source: "hashicorp/tls",
+				},
 			},
-			// remove SAML IDP
-			{
-				Config: noSAMLConfig,
-				Check:  testAccResourceDestroy,
+			CheckDestroy: testAccResourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: initialConfig,
+					Check: checkResource(
+						siloSamlIdentityProviderResourceID,
+						siloSamlIdentityProviderName,
+					),
+				},
+				// remove SAML IDP
+				{
+					Config: noSAMLConfig,
+					Check:  testAccResourceDestroy,
+				},
+				// adopt existing SAML IDP
+				{
+					Config: initialConfig,
+					Check: checkResource(
+						siloSamlIdentityProviderResourceID,
+						siloSamlIdentityProviderName,
+					),
+				},
 			},
-			// adopt existing SAML IDP
-			{
-				Config: initialConfig,
-				Check: checkResource(
-					siloSamlIdentityProviderResourceID,
-					siloSamlIdentityProviderName,
-				),
-			},
-		},
+		})
 	})
+
+	t.Run("adopt-mismatched-group-attribute-name", func(t *testing.T) {
+		// Silo creation and deletion can cause database contention in nexus,
+		// so run all related tests in series:
+		// https://github.com/oxidecomputer/omicron/issues/9851
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { sharedtest.PreCheck(t) },
+			ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"tls": {
+					Source: "hashicorp/tls",
+				},
+			},
+			CheckDestroy: testAccResourceDestroy,
+			Steps: []resource.TestStep{
+				// no group_attribute_name
+				{
+					Config: noGroupAttributeNameConfig,
+					Check:  resource.TestCheckNoResourceAttr(siloSamlIdentityProviderResourceID, "group_attribute_name"),
+				},
+				// remove SAML IDP
+				{
+					Config: noSAMLConfig,
+					Check:  testAccResourceDestroy,
+				},
+				// try to adopt existing SAML IDP and fill in the optional group_attribute_name
+				{
+					Config:      initialConfig,
+					ExpectError: regexp.MustCompile(`group_attribute_name`),
+				},
+			},
+		})
+	})
+
 }
 
 func checkResource(

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -2,16 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 package silosamlidp_test
 
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,13 +21,20 @@ import (
 )
 
 type resourceConfig struct {
-	SiloBlockName                              string
-	SiloDNSName                                string
-	SiloName                                   string
-	SiloSamlIdentityProviderBlockName          string
-	SiloSamlIdentityProviderName               string
-	SkipSamlIdentityProviderGroupAttributeName bool
-	SkipSamlIdentityProvider                   bool
+	SiloBlockName                                  string
+	SiloDNSName                                    string
+	SiloName                                       string
+	SiloSamlIdentityProviderBlockName              string
+	SiloSamlIdentityProviderName                   string
+	SiloSamlIdentityProviderDescription            string
+	SiloSamlIdentityProviderGroupAttributeName     string
+	SiloSamlIdentityProviderIDPEntityID            string
+	SiloSamlIdentityProviderACSURL                 string
+	SiloSamlIdentityProviderSLOURL                 string
+	SiloSamlIdentityProviderSPClientID             string
+	SiloSamlIdentityProviderTechnicalContactEmail  string
+	SkipSiloSamlIdentityProviderGroupAttributeName bool
+	SkipSiloSamlIdentityProvider                   bool
 }
 
 var resourceConfigTpl = `
@@ -86,19 +89,19 @@ resource "oxide_silo" "{{.SiloBlockName}}" {
     },
   ]
 }
-{{ if not .SkipSamlIdentityProvider }}
+{{ if not .SkipSiloSamlIdentityProvider }}
 resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockName}}" {
   silo                    = oxide_silo.{{.SiloBlockName}}.id
   name                    = "{{.SiloSamlIdentityProviderName}}"
-  description             = "Managed by Terraform."
-  {{ if not .SkipSamlIdentityProviderGroupAttributeName }}
-  group_attribute_name    = "example"
+  description             = "{{or .SiloSamlIdentityProviderDescription "Managed by Terraform."}}"
+  {{ if not .SkipSiloSamlIdentityProviderGroupAttributeName }}
+  group_attribute_name    = "{{or .SiloSamlIdentityProviderGroupAttributeName "example"}}"
   {{ end }}
-  idp_entity_id           = "example"
-  acs_url                 = "https://example.com"
-  slo_url                 = "https://example.com"
-  sp_client_id            = "example"
-  technical_contact_email = "example@example.com"
+  idp_entity_id           = "{{or .SiloSamlIdentityProviderIDPEntityID "example"}}"
+  acs_url                 = "{{or .SiloSamlIdentityProviderACSURL "https://example.com"}}"
+  slo_url                 = "{{or .SiloSamlIdentityProviderSLOURL "https://example.com"}}"
+  sp_client_id            = "{{or .SiloSamlIdentityProviderSPClientID "example"}}"
+  technical_contact_email = "{{or .SiloSamlIdentityProviderTechnicalContactEmail "example@example.com"}}"
 
   idp_metadata_source = {
     type = "base64_encoded_xml"
@@ -132,7 +135,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		resourceConfigTpl,
 	)
 	if err != nil {
-		t.Errorf("error parsing config template data: %v", err)
+		t.Fatalf("error parsing config template data: %v", err)
 	}
 
 	// Silo creation and deletion can cause database contention in nexus,
@@ -183,7 +186,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		resourceConfigTpl,
 	)
 	if err != nil {
-		t.Errorf("error parsing config template data: %v", err)
+		t.Fatalf("error parsing config template data: %v", err)
 	}
 
 	noSAMLConfig, err := sharedtest.ParsedAccConfig(
@@ -193,27 +196,12 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 			SiloName:                          siloName,
 			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
 			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
-			SkipSamlIdentityProvider:          true,
+			SkipSiloSamlIdentityProvider:      true,
 		},
 		resourceConfigTpl,
 	)
 	if err != nil {
-		t.Errorf("error parsing no SAML config template data: %v", err)
-	}
-
-	noGroupAttributeNameConfig, err := sharedtest.ParsedAccConfig(
-		resourceConfig{
-			SiloBlockName:                     siloBlockName,
-			SiloDNSName:                       siloDNSName,
-			SiloName:                          siloName,
-			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
-			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
-			SkipSamlIdentityProviderGroupAttributeName: true,
-		},
-		resourceConfigTpl,
-	)
-	if err != nil {
-		t.Errorf("error parsing different group_attribute_name config template data: %v", err)
+		t.Fatalf("error parsing no SAML config template data: %v", err)
 	}
 
 	t.Run("simple-adoption", func(t *testing.T) {
@@ -254,42 +242,119 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		})
 	})
 
-	t.Run("adopt-mismatched-group-attribute-name", func(t *testing.T) {
-		// Silo creation and deletion can cause database contention in nexus,
-		// so run all related tests in series:
-		// https://github.com/oxidecomputer/omicron/issues/9851
-		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { sharedtest.PreCheck(t) },
-			ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
-			ExternalProviders: map[string]resource.ExternalProvider{
-				"tls": {
-					Source: "hashicorp/tls",
-				},
-			},
-			CheckDestroy: testAccResourceDestroy,
-			Steps: []resource.TestStep{
-				// no group_attribute_name
-				{
-					Config: noGroupAttributeNameConfig,
-					Check: resource.TestCheckNoResourceAttr(
-						siloSamlIdentityProviderResourceID,
-						"group_attribute_name",
-					),
-				},
-				// remove SAML IDP
-				{
-					Config: noSAMLConfig,
-					Check:  testAccResourceDestroy,
-				},
-				// try to adopt existing SAML IDP and fill in the optional group_attribute_name
-				{
-					Config:      initialConfig,
-					ExpectError: regexp.MustCompile(`group_attribute_name`),
-				},
-			},
-		})
-	})
+}
 
+func TestAccSiloResourceSiloSamlIdentityProvider_adoptMismatch(t *testing.T) {
+	siloBlockName := sharedtest.NewBlockName("silo")
+	siloName := sharedtest.NewResourceName()
+	siloSamlIdentityProviderBlockName := sharedtest.NewBlockName("silo-idp")
+	siloSamlIdentityProviderName := sharedtest.NewResourceName()
+	siloDNSName := sharedtest.SiloDNSName()
+
+	baseConfig := resourceConfig{
+		SiloBlockName:                     siloBlockName,
+		SiloDNSName:                       siloDNSName,
+		SiloName:                          siloName,
+		SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
+		SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+	}
+
+	initialConfig, err := sharedtest.ParsedAccConfig(baseConfig, resourceConfigTpl)
+	if err != nil {
+		t.Fatalf("error parsing initial config: %v", err)
+	}
+
+	noSAMLBase := baseConfig
+	noSAMLBase.SkipSiloSamlIdentityProvider = true
+	noSAMLConfig, err := sharedtest.ParsedAccConfig(noSAMLBase, resourceConfigTpl)
+	if err != nil {
+		t.Fatalf("error parsing no-SAML config: %v", err)
+	}
+
+	mutatedBase := baseConfig
+	mutatedBase.SiloSamlIdentityProviderACSURL = "https://mismatched-acs.example.com"
+	mutatedBase.SiloSamlIdentityProviderDescription = "mismatched description"
+	mutatedBase.SiloSamlIdentityProviderGroupAttributeName = "mismatched-group-attribute"
+	mutatedBase.SiloSamlIdentityProviderIDPEntityID = "mismatched-entity-id"
+	mutatedBase.SiloSamlIdentityProviderSLOURL = "https://mismatched-slo.example.com"
+	mutatedBase.SiloSamlIdentityProviderSPClientID = "mismatched-client-id"
+	mutatedBase.SiloSamlIdentityProviderTechnicalContactEmail = "mismatched@example.com"
+	mutatedConfig, err := sharedtest.ParsedAccConfig(mutatedBase, resourceConfigTpl)
+	if err != nil {
+		t.Fatalf("error parsing mutated config: %v", err)
+	}
+
+	// Records that the ErrorCheck callback ran; verified after resource.Test
+	// returns to enforce that the re-adoption step actually errored.
+	var errorChecked bool
+
+	// Each attribute Diff is expected to flag. Add to this list (and to the
+	// mutation block above) when extending Diff.
+	expectedAttrs := []string{
+		"acs_url",
+		"description",
+		"group_attribute_name",
+		"idp_entity_id",
+		"slo_url",
+		"sp_client_id",
+		"technical_contact_email",
+	}
+
+	// Silo creation and deletion can cause database contention in nexus,
+	// so run all related tests in series:
+	// https://github.com/oxidecomputer/omicron/issues/9851
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"tls": {
+				Source: "hashicorp/tls",
+			},
+		},
+		CheckDestroy: testAccResourceDestroy,
+		// ExpectError and ErrorCheck are mutually exclusive per step in the
+		// testing framework — when ExpectError is set the framework skips
+		// ErrorCheck. We want the must-error enforcement of the former and
+		// the substring loop of the latter, so we wire both via ErrorCheck
+		// alone: the flag records that ErrorCheck fired, and the assertion
+		// after resource.Test verifies the re-adoption step actually
+		// errored.
+		ErrorCheck: func(err error) error {
+			errorChecked = true
+			msg := err.Error()
+			for _, attr := range expectedAttrs {
+				if !strings.Contains(msg, attr) {
+					return fmt.Errorf(
+						"expected adoption diagnostic to mention %q; got: %s",
+						attr,
+						msg,
+					)
+				}
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Create the IdP with the original values.
+			{
+				Config: initialConfig,
+			},
+			// Remove the IdP from Terraform state; it remains in Oxide.
+			{
+				Config: noSAMLConfig,
+				Check:  testAccResourceDestroy,
+			},
+			// Re-adopt with every API-returned attribute mutated; ErrorCheck
+			// above verifies each attribute is mentioned.
+			{
+				Config: mutatedConfig,
+			},
+		},
+	})
+	if !errorChecked {
+		t.Fatal(
+			"expected the re-adoption step to fail with mismatch diagnostics, but no error occurred",
+		)
+	}
 }
 
 func checkResource(
@@ -344,7 +409,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		return fmt.Errorf("silo saml identity provider (%v) still exists", &res.Name)
+		return fmt.Errorf("silo saml identity provider (%v) still exists", res.Name)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/terraform-provider-oxide/issues/761

The silo_saml_identity_provider resource cannot be deleted once created. It can be removed from Terraform state, but adding it back was problematic since it would already exist in the Oxide control plane. This change handles the "already exists" error in the Create path which triggers a read of the resource to update Terraform's state. 

Fixed a few test issues related error propagation and formatting. 

-----

### Pull request checklist

- [x] Add changelog entry for this change.
