### PR TITLE
tests: refactor `sharedtest.ParsedAccConfig`

### DIFF
--- a/internal/provider/anti_affinity_group/datasource_test.go
+++ b/internal/provider/anti_affinity_group/datasource_test.go
@@ -44,7 +44,7 @@ data "oxide_anti_affinity_group" "{{.BlockName}}" {
 func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-anti-affinity-group")
 	resourceName := sharedtest.NewResourceName()
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:         blockName,
 			SupportBlockName:  sharedtest.NewBlockName("support"),
@@ -53,9 +53,6 @@ func TestAccCloudDataSourceAntiAffinityGroup_full(t *testing.T) {
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/anti_affinity_group/resource_test.go
+++ b/internal/provider/anti_affinity_group/resource_test.go
@@ -62,7 +62,7 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("anti_affinity_group")
 	resourceName := fmt.Sprintf("oxide_anti_affinity_group.%s", blockName)
 	supportBlockName := sharedtest.NewBlockName("support")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupName,
@@ -70,12 +70,9 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	antiAffinityGroupNameUpdated := antiAffinityGroupName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:             blockName,
 			AntiAffinityGroupName: antiAffinityGroupNameUpdated,
@@ -83,9 +80,6 @@ func TestAccCloudResourceAntiAffinityGroup_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/disk/datasource_test.go
+++ b/internal/provider/disk/datasource_test.go
@@ -40,15 +40,12 @@ data "oxide_disk" "test" {
 
 func TestAccCloudDataSourceDisk_full(t *testing.T) {
 	diskName := sharedtest.NewResourceName()
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			DiskName: diskName,
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/disk/resource_test.go
+++ b/internal/provider/disk/resource_test.go
@@ -46,15 +46,12 @@ resource "oxide_disk" "test" {
 
 func TestAccCloudResourceDisk_full(t *testing.T) {
 	diskName := sharedtest.NewResourceName()
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			DiskName: diskName,
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -91,15 +88,12 @@ resource "oxide_disk" "test" {
 func TestAccCloudResourceDisk_local(t *testing.T) {
 	diskName := sharedtest.NewResourceName()
 
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			DiskName: diskName,
 		},
 		resourceLocalConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -134,15 +128,12 @@ resource "oxide_disk" "test" {
 `
 
 func TestAccCloudResourceDisk_localSourceValidation(t *testing.T) {
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			DiskName: sharedtest.NewResourceName(),
 		},
 		resourceLocalInvalidConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -183,27 +174,21 @@ resource "oxide_disk" "test" {
 func TestAccCloudResourceDisk_readOnly(t *testing.T) {
 	diskName := sharedtest.NewResourceName()
 
-	configReadOnly, err := sharedtest.ParsedAccConfig(
+	configReadOnly := sharedtest.ParsedAccConfig(t,
 		resourceReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: true,
 		},
 		resourceReadOnlyConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configReadWrite, err := sharedtest.ParsedAccConfig(
+	configReadWrite := sharedtest.ParsedAccConfig(t,
 		resourceReadOnlyConfig{
 			DiskName: diskName,
 			ReadOnly: false,
 		},
 		resourceReadOnlyConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/external_subnet/resource_test.go
+++ b/internal/provider/external_subnet/resource_test.go
@@ -91,11 +91,7 @@ resource "oxide_external_subnet" "test" {
 
 func buildResourceConfig(t *testing.T, cfg resourceConfig) string {
 	t.Helper()
-	config, err := sharedtest.ParsedAccConfig(cfg, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing config template: %v", err)
-	}
-	return config
+	return sharedtest.ParsedAccConfig(t, cfg, resourceConfigTpl)
 }
 
 func TestAccResourceExternalSubnet_full(t *testing.T) {

--- a/internal/provider/external_subnet_attachment/resource_test.go
+++ b/internal/provider/external_subnet_attachment/resource_test.go
@@ -117,10 +117,7 @@ func buildResourceConfig(
 	cfg resourceConfig,
 ) string {
 	t.Helper()
-	config, err := sharedtest.ParsedAccConfig(cfg, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing config template: %v", err)
-	}
+	config := sharedtest.ParsedAccConfig(t, cfg, resourceConfigTpl)
 	return config
 }
 

--- a/internal/provider/floating_ip/datasource_test.go
+++ b/internal/provider/floating_ip/datasource_test.go
@@ -44,7 +44,7 @@ data "oxide_floating_ip" "{{.BlockName}}" {
 func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-floating-ip")
 	resourceName := sharedtest.NewResourceName()
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:         blockName,
 			SupportBlockName:  sharedtest.NewBlockName("support"),
@@ -53,9 +53,6 @@ func TestAccCloudDataSourceFloatingIP_full(t *testing.T) {
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/floating_ip/resource_test.go
+++ b/internal/provider/floating_ip/resource_test.go
@@ -93,7 +93,7 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("floating_ip")
 	resourceName := fmt.Sprintf("oxide_floating_ip.%s", blockName)
 	supportBlockName := sharedtest.NewBlockName("support")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -101,12 +101,9 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	floatingIPNameUpdated := floatingIPName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPNameUpdated,
@@ -114,11 +111,8 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configV6, err := sharedtest.ParsedAccConfig(
+	configV6 := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -126,11 +120,8 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		},
 		resourceV6ConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configNonDefaultPool, err := sharedtest.ParsedAccConfig(
+	configNonDefaultPool := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			FloatingIPName:   floatingIPName,
@@ -138,9 +129,6 @@ func TestAccCloudResourceFloatingIP_full(t *testing.T) {
 		},
 		resourceNonDefaultPoolConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/image/datasource_test.go
+++ b/internal/provider/image/datasource_test.go
@@ -40,7 +40,7 @@ data "oxide_image" "{{.BlockName}}" {
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImage_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-image")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:         blockName,
 			SupportBlockName:  sharedtest.NewBlockName("support"),
@@ -48,9 +48,6 @@ func TestAccCloudDataSourceImage_full(t *testing.T) {
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/image/resource_test.go
+++ b/internal/provider/image/resource_test.go
@@ -79,7 +79,7 @@ func TestAccCloudResourceImage_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("image")
 	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_image.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:         blockName,
 			ImageName:         imageName,
@@ -91,9 +91,6 @@ func TestAccCloudResourceImage_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/images/datasource_test.go
+++ b/internal/provider/images/datasource_test.go
@@ -42,16 +42,13 @@ data "oxide_images" "{{.BlockName}}" {}
 // NB: The project must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_project(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-images")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceProjectConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceProjectConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -70,15 +67,12 @@ func TestAccCloudDataSourceImages_project(t *testing.T) {
 // NB: The silo must be populated with at least one image for this test to pass
 func TestAccCloudDataSourceImages_silo(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-images")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceSiloConfig{
 			BlockName: blockName,
 		},
 		dataSourceSiloConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -162,7 +162,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	blockName := sharedtest.NewBlockName("instance")
 	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -170,9 +170,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	instanceName2 := sharedtest.NewResourceName()
 	instanceDiskName := sharedtest.NewResourceName()
@@ -188,7 +185,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	supportBlockNameAaGroup := sharedtest.NewBlockName("support-instance-anti-affinity-group")
 	resourceName2 := fmt.Sprintf("oxide_instance.%s", blockName2)
 	autoRestartPolicy := "best_effort"
-	config2, err := sharedtest.ParsedAccConfig(
+	config2 := sharedtest.ParsedAccConfig(t,
 		resourceInstanceFullConfig{
 			BlockName:                  blockName2,
 			InstanceName:               instanceName2,
@@ -206,9 +203,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceFullConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -483,7 +477,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	supportBlockName := sharedtest.NewBlockName("support")
 	ipPoolBlockName := sharedtest.NewBlockName("ip-pool")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	initialConfig, err := sharedtest.ParsedAccConfig(
+	initialConfig := sharedtest.ParsedAccConfig(t,
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -494,11 +488,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceExternalIPConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing initial config template data: %e", err)
-	}
 
-	updateConfig1, err := sharedtest.ParsedAccConfig(
+	updateConfig1 := sharedtest.ParsedAccConfig(t,
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -507,11 +498,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceExternalIPConfigUpdate1Tpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing first update config template data: %e", err)
-	}
 
-	updateConfig1SingleStack, err := sharedtest.ParsedAccConfig(
+	updateConfig1SingleStack := sharedtest.ParsedAccConfig(t,
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -520,11 +508,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceExternalIPConfigUpdate1SingleStackTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing first update single stack config template data: %e", err)
-	}
 
-	updateConfig2, err := sharedtest.ParsedAccConfig(
+	updateConfig2 := sharedtest.ParsedAccConfig(t,
 		resourceInstanceConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -533,9 +518,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceExternalIPConfigUpdate2Tpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing second update config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -624,7 +606,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	supportBlockNameSshKeys := sharedtest.NewBlockName("support-instance-ssh-keys")
 	supportBlockNameSshKeys2 := sharedtest.NewBlockName("support-instance-ssh-keys-2")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameSshKeys)
-	configSshKeys, err := sharedtest.ParsedAccConfig(
+	configSshKeys := sharedtest.ParsedAccConfig(t,
 		resourceInstanceSshKeyConfig{
 			BlockName:         blockNameSshKeys,
 			SshKeyName:        instanceSshKeysName2,
@@ -634,9 +616,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceSSHKeysConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -884,7 +863,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	nonDefaultSubnetName := sharedtest.NewResourceName()
 	nonDefaultSubnetIPv4Block := fmt.Sprintf("10.%d.%d.0/24", rand.IntN(255), rand.IntN(255))
 	nonDefaultSubnetIPv6NetNum := rand.IntN(200)
-	configNic, err := sharedtest.ParsedAccConfig(
+	configNic := sharedtest.ParsedAccConfig(t,
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -897,10 +876,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceNicConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
-	configNicAdd, err := sharedtest.ParsedAccConfig(
+	configNicAdd := sharedtest.ParsedAccConfig(t,
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -913,10 +889,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceNicConfigTwoNICsTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
-	configNicUpdateSingleStack, err := sharedtest.ParsedAccConfig(
+	configNicUpdateSingleStack := sharedtest.ParsedAccConfig(t,
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -929,10 +902,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceNicConfigTwoNICsSingleStackTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
-	configNicDelete, err := sharedtest.ParsedAccConfig(
+	configNicDelete := sharedtest.ParsedAccConfig(t,
 		resourceInstanceNicConfig{
 			BlockName:                  blockNameInstanceNic,
 			SubnetBlockName:            blockNameSubnet,
@@ -945,9 +915,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceNicConfigDeleteNicsTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -1094,7 +1061,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	blockNameInstanceDisk := sharedtest.NewBlockName("instance-disk")
 	blockNameInstanceDisk2 := sharedtest.NewBlockName("instance-disk-2")
 	resourceNameInstanceDisk := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	configDisk, err := sharedtest.ParsedAccConfig(
+	configDisk := sharedtest.ParsedAccConfig(t,
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1106,10 +1073,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceDiskConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
-	configDiskUpdate, err := sharedtest.ParsedAccConfig(
+	configDiskUpdate := sharedtest.ParsedAccConfig(t,
 		resourceInstanceDiskConfig{
 			BlockName:        blockNameInstance,
 			DiskBlockName:    blockNameInstanceDisk,
@@ -1121,9 +1085,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceDiskConfigUpdateTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -1216,7 +1177,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	supportBlockName2 := sharedtest.NewBlockName("support-update")
 	blockNameInstance := sharedtest.NewBlockName("instance")
 	resourceNameInstance := fmt.Sprintf("oxide_instance.%s", blockNameInstance)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1224,11 +1185,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1236,11 +1194,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceConfigUpdateTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configUpdate2, err := sharedtest.ParsedAccConfig(
+	configUpdate2 := sharedtest.ParsedAccConfig(t,
 		resourceInstanceUpdateConfig{
 			BlockName:        blockNameInstance,
 			InstanceName:     instanceName,
@@ -1248,9 +1203,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceConfigUpdate2Tpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -1328,7 +1280,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 	diskBlockName := sharedtest.NewBlockName("disk")
 	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceInstanceNoBootDiskConfig{
 			BlockName:        blockName,
 			InstanceName:     instanceName,
@@ -1338,9 +1290,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceNoBootDiskConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -1474,7 +1423,7 @@ resource "oxide_instance" "{{.BlockName}}" {
 		"support-instance-anti-affinity-group",
 	)
 	resourceName := fmt.Sprintf("oxide_instance.%s", blockNameAntiAffinityGroups)
-	configAntiAffinityGroups, err := sharedtest.ParsedAccConfig(
+	configAntiAffinityGroups := sharedtest.ParsedAccConfig(t,
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                  blockNameAntiAffinityGroups,
 			InstanceName:               instanceAntiAffinityGroupsName,
@@ -1484,11 +1433,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceAntiAffinityGroupsConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configAntiAffinityGroupsUpdate, err := sharedtest.ParsedAccConfig(
+	configAntiAffinityGroupsUpdate := sharedtest.ParsedAccConfig(t,
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1500,11 +1446,8 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceAntiAffinityGroupsConfigTplUpdate,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configAntiAffinityGroupsUpdate2, err := sharedtest.ParsedAccConfig(
+	configAntiAffinityGroupsUpdate2 := sharedtest.ParsedAccConfig(t,
 		resourceInstanceAntiAffinityGroupsConfig{
 			BlockName:                   blockNameAntiAffinityGroups,
 			InstanceName:                instanceAntiAffinityGroupsName,
@@ -1516,9 +1459,6 @@ resource "oxide_instance" "{{.BlockName}}" {
 		},
 		resourceInstanceAntiAffinityGroupsConfigTplUpdate2,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/instance_external_ips/datasource_test.go
+++ b/internal/provider/instance_external_ips/datasource_test.go
@@ -71,7 +71,7 @@ data "oxide_instance_external_ips" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-instance-external-ips")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:         blockName,
 			SupportBlockName:  sharedtest.NewBlockName("support"),
@@ -80,9 +80,6 @@ func TestAccCloudDataSourceInstanceExternalIPs_full(t *testing.T) {
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/ip_pool/datasource_test.go
+++ b/internal/provider/ip_pool/datasource_test.go
@@ -29,16 +29,13 @@ data "oxide_ip_pool" "{{.BlockName}}" {
 
 func TestAccSiloDataSourceIPPool_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-ip-pool")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/ip_pool_silo_link/resource_test.go
+++ b/internal/provider/ip_pool_silo_link/resource_test.go
@@ -106,7 +106,7 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 	supportBlockName := sharedtest.NewBlockName("support")
 	resourceName := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
 	resourceName2 := fmt.Sprintf("oxide_ip_pool_silo_link.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: supportBlockName,
@@ -114,11 +114,8 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfigUpdate{
 			BlockName:         blockName,
 			IPPoolName:        ipPoolName,
@@ -129,9 +126,6 @@ func TestAccSiloResourceIPPoolSiloLink_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/project/datasource_test.go
+++ b/internal/provider/project/datasource_test.go
@@ -29,16 +29,13 @@ data "oxide_project" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceProject_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-project")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/project/resource_test.go
+++ b/internal/provider/project/resource_test.go
@@ -48,28 +48,22 @@ func TestAccCloudResourceProject_full(t *testing.T) {
 	projectName := sharedtest.NewResourceName()
 	blockName := sharedtest.NewBlockName("project")
 	resourceName := fmt.Sprintf("oxide_project.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:   blockName,
 			ProjectName: projectName,
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	projectNameUpdated := projectName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:   blockName,
 			ProjectName: projectNameUpdated,
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/projects/datasource_test.go
+++ b/internal/provider/projects/datasource_test.go
@@ -27,15 +27,12 @@ data "oxide_projects" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceProjects_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-projects")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName: blockName,
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/sharedtest/sharedtest.go
+++ b/internal/provider/sharedtest/sharedtest.go
@@ -56,19 +56,17 @@ func NewTestClient() (*oxide.Client, error) {
 	return client, nil
 }
 
-func ParsedAccConfig(
-	config any,
-	tpl string,
-) (string, error) {
+func ParsedAccConfig(tb testing.TB, config any, tpl string) string {
+	tb.Helper()
 	var buf bytes.Buffer
 	tmpl, err := template.New("test").Parse(tpl)
 	if err != nil {
-		return "", err
+		tb.Fatalf("failed to parse configuration template: %v", err)
 	}
 	if err := tmpl.Execute(&buf, config); err != nil {
-		return "", err
+		tb.Fatalf("failed to execute configuration template: %v", err)
 	}
-	return buf.String(), nil
+	return buf.String()
 }
 
 func NewResourceName() string {

--- a/internal/provider/silo/datasource_test.go
+++ b/internal/provider/silo/datasource_test.go
@@ -90,16 +90,13 @@ func TestAccSiloDataSourceSilo_full(t *testing.T) {
 
 	dnsName := sharedtest.SiloDNSName()
 
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:   blockName,
 			SiloDNSName: dnsName,
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	// Silo creation and deletion can cause database contention in nexus,
 	// so run all related tests in series:

--- a/internal/provider/silo/resource_test.go
+++ b/internal/provider/silo/resource_test.go
@@ -145,7 +145,7 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 
 	dnsName := sharedtest.SiloDNSName()
 
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -153,11 +153,8 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:   blockName,
 			SiloName:    siloName,
@@ -165,9 +162,6 @@ func TestAccSiloResourceSilo_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	// Silo creation and deletion can cause database contention in nexus,
 	// so run all related tests in series:

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -124,7 +124,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 
 	siloDNSName := sharedtest.SiloDNSName()
 
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			SiloBlockName:                     siloBlockName,
 			SiloDNSName:                       siloDNSName,
@@ -134,9 +134,6 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Fatalf("error parsing config template data: %v", err)
-	}
 
 	// Silo creation and deletion can cause database contention in nexus,
 	// so run all related tests in series:
@@ -175,7 +172,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 
 	siloDNSName := sharedtest.SiloDNSName()
 
-	initialConfig, err := sharedtest.ParsedAccConfig(
+	initialConfig := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			SiloBlockName:                     siloBlockName,
 			SiloDNSName:                       siloDNSName,
@@ -185,11 +182,8 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Fatalf("error parsing config template data: %v", err)
-	}
 
-	noSAMLConfig, err := sharedtest.ParsedAccConfig(
+	noSAMLConfig := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			SiloBlockName:                     siloBlockName,
 			SiloDNSName:                       siloDNSName,
@@ -200,9 +194,6 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adopt(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Fatalf("error parsing no SAML config template data: %v", err)
-	}
 
 	// Silo creation and deletion can cause database contention in nexus,
 	// so run all related tests in series:
@@ -256,17 +247,11 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adoptMismatch(t *testing.T) {
 		SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
 	}
 
-	initialConfig, err := sharedtest.ParsedAccConfig(baseConfig, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing initial config: %v", err)
-	}
+	initialConfig := sharedtest.ParsedAccConfig(t, baseConfig, resourceConfigTpl)
 
 	noSAMLBase := baseConfig
 	noSAMLBase.SkipSiloSamlIdentityProvider = true
-	noSAMLConfig, err := sharedtest.ParsedAccConfig(noSAMLBase, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing no-SAML config: %v", err)
-	}
+	noSAMLConfig := sharedtest.ParsedAccConfig(t, noSAMLBase, resourceConfigTpl)
 
 	mutatedBase := baseConfig
 	mutatedBase.SiloSamlIdentityProviderACSURL = "https://mismatched-acs.example.com"
@@ -276,10 +261,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adoptMismatch(t *testing.T) {
 	mutatedBase.SiloSamlIdentityProviderSLOURL = "https://mismatched-slo.example.com"
 	mutatedBase.SiloSamlIdentityProviderSPClientID = "mismatched-client-id"
 	mutatedBase.SiloSamlIdentityProviderTechnicalContactEmail = "mismatched@example.com"
-	mutatedConfig, err := sharedtest.ParsedAccConfig(mutatedBase, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing mutated config: %v", err)
-	}
+	mutatedConfig := sharedtest.ParsedAccConfig(t, mutatedBase, resourceConfigTpl)
 
 	// Records that the ErrorCheck callback ran; verified after resource.Test
 	// returns to enforce that the re-adoption step actually errored.

--- a/internal/provider/snapshot/resource_test.go
+++ b/internal/provider/snapshot/resource_test.go
@@ -64,7 +64,7 @@ func TestAccCloudResourceSnapshot_full(t *testing.T) {
 	snapshotName := sharedtest.NewResourceName()
 	blockName := sharedtest.NewBlockName("snapshot")
 	resourceName := fmt.Sprintf("oxide_snapshot.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			SnapshotName:     snapshotName,
@@ -74,9 +74,6 @@ func TestAccCloudResourceSnapshot_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/ssh_key/datasource_test.go
+++ b/internal/provider/ssh_key/datasource_test.go
@@ -42,7 +42,7 @@ data "oxide_ssh_key" "{{.BlockName}}" {
 func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-ssh-key")
 	resourceName := sharedtest.NewResourceName()
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:         blockName,
 			SupportBlockName:  sharedtest.NewBlockName("support"),
@@ -51,9 +51,6 @@ func TestAccCloudDataSourceSSHKey_full(t *testing.T) {
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/ssh_key/resource_test.go
+++ b/internal/provider/ssh_key/resource_test.go
@@ -46,7 +46,7 @@ func TestAccCloudResourceSSHKey_full(t *testing.T) {
 	publicKey := "ssh-ed25519 AAAA"
 	blockName := sharedtest.NewBlockName("ssh_key")
 	resourceName := fmt.Sprintf("oxide_ssh_key.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:   blockName,
 			Name:        sshKeyName,
@@ -55,9 +55,6 @@ func TestAccCloudResourceSSHKey_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/switch_port_settings/resource_test.go
+++ b/internal/provider/switch_port_settings/resource_test.go
@@ -165,27 +165,21 @@ resource "oxide_switch_port_settings" "{{.BlockName}}" {
 	blockName := sharedtest.NewBlockName("switch-port-settings")
 	resourceName := fmt.Sprintf("oxide_switch_port_settings.%s", blockName)
 
-	initialConfig, err := sharedtest.ParsedAccConfig(
+	initialConfig := sharedtest.ParsedAccConfig(t,
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
 		},
 		initialConfigTmpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing initial config template data: %e", err)
-	}
 
-	updateConfig, err := sharedtest.ParsedAccConfig(
+	updateConfig := sharedtest.ParsedAccConfig(t,
 		resourceSwitchPortSettingsConfig{
 			BlockName:              blockName,
 			SwitchPortSettingsName: switchPortSettingsName,
 		},
 		updateConfigTmpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing update config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/provider/system_ip_pools/datasource_test.go
+++ b/internal/provider/system_ip_pools/datasource_test.go
@@ -28,16 +28,13 @@ data "oxide_system_ip_pools" "{{.BlockName}}" {
 
 func TestAccSiloDataSourceSystemIPPools_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-ip-pool")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc/datasource_test.go
+++ b/internal/provider/vpc/datasource_test.go
@@ -30,16 +30,13 @@ data "oxide_vpc" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceVPC_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-vpc")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc/resource_test.go
+++ b/internal/provider/vpc/resource_test.go
@@ -76,7 +76,7 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc.%s", blockName)
 	supportBlockName := sharedtest.NewBlockName("support")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			VPCName:          vpcName,
@@ -84,12 +84,9 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	vpcNameUpdated := vpcName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName,
 			VPCName:          vpcNameUpdated,
@@ -97,14 +94,11 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	blockName2 := sharedtest.NewBlockName("vpc")
 	resourceName2 := fmt.Sprintf("oxide_vpc.%s", blockName2)
 	vpcName2 := vpcName + "-2"
-	config2, err := sharedtest.ParsedAccConfig(
+	config2 := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			BlockName:        blockName2,
 			VPCName:          vpcName2,
@@ -112,9 +106,6 @@ func TestAccCloudResourceVPC_full(t *testing.T) {
 		},
 		resourceIPv6ConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_firewall_rules/resource_test.go
+++ b/internal/provider/vpc_firewall_rules/resource_test.go
@@ -418,35 +418,17 @@ func TestAccCloudResourceFirewallRules_full(t *testing.T) {
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceConfig{VPCName: vpcName}
 
-	config, err := sharedtest.ParsedAccConfig(tplData, resourceConfigTpl)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
+	config := sharedtest.ParsedAccConfig(t, tplData, resourceConfigTpl)
 
-	configUpdate, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl)
-	if err != nil {
-		t.Errorf("error parsing update config template data: %e", err)
-	}
+	configUpdate := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl)
 
-	configUpdate2, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl2)
-	if err != nil {
-		t.Errorf("error parsing update config 2 template data: %e", err)
-	}
+	configUpdate2 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl2)
 
-	configUpdate3, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl3)
-	if err != nil {
-		t.Errorf("error parsing update config 3 template data: %e", err)
-	}
+	configUpdate3 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl3)
 
-	configUpdate4, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl4)
-	if err != nil {
-		t.Errorf("error parsing update config 4 template data: %e", err)
-	}
+	configUpdate4 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl4)
 
-	configUpdate5, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl5)
-	if err != nil {
-		t.Errorf("error parsing update config 5 template data: %e", err)
-	}
+	configUpdate5 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },
@@ -486,15 +468,9 @@ func TestAccCloudResourceFirewallRules_v1_upgrade(t *testing.T) {
 	resourceName := "oxide_vpc_firewall_rules.test"
 	tplData := resourceConfig{VPCName: vpcName}
 
-	configV1, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTplV1)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
+	configV1 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTplV1)
 
-	configV2, err := sharedtest.ParsedAccConfig(tplData, resourceUpdateConfigTpl5)
-	if err != nil {
-		t.Errorf("error parsing update config template data: %e", err)
-	}
+	configV2 := sharedtest.ParsedAccConfig(t, tplData, resourceUpdateConfigTpl5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { sharedtest.PreCheck(t) },
@@ -530,13 +506,10 @@ func TestAccCloudResourceFirewallRules_icmp_no_filter(t *testing.T) {
 	vpcName := sharedtest.NewResourceName()
 	resourceName := "oxide_vpc_firewall_rules.test"
 
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{VPCName: vpcName},
 		resourceIcmpNoFilterConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_internet_gateway/datasource_test.go
+++ b/internal/provider/vpc_internet_gateway/datasource_test.go
@@ -42,16 +42,13 @@ data "oxide_vpc_internet_gateway" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceVPCInternetGateway_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-vpc-router")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_internet_gateway/resource_test.go
+++ b/internal/provider/vpc_internet_gateway/resource_test.go
@@ -79,7 +79,7 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 	supportBlockName := sharedtest.NewBlockName("support")
 	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_internet_gateway.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -89,11 +89,8 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:                vpcName,
 			SupportBlockName:       supportBlockName,
@@ -103,9 +100,6 @@ func TestAccCloudResourceVPCInternetGateway_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_router/datasource_test.go
+++ b/internal/provider/vpc_router/datasource_test.go
@@ -43,16 +43,13 @@ data "oxide_vpc_router" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceVPCRouter_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-vpc-router")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_router/resource_test.go
+++ b/internal/provider/vpc_router/resource_test.go
@@ -78,7 +78,7 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 	supportBlockName := sharedtest.NewBlockName("support")
 	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -88,12 +88,9 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	routerNameUpdated := routerName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:          vpcName,
 			SupportBlockName: supportBlockName,
@@ -103,9 +100,6 @@ func TestAccCloudResourceVPCRouter_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_router_route/datasource_test.go
+++ b/internal/provider/vpc_router_route/datasource_test.go
@@ -33,16 +33,13 @@ data "oxide_vpc_router_route" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceVPCRouterRoute_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-vpc-router")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_router_route/resource_test.go
+++ b/internal/provider/vpc_router_route/resource_test.go
@@ -148,7 +148,7 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	supportBlockName := sharedtest.NewBlockName("support")
 	vpcBlockName := sharedtest.NewBlockName("vpc")
 	resourceName := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -160,12 +160,9 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 		},
 		resourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	routerRouteNameUpdated := routerRouteName + "-updated"
-	configUpdate, err := sharedtest.ParsedAccConfig(
+	configUpdate := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:            vpcName,
 			SupportBlockName:   supportBlockName,
@@ -177,9 +174,6 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 		},
 		resourceUpdateConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	vpcNameDrop := sharedtest.NewResourceName()
 	routerNameDrop := sharedtest.NewResourceName()
@@ -188,7 +182,7 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 	supportBlockNameDrop := sharedtest.NewBlockName("support")
 	vpcBlockNameDrop := sharedtest.NewBlockName("vpc")
 	resourceNameDrop := fmt.Sprintf("oxide_vpc_router_route.%s", blockName)
-	configDrop, err := sharedtest.ParsedAccConfig(
+	configDrop := sharedtest.ParsedAccConfig(t,
 		resourceConfig{
 			VPCName:            vpcNameDrop,
 			SupportBlockName:   supportBlockNameDrop,
@@ -200,9 +194,6 @@ func TestAccCloudResourceVPCRouterRoute_full(t *testing.T) {
 		},
 		resourceTargetDropConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_subnet/datasource_test.go
+++ b/internal/provider/vpc_subnet/datasource_test.go
@@ -31,16 +31,13 @@ data "oxide_vpc_subnet" "{{.BlockName}}" {
 
 func TestAccCloudDataSourceVPCSubnet_full(t *testing.T) {
 	blockName := sharedtest.NewBlockName("datasource-vpc-subnet")
-	config, err := sharedtest.ParsedAccConfig(
+	config := sharedtest.ParsedAccConfig(t,
 		dataSourceConfig{
 			BlockName:        blockName,
 			SupportBlockName: sharedtest.NewBlockName("support"),
 		},
 		dataSourceConfigTpl,
 	)
-	if err != nil {
-		t.Errorf("error parsing config template data: %e", err)
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { sharedtest.PreCheck(t) },

--- a/internal/provider/vpc_subnet/resource_test.go
+++ b/internal/provider/vpc_subnet/resource_test.go
@@ -58,11 +58,7 @@ resource "oxide_vpc_subnet" "test" {
 
 func buildResourceConfig(t *testing.T, cfg resourceConfig) string {
 	t.Helper()
-	config, err := sharedtest.ParsedAccConfig(cfg, resourceConfigTpl)
-	if err != nil {
-		t.Fatalf("error parsing config template: %v", err)
-	}
-	return config
+	return sharedtest.ParsedAccConfig(t, cfg, resourceConfigTpl)
 }
 
 func TestAccCloudResourceVPCSubnet_full(t *testing.T) {


### PR DESCRIPTION
Refactor `sharedtest.ParsedAccConfig` to take `t` as in input, simplifying and standardizing error handling.

