### PR TITLE
misc: add colima instructions for apple silicon acceptance test runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,15 @@ Run `make testacc`.
 
 To run tests against an empty simulated omicron environment, first provision
 the Docker containers with `make testacc-sim` and run the test suite with `make
-testacc-local`.
+testacc-local`. 
+
+To run the simulated omicron environment on Apple Silicon (arm64), use [colima](https://colima.run/).
+
+```
+colima start --vm-type=vz --vz-rosetta --runtime docker --cpu 8 --memory 16 --disk 100
+docker context use colima
+make testacc-sim
+```
 
 To run specific test cases, set the test name pattern as the variable
 `TEST_ACC_NAME` .

--- a/acctest/ensure-image.sh
+++ b/acctest/ensure-image.sh
@@ -13,7 +13,7 @@ OMICRON_SHA="${1:?usage: ensure-image.sh <omicron-sha>}"
 REMOTE_IMAGE="ghcr.io/oxidecomputer/terraform-provider-oxide/acctest-omicron-dev:${OMICRON_SHA}"
 LOCAL_IMAGE="acctest-omicron-dev:${OMICRON_SHA}"
 
-if docker pull "${REMOTE_IMAGE}" 2>/dev/null; then
+if docker pull --platform linux/amd64 "${REMOTE_IMAGE}" 2>/dev/null; then
     docker tag "${REMOTE_IMAGE}" "${LOCAL_IMAGE}"
 else
     echo "-> Image not found in GHCR, building locally"


### PR DESCRIPTION
- Add instructions to use colima w/ rosetta for omicon simulator to run acceptance tests locally on apple silicon.
- Explicitly set platform when pulling the image. 

-----

### Pull request checklist

- [ ] Add changelog entry for this change.
