### PR TITLE
fix local upgrade testing when terraformrc dev overrides is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
 OS_ARCH ?= $(OS)_$(ARCH)
 RELEASE_VERSION ?= $(shell cat $(CURDIR)/VERSION | sed s/-dev//g)
-export GOBIN = $(shell pwd)/bin
+export GOBIN ?= $(shell pwd)/bin
 
 # Terraform currently does not have a binary for Illumos.
 # The one for Solaris works fine with Illumos, so we'll need
@@ -143,6 +143,9 @@ testacc-sim-setup: testacc-sim-token testacc-sim-oxide-cli
 
 .PHONY: testacc
 ## Runs the Terraform acceptance tests. Use TEST_ACC_NAME, TEST_ACC_ARGS, TEST_ACC_GOTESTSUM_ARGS, TEST_ACC_COUNT and TEST_ACC_PARALLEL for acceptance testing settings.
+# acctest/terraformrc neutralizes any dev_overrides in ~/.terraformrc so the
+# ExternalProviders pins used by state-upgrade tests resolve from the registry.
+testacc: export TF_CLI_CONFIG_FILE = $(CURDIR)/acctest/terraformrc
 testacc:
 	@ echo "-> Running terraform acceptance tests"
 	@ TF_ACC=1 $(GO_TOOL) gotestsum \

--- a/acctest/terraformrc
+++ b/acctest/terraformrc
@@ -1,0 +1,3 @@
+provider_installation {
+  direct {}
+}


### PR DESCRIPTION
When running acceptance tests locally with a terraformrc file that uses dev overrides, upgrade tests fail since the dev_override block is overriding the ExternalProviders. This change uses an empty terraformrc file for the acceptance tests so that the tests are the source of truth for the provider version.

<details>
<summary>Here is the failures I encountered before adding the empty terraformrc for the tests to use:</summary>

```
=== Failed
=== FAIL: internal/provider/vpc_firewall_rules TestAccCloudResourceFirewallRules_v1_upgrade (0.28s)
    resource_test.go:499: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Incorrect attribute value type

          on terraform_plugin_test.tf line 27, in resource "oxide_vpc_firewall_rules" "test":
          27:   rules = [
          28:     {
          29:       action      = "allow"
          30:       name        = "allow-icmp"
          31:       description = "ICMP rule."
          32:       direction   = "inbound"
          33:       priority    = 65535
          34:       status      = "enabled"
          35:       filters = {
          36:         protocols = [
          37:           {
          38:             type = "icmp"
          39:             icmp_type = 0
          40:             icmp_code = "1-3"
          41:           },
          42:         ]
          43:       }
          44:       targets = [
          45:         {
          46:           type  = "subnet"
          47:           value = "default"
          48:         }
          49:       ]
          50:     }
          51:   ]

        Inappropriate value for attribute "rules": map of object required.

=== FAIL: internal/provider/vpc_firewall_rules TestAccCloudResourceFirewallRules_v1_upgrade (re-run 1) (0.19s)
    resource_test.go:499: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Incorrect attribute value type

          on terraform_plugin_test.tf line 27, in resource "oxide_vpc_firewall_rules" "test":
          27:   rules = [
          28:     {
          29:       action      = "allow"
          30:       name        = "allow-icmp"
          31:       description = "ICMP rule."
          32:       direction   = "inbound"
          33:       priority    = 65535
          34:       status      = "enabled"
          35:       filters = {
          36:         protocols = [
          37:           {
          38:             type = "icmp"
          39:             icmp_type = 0
          40:             icmp_code = "1-3"
          41:           },
          42:         ]
          43:       }
          44:       targets = [
          45:         {
          46:           type  = "subnet"
          47:           value = "default"
          48:         }
          49:       ]
          50:     }
          51:   ]

        Inappropriate value for attribute "rules": map of object required.

=== FAIL: internal/provider/vpc_firewall_rules TestAccCloudResourceFirewallRules_v1_upgrade (re-run 2) (0.15s)
    resource_test.go:499: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Incorrect attribute value type

          on terraform_plugin_test.tf line 27, in resource "oxide_vpc_firewall_rules" "test":
          27:   rules = [
          28:     {
          29:       action      = "allow"
          30:       name        = "allow-icmp"
          31:       description = "ICMP rule."
          32:       direction   = "inbound"
          33:       priority    = 65535
          34:       status      = "enabled"
          35:       filters = {
          36:         protocols = [
          37:           {
          38:             type = "icmp"
          39:             icmp_type = 0
          40:             icmp_code = "1-3"
          41:           },
          42:         ]
          43:       }
          44:       targets = [
          45:         {
          46:           type  = "subnet"
          47:           value = "default"
          48:         }
          49:       ]
          50:     }
          51:   ]

        Inappropriate value for attribute "rules": map of object required.

=== FAIL: internal/provider/vpc_firewall_rules TestAccCloudResourceFirewallRules_v1_upgrade (re-run 3) (0.15s)
    resource_test.go:499: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Incorrect attribute value type

          on terraform_plugin_test.tf line 27, in resource "oxide_vpc_firewall_rules" "test":
          27:   rules = [
          28:     {
          29:       action      = "allow"
          30:       name        = "allow-icmp"
          31:       description = "ICMP rule."
          32:       direction   = "inbound"
          33:       priority    = 65535
          34:       status      = "enabled"
          35:       filters = {
          36:         protocols = [
          37:           {
          38:             type = "icmp"
          39:             icmp_type = 0
          40:             icmp_code = "1-3"
          41:           },
          42:         ]
          43:       }
          44:       targets = [
          45:         {
          46:           type  = "subnet"
          47:           value = "default"
          48:         }
          49:       ]
          50:     }
          51:   ]

        Inappropriate value for attribute "rules": map of object required.

DONE 4 runs, 70 tests, 2 skipped, 4 failures in 88.929s
make: *** [testacc] Error 1
```
</details>

-----

### Pull request checklist

- [ ] Add changelog entry for this change.
