### PR TITLE
fix: disk acceptance test flakes

### DIFF
--- a/internal/provider/disk/resource_test.go
+++ b/internal/provider/disk/resource_test.go
@@ -166,8 +166,8 @@ data "oxide_project" "test" {
 	name = "tf-acc-test"
 }
 
-data "oxide_images" "test" {
-  project_id = data.oxide_project.test.id
+data "oxide_image" "test" {
+  name = "alpine-project"
 }
 
 resource "oxide_disk" "test" {
@@ -175,7 +175,7 @@ resource "oxide_disk" "test" {
   description     = "a test read-only disk"
   name            = "{{.DiskName}}"
   size            = 1073741824
-  source_image_id = element(tolist(data.oxide_images.test.images[*].id), 0)
+  source_image_id = data.oxide_image.test.id
   read_only       = {{.ReadOnly}}
 }
 `


### PR DESCRIPTION
- The source image id was being changed between steps due the data source query taking the first item which was not deterministic. The flakes stopped when I query for a specific image. 

<details>
<summary>Example Test Failure Case</summary>
<pre>
=== Failed
=== FAIL: internal/provider/disk TestAccCloudResourceDisk_readOnly (26.70s)
    resource_test.go:208: Step 3/3 error: After applying this test step, the non-refresh plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # oxide_disk.test must be replaced
        -/+ resource "oxide_disk" "test" {
              ~ block_size      = 512 -> (known after apply) # forces replacement
              ~ device_path     = "/mnt/acc-terraform-6363d032-bb08-42b7-8b7f-76444453cba8" -> (known after apply)
              ~ id              = "42a9840a-1674-4332-9151-24594f6b83b6" -> (known after apply)
                name            = "acc-terraform-6363d032-bb08-42b7-8b7f-76444453cba8"
              ~ source_image_id = "bc9507b8-9ea5-42c2-86a3-8060db8a8b8c" -> "aeb0d146-26c1-470d-874a-f845fd3dfb2f" # forces replacement
              ~ time_created    = "2026-06-11 18:24:00.40146 +0000 UTC" -> (known after apply)
              ~ time_modified   = "2026-06-11 18:24:00.40146 +0000 UTC" -> (known after apply)
                # (5 unchanged attributes hidden)
            }

        Plan: 1 to add, 0 to change, 1 to destroy.

DONE 2 runs, 69 tests, 2 skipped, 1 failure in 72.454s
</pre>
</details>

-----

### Pull request checklist

- [ ] Add changelog entry for this change.
