### PR TITLE
ci: ignore Go SDK version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
+    ignore:
+      # The Oxide GO SDK is updated manually on each release.
+      - dependency-name: "github.com/oxidecomputer/oxide.go"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions" # See documentation for possible values


### PR DESCRIPTION
The Go SDK is updated manually on each release because it often requires manual fixes.