### PR TITLE
feat(oxide_instance): multicast_groups attribute

### DIFF
--- a/.changelog/0.21.0.toml
+++ b/.changelog/0.21.0.toml
@@ -1,0 +1,15 @@
+[[breaking]]
+title = ""
+description = ""
+
+[[features]]
+title = "`oxide_instance`"
+description = "The `multicast_groups` attribute was added to configure an instance's multicast groups. [#TODO](https://github.com/oxidecomputer/terraform-provider-oxide/pull/TODO)."
+
+[[enhancements]]
+title = ""
+description = ""
+
+[[bugs]]
+title = ""
+description = ""

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # Acceptance test variables
 TEST_ACC_COUNT ?= 1
 TEST_ACC ?= github.com/oxidecomputer/terraform-provider-oxide/internal/...
-TEST_ACC_NAME ?= TestAcc
+TEST_ACC_NAME ?= TestAccCloudResourceInstance
 TEST_ACC_PARALLEL = 6
 TEST_ACC_OMICRON_BRANCH ?=
 TEST_ACC_SIM_HOST ?= http://localhost:12220

--- a/acctest/docker-compose.yaml
+++ b/acctest/docker-compose.yaml
@@ -6,10 +6,18 @@ services:
     environment:
       RUST_BACKTRACE: "1"
     command:
-      - "omicron-dev"
-      - "run-all"
-      - "--nexus-config=/omicron/nexus/examples/config.toml"
-      - "--gateway-config=/omicron/gateway-test-utils/configs/sp_sim_config.test.toml"
+      - "sh"
+      - "-c"
+      - |
+        config=/omicron/nexus/examples/config.toml
+        if grep -q '^\[multicast\]' "$$config"; then
+          sed -i '/^\[multicast\]/,/^\[/{s/^enabled = .*/enabled = true/}' "$$config"
+        else
+          printf '\n[multicast]\nenabled = true\n' >> "$$config"
+        fi
+        exec omicron-dev run-all \
+          --nexus-config=/omicron/nexus/examples/config.toml \
+          --gateway-config=/omicron/gateway-test-utils/configs/sp_sim_config.test.toml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:12220"]
       interval: "5s"

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -156,6 +156,7 @@ resource "oxide_instance" "example" {
 - `enable_jumbo_frames` (Boolean) Whether to enable jumbo frames (8500 byte MTU) on the instance's primary network interface. Enabling this requires the fleet-wide jumbo-frames opt-in to be enabled. Changes only take effect on the next instance restart.
 - `external_ips` (Attributes) External IP addresses provided to this instance. By default, all instances have outbound connectivity, but no inbound connectivity. These external addresses can be used to provide a fixed, known IP address for making inbound connections to the instance. (see [below for nested schema](#nestedatt--external_ips))
 - `hostname` (String) RFC1035-compliant hostname for the instance.
+- `multicast_groups` (Attributes Set) Multicast groups this instance should join. (see [below for nested schema](#nestedatt--multicast_groups))
 - `network_interfaces` (Attributes Set) The network interfaces to be created for this instance. (see [below for nested schema](#nestedatt--network_interfaces))
 - `ssh_public_keys` (Set of String) An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation. If an empty list is provided, no public keys will be transmitted to the instance.
 - `start_on_create` (Boolean) Whether to start this instance upon creation.
@@ -195,6 +196,19 @@ Required:
 
 - `id` (String) The external floating IP ID.
 
+
+
+<a id="nestedatt--multicast_groups"></a>
+### Nested Schema for `multicast_groups`
+
+Required:
+
+- `group` (String) Multicast group to join, specified by name, UUID, or IP address.
+
+Optional:
+
+- `ip_version` (String) IP version for pool selection when creating a multicast group by name. Must be one of `v4` or `v6`.
+- `source_ips` (Set of String) Source IPs for source-filtered multicast.
 
 
 <a id="nestedatt--network_interfaces"></a>

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sort"
 	"strconv"
 	"time"
 
@@ -66,6 +67,7 @@ type ResourceModel struct {
 	Hostname                  types.String             `tfsdk:"hostname"`
 	ID                        types.String             `tfsdk:"id"`
 	Memory                    types.Int64              `tfsdk:"memory"`
+	MulticastGroups           []MulticastGroupModel    `tfsdk:"multicast_groups"`
 	Name                      types.String             `tfsdk:"name"`
 	NetworkInterfaces         []NICResourceModel       `tfsdk:"network_interfaces"`
 	AttachedNetworkInterfaces types.Map                `tfsdk:"attached_network_interfaces"`
@@ -161,6 +163,27 @@ type EphemeralIPResourceModel struct {
 
 type FloatingIPResourceModel struct {
 	ID types.String `tfsdk:"id"`
+}
+
+type MulticastGroupModel struct {
+	Group     types.String `tfsdk:"group"`
+	IPVersion types.String `tfsdk:"ip_version"`
+	SourceIPs types.Set    `tfsdk:"source_ips"`
+}
+
+func (group MulticastGroupModel) Hash() string {
+	h := md5.New()
+
+	io.WriteString(h, group.Group.ValueString())
+	io.WriteString(h, group.IPVersion.ValueString())
+
+	sourceIPs := sourceIPStrings(group.SourceIPs)
+	sort.Strings(sourceIPs)
+	for _, ip := range sourceIPs {
+		io.WriteString(h, ip)
+	}
+
+	return string(h.Sum(nil))
 }
 
 var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
@@ -309,6 +332,42 @@ This resource manages instances.
 				Optional:    true,
 				Description: "IDs of the anti-affinity groups to which this instance should be added.",
 				ElementType: types.StringType,
+			},
+			"multicast_groups": schema.SetNestedAttribute{
+				Optional:    true,
+				Description: "Multicast groups this instance should join.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"group": schema.StringAttribute{
+							Required:    true,
+							Description: "Multicast group to join, specified by name, UUID, or IP address.",
+							Validators: []validator.String{
+								stringvalidator.NoneOf(""),
+							},
+						},
+						"ip_version": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "IP version for pool selection when creating a multicast group by name. Must be one of `v4` or `v6`.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									string(oxide.IpVersionV4),
+									string(oxide.IpVersionV6),
+								),
+							},
+						},
+						"source_ips": schema.SetAttribute{
+							Optional:    true,
+							Description: "Source IPs for source-filtered multicast.",
+							ElementType: types.StringType,
+							Validators: []validator.Set{
+								setvalidator.NoNullValues(),
+								setvalidator.ValueStringsAre(
+									stringvalidator.NoneOf(""),
+								),
+							},
+						},
+					},
+				},
 			},
 			"boot_disk_id": schema.StringAttribute{
 				Optional:            true,
@@ -936,6 +995,20 @@ func (r *Resource) Create(
 		map[string]any{"success": true},
 	)
 
+	diags = addMulticastGroups(ctx, r.client, plan.MulticastGroups, instance.Id)
+	if diags.HasError() {
+		if err := r.client.InstanceDelete(ctx, oxide.InstanceDeleteParams{
+			Instance: oxide.NameOrId(instance.Id),
+		}); err != nil && !shared.Is404(err) {
+			diags.AddWarning(
+				"Unable to clean up instance after multicast group error",
+				"API error: "+err.Error(),
+			)
+		}
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	// Map response body to schema and populate Computed attribute values
 	plan.EnableJumboFrames = types.BoolPointerValue(instance.EnableJumboFrames)
 	plan.ID = types.StringValue(instance.Id)
@@ -1074,6 +1147,15 @@ func (r *Resource) Read(
 	// Only set the anti-affinity group list if there are any associated groups
 	if len(antiAffinityGroupSet.Elements()) > 0 {
 		state.AntiAffinityGroups = antiAffinityGroupSet
+	}
+
+	multicastGroups, diags := newAssociatedMulticastGroups(ctx, r.client, state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(multicastGroups) > 0 || len(state.MulticastGroups) > 0 {
+		state.MulticastGroups = multicastGroups
 	}
 
 	diskSet, diags := newAttachedDisksSet(ctx, r.client, state.ID.ValueString())
@@ -1317,6 +1399,33 @@ func (r *Resource) Update(
 		return
 	}
 
+	// Update multicast groups.
+	multicastGroupsToRemove := shared.SliceDiffByID(
+		state.MulticastGroups,
+		plan.MulticastGroups,
+		func(e MulticastGroupModel) any {
+			return e.Hash()
+		},
+	)
+	resp.Diagnostics.Append(
+		removeMulticastGroups(ctx, r.client, multicastGroupsToRemove, state.ID.ValueString())...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	multicastGroupsToAdd := shared.SliceDiffByID(
+		plan.MulticastGroups,
+		state.MulticastGroups,
+		func(e MulticastGroupModel) any {
+			return e.Hash()
+		},
+	)
+	resp.Diagnostics.Append(
+		addMulticastGroups(ctx, r.client, multicastGroupsToAdd, state.ID.ValueString())...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Update anti-affinity groups
 	planAntiAffinityGroups := plan.AntiAffinityGroups.Elements()
 	stateAntiAffinityGroups := state.AntiAffinityGroups.Elements()
@@ -1401,6 +1510,15 @@ func (r *Resource) Update(
 	// Only set the disk list if there are disk attachments
 	if len(diskSet.Elements()) > 0 {
 		plan.DiskAttachments = diskSet
+	}
+
+	multicastGroups, diags := newAssociatedMulticastGroups(ctx, r.client, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(multicastGroups) > 0 || len(plan.MulticastGroups) > 0 {
+		plan.MulticastGroups = multicastGroups
 	}
 
 	// TODO: should I do this or read from the newly created ones?
@@ -1655,6 +1773,220 @@ func newAssociatedAntiAffinityGroupsOnCreateSet(
 	}
 
 	return groupSet, nil
+}
+
+func newAssociatedMulticastGroups(
+	ctx context.Context,
+	client *oxide.Client,
+	state ResourceModel,
+) ([]MulticastGroupModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	params := oxide.InstanceMulticastGroupListParams{
+		Limit:    oxide.NewPointer(1000000000),
+		Instance: oxide.NameOrId(state.ID.ValueString()),
+	}
+	groups, err := client.ExperimentalInstanceMulticastGroupList(ctx, params)
+	if err != nil {
+		diags.AddError(
+			"Unable to list associated multicast groups:",
+			"API error: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	groupModels := []MulticastGroupModel{}
+	for _, group := range groups.Items {
+		matched := matchingMulticastGroupModel(group, state.MulticastGroups)
+		model := MulticastGroupModel{
+			Group:     types.StringValue(group.MulticastGroupId),
+			IPVersion: types.StringNull(),
+		}
+		if matched != nil {
+			model.Group = matched.Group
+			model.IPVersion = matched.IPVersion
+		}
+
+		if len(group.SourceIps) == 0 && matched != nil && matched.SourceIPs.IsNull() {
+			model.SourceIPs = types.SetNull(types.StringType)
+		} else {
+			sourceIPs, sourceIPDiags := newStringSet(group.SourceIps)
+			diags.Append(sourceIPDiags...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			model.SourceIPs = sourceIPs
+		}
+		groupModels = append(groupModels, model)
+	}
+
+	return groupModels, nil
+}
+
+func matchingMulticastGroupModel(
+	group oxide.MulticastGroupMember,
+	models []MulticastGroupModel,
+) *MulticastGroupModel {
+	for i, model := range models {
+		groupID := model.Group.ValueString()
+		if groupID == group.MulticastGroupId ||
+			groupID == group.MulticastIp ||
+			groupID == string(group.Name) {
+			return &models[i]
+		}
+	}
+
+	return nil
+}
+
+func newMulticastGroupJoinSpecs(
+	model []MulticastGroupModel,
+) ([]oxide.MulticastGroupJoinSpec, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if len(model) == 0 {
+		return nil, nil
+	}
+
+	groups := make([]oxide.MulticastGroupJoinSpec, 0, len(model))
+	for _, group := range model {
+		sourceIPs := sourceIPStrings(group.SourceIPs)
+		spec := oxide.MulticastGroupJoinSpec{
+			Group:     oxide.MulticastGroupIdentifier(group.Group.ValueString()),
+			SourceIps: sourceIPs,
+		}
+		if !group.IPVersion.IsNull() {
+			spec.IpVersion = oxide.IpVersion(group.IPVersion.ValueString())
+		}
+		groups = append(groups, spec)
+	}
+
+	return groups, diags
+}
+
+func multicastGroupsChanged(state, plan []MulticastGroupModel) bool {
+	return len(shared.SliceDiffByID(
+		plan,
+		state,
+		func(e MulticastGroupModel) any {
+			return e.Hash()
+		},
+	)) > 0 || len(shared.SliceDiffByID(
+		state,
+		plan,
+		func(e MulticastGroupModel) any {
+			return e.Hash()
+		},
+	)) > 0
+}
+
+func addMulticastGroups(
+	ctx context.Context,
+	client *oxide.Client,
+	groups []MulticastGroupModel,
+	instanceID string,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for _, group := range groups {
+		groupID := group.Group.ValueString()
+		params := oxide.InstanceMulticastGroupJoinParams{
+			Instance:       oxide.NameOrId(instanceID),
+			MulticastGroup: oxide.MulticastGroupIdentifier(groupID),
+			Body: &oxide.InstanceMulticastGroupJoin{
+				SourceIps: sourceIPStrings(group.SourceIPs),
+			},
+		}
+		if !group.IPVersion.IsNull() {
+			params.Body.IpVersion = oxide.IpVersion(group.IPVersion.ValueString())
+		}
+
+		_, err := client.ExperimentalInstanceMulticastGroupJoin(ctx, params)
+		if err != nil {
+			diags.AddError(
+				"Error adding multicast group to instance",
+				"API error: "+err.Error(),
+			)
+			return diags
+		}
+		tflog.Trace(
+			ctx,
+			fmt.Sprintf(
+				"added multicast group %q to instance with ID: %v",
+				groupID,
+				instanceID,
+			),
+			map[string]any{"success": true},
+		)
+	}
+
+	return nil
+}
+
+func removeMulticastGroups(
+	ctx context.Context,
+	client *oxide.Client,
+	groups []MulticastGroupModel,
+	instanceID string,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for _, group := range groups {
+		groupID := group.Group.ValueString()
+		params := oxide.InstanceMulticastGroupLeaveParams{
+			Instance:       oxide.NameOrId(instanceID),
+			MulticastGroup: oxide.MulticastGroupIdentifier(groupID),
+		}
+
+		err := client.ExperimentalInstanceMulticastGroupLeave(ctx, params)
+		if err != nil {
+			if shared.Is404(err) {
+				return nil
+			}
+			diags.AddError(
+				"Error removing multicast group from instance",
+				"API error: "+err.Error(),
+			)
+			return diags
+		}
+		tflog.Trace(
+			ctx,
+			fmt.Sprintf(
+				"removed multicast group %q from instance with ID: %v",
+				groupID,
+				instanceID,
+			),
+			map[string]any{"success": true},
+		)
+	}
+
+	return nil
+}
+
+func sourceIPStrings(sourceIPs types.Set) []string {
+	if sourceIPs.IsNull() || sourceIPs.IsUnknown() {
+		return nil
+	}
+
+	ips := make([]string, 0, len(sourceIPs.Elements()))
+	for _, sourceIP := range sourceIPs.Elements() {
+		ip, err := strconv.Unquote(sourceIP.String())
+		if err != nil {
+			continue
+		}
+		ips = append(ips, ip)
+	}
+
+	return ips
+}
+
+func newStringSet(values []string) (types.Set, diag.Diagnostics) {
+	setValues := make([]attr.Value, 0, len(values))
+	for _, value := range values {
+		setValues = append(setValues, types.StringValue(value))
+	}
+
+	return types.SetValue(types.StringType, setValues)
 }
 
 func newNetworkInterfaceAttachment(

--- a/internal/provider/instance/resource_internal_test.go
+++ b/internal/provider/instance/resource_internal_test.go
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+func TestNewMulticastGroupJoinSpecs(t *testing.T) {
+	sourceIPs := mustStringSet(t, "192.0.2.1", "192.0.2.2")
+
+	got, diags := newMulticastGroupJoinSpecs([]MulticastGroupModel{
+		{
+			Group:     types.StringValue("multicast-group"),
+			IPVersion: types.StringValue(string(oxide.IpVersionV4)),
+			SourceIPs: sourceIPs,
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d multicast groups, want 1", len(got))
+	}
+	if got[0].Group != oxide.MulticastGroupIdentifier("multicast-group") {
+		t.Fatalf("got group %q, want multicast-group", got[0].Group)
+	}
+	if got[0].IpVersion != oxide.IpVersionV4 {
+		t.Fatalf("got IP version %q, want %q", got[0].IpVersion, oxide.IpVersionV4)
+	}
+	if len(got[0].SourceIps) != 2 {
+		t.Fatalf("got %d source IPs, want 2", len(got[0].SourceIps))
+	}
+}
+
+func TestMulticastGroupsChangedIgnoresSourceIPOrder(t *testing.T) {
+	a := []MulticastGroupModel{
+		{
+			Group:     types.StringValue("multicast-group"),
+			IPVersion: types.StringNull(),
+			SourceIPs: mustStringSet(t, "192.0.2.1", "192.0.2.2"),
+		},
+	}
+	b := []MulticastGroupModel{
+		{
+			Group:     types.StringValue("multicast-group"),
+			IPVersion: types.StringNull(),
+			SourceIPs: mustStringSet(t, "192.0.2.2", "192.0.2.1"),
+		},
+	}
+
+	if multicastGroupsChanged(a, b) {
+		t.Fatal("expected source IP order not to produce a multicast group change")
+	}
+}
+
+func TestMatchingMulticastGroupModel(t *testing.T) {
+	models := []MulticastGroupModel{
+		{Group: types.StringValue("group-name")},
+		{Group: types.StringValue("224.0.2.42")},
+		{Group: types.StringValue("group-id")},
+	}
+	member := oxide.MulticastGroupMember{
+		MulticastGroupId: "group-id",
+		MulticastIp:      "224.0.2.42",
+		Name:             oxide.Name("group-name"),
+	}
+
+	got := matchingMulticastGroupModel(member, models)
+	if got == nil {
+		t.Fatal("expected multicast group model match")
+	}
+	if got.Group.ValueString() != "group-name" {
+		t.Fatalf("got group %q, want first configured matching identifier", got.Group.ValueString())
+	}
+}
+
+func mustStringSet(t *testing.T, values ...string) types.Set {
+	t.Helper()
+
+	attrs := make([]attr.Value, 0, len(values))
+	for _, value := range values {
+		attrs = append(attrs, types.StringValue(value))
+	}
+	set, diags := types.SetValue(types.StringType, attrs)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	return set
+}

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1559,6 +1560,207 @@ resource "oxide_instance" "{{.BlockName}}" {
 	})
 }
 
+func TestAccCloudResourceInstance_multicastGroups(t *testing.T) {
+	type resourceInstanceMulticastGroupsConfig struct {
+		BlockName        string
+		InstanceName     string
+		SupportBlockName string
+		GroupIP          string
+		GroupIP2         string
+	}
+
+	resourceInstanceMulticastGroupsConfigTpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+data "oxide_ip_pool" "non_default_multicast" {
+  name = "non-default-multicast"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  hostname        = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 1
+  start_on_create = false
+  multicast_groups = [
+    {
+      group = "{{.GroupIP}}"
+    }
+  ]
+
+  depends_on = [data.oxide_ip_pool.non_default_multicast]
+}
+`
+
+	resourceInstanceMulticastGroupsConfigTplUpdate := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+data "oxide_ip_pool" "non_default_multicast" {
+  name = "non-default-multicast"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  hostname        = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 1
+  start_on_create = false
+  multicast_groups = [
+    {
+      group = "{{.GroupIP}}"
+    },
+    {
+      group      = "{{.GroupIP2}}"
+      source_ips = ["192.0.2.1"]
+    }
+  ]
+
+  depends_on = [data.oxide_ip_pool.non_default_multicast]
+}
+`
+
+	instanceName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance-multicast-groups")
+	supportBlockName := sharedtest.NewBlockName("support-instance-multicast-groups")
+	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
+	groupOctet := rand.IntN(127) + 1
+	groupIP := fmt.Sprintf("239.1.0.%d", groupOctet)
+	groupIP2 := fmt.Sprintf("239.1.0.%d", groupOctet+127)
+
+	config, err := sharedtest.ParsedAccConfig(
+		resourceInstanceMulticastGroupsConfig{
+			BlockName:        blockName,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName,
+			GroupIP:          groupIP,
+		},
+		resourceInstanceMulticastGroupsConfigTpl,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	configUpdate, err := sharedtest.ParsedAccConfig(
+		resourceInstanceMulticastGroupsConfig{
+			BlockName:        blockName,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName,
+			GroupIP:          groupIP,
+			GroupIP2:         groupIP2,
+		},
+		resourceInstanceMulticastGroupsConfigTplUpdate,
+	)
+	if err != nil {
+		t.Errorf("error parsing config template data: %e", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			sharedtest.PreCheck(t)
+			skipIfMulticastDisabled(t)
+		},
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		CheckDestroy:             testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkResourceMulticastGroups(
+					resourceName,
+					instanceName,
+					groupIP,
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: checkResourceMulticastGroupsUpdate(
+					resourceName,
+					instanceName,
+					groupIP,
+					groupIP2,
+				),
+			},
+			{
+				Config: config,
+				Check: checkResourceMulticastGroups(
+					resourceName,
+					instanceName,
+					groupIP,
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_on_create",
+					"multicast_groups",
+				},
+			},
+		},
+	})
+}
+
+func skipIfMulticastDisabled(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	client, err := sharedtest.NewTestClient()
+	if err != nil {
+		t.Fatalf("failed to create oxide client for multicast precheck: %v", err)
+	}
+
+	instanceName := sharedtest.NewResourceName()
+	instance, err := client.InstanceCreate(ctx, oxide.InstanceCreateParams{
+		Project: oxide.NameOrId("tf-acc-test"),
+		Body: &oxide.InstanceCreate{
+			Description: "multicast precheck",
+			Name:        oxide.Name(instanceName),
+			Hostname:    oxide.Hostname(instanceName),
+			Memory:      oxide.ByteCount(1073741824),
+			Ncpus:       oxide.InstanceCpuCount(1),
+			Start:       oxide.NewPointer(false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create multicast precheck instance: %v", err)
+	}
+
+	t.Cleanup(func() {
+		deleteCtx, deleteCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer deleteCancel()
+		_ = client.InstanceDelete(deleteCtx, oxide.InstanceDeleteParams{
+			Instance: oxide.NameOrId(instance.Id),
+		})
+	})
+
+	groupIP := fmt.Sprintf("239.1.0.%d", rand.IntN(127)+128)
+	_, err = client.ExperimentalInstanceMulticastGroupJoin(
+		ctx,
+		oxide.InstanceMulticastGroupJoinParams{
+			Instance:       oxide.NameOrId(instance.Id),
+			MulticastGroup: oxide.MulticastGroupIdentifier(groupIP),
+			Body:           &oxide.InstanceMulticastGroupJoin{},
+		},
+	)
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "multicast functionality is currently disabled") {
+		t.Skip("multicast functionality is currently disabled in this acceptance environment")
+	}
+	t.Fatalf("failed to join multicast group during precheck: %v", err)
+}
+
 func checkResource(resourceName, instanceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -1894,6 +2096,60 @@ func checkResourceAntiAffinityGroupsUpdate(
 		resource.TestCheckResourceAttr(resourceName, "start_on_create", "false"),
 		resource.TestCheckResourceAttrSet(resourceName, "anti_affinity_groups.0"),
 		resource.TestCheckResourceAttrSet(resourceName, "anti_affinity_groups.1"),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func checkResourceMulticastGroups(
+	resourceName, instanceName, groupIP string,
+) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
+		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "hostname", "terraform-acc-myhost"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "false"),
+		resource.TestCheckResourceAttr(resourceName, "multicast_groups.#", "1"),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			resourceName,
+			"multicast_groups.*",
+			map[string]string{"group": groupIP},
+		),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
+		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
+	}...)
+}
+
+func checkResourceMulticastGroupsUpdate(
+	resourceName, instanceName, groupIP, groupIP2 string,
+) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttr(resourceName, "description", "a test instance"),
+		resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "hostname", "terraform-acc-myhost"),
+		resource.TestCheckResourceAttr(resourceName, "memory", "1073741824"),
+		resource.TestCheckResourceAttr(resourceName, "ncpus", "1"),
+		resource.TestCheckResourceAttr(resourceName, "start_on_create", "false"),
+		resource.TestCheckResourceAttr(resourceName, "multicast_groups.#", "2"),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			resourceName,
+			"multicast_groups.*",
+			map[string]string{"group": groupIP},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			resourceName,
+			"multicast_groups.*",
+			map[string]string{
+				"group":        groupIP2,
+				"source_ips.#": "1",
+			},
+		),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),

--- a/scripts/acc-test-setup.sh
+++ b/scripts/acc-test-setup.sh
@@ -40,6 +40,11 @@ if ! oxide system networking ip-pool view --pool non-default > /dev/null; then
     oxide system networking ip-pool silo link --pool non-default --silo $SILO_NAME --is-default false
     oxide system networking ip-pool range add --first 10.0.2.0 --last 10.0.2.255 --pool non-default
 fi
+if ! oxide system networking ip-pool view --pool non-default-multicast > /dev/null; then
+    oxide system networking ip-pool create --name non-default-multicast --description 'non default multicast' --ip-version v4 --pool-type multicast
+    oxide system networking ip-pool silo link --pool non-default-multicast --silo $SILO_NAME --is-default false
+    oxide system networking ip-pool range add --first 239.1.0.0 --last 239.1.0.255 --pool non-default-multicast
+fi
 
 # The acceptance tests expect both at least a single project-scoped image and a
 # silo-scoped image. Import the same image twice, then promote one copy to the


### PR DESCRIPTION
The `multicast_groups` attribute was added to configure an instance's multicast groups

Closes SSE-338.

