### PR TITLE
misc: update golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,12 @@
+---
 version: "2"
 
 linters:
   default: standard
   enable:
     - godoclint
+    - unparam
+    - goheader
   disable:
     - errcheck
   settings:
@@ -14,12 +17,16 @@ linters:
       options:
         max-len:
           length: 100
+    goheader:
+      template: |-
+        This Source Code Form is subject to the terms of the Mozilla Public
+        License, v. 2.0. If a copy of the MPL was not distributed with this
+        file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 formatters:
   enable:
-    - gofmt
-    - golines
     - goimports
+    - golines
   settings:
     golines:
       max-len: 100
@@ -27,6 +34,8 @@ formatters:
     goimports:
       local-prefixes:
         - github.com/oxidecomputer/terraform-provider-oxide
+  exclusions:
+    generated: disable
 
 run:
   timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ fmt: golangci-fmt terrafmt-fmt docs
 golangci-fmt:
 	@ echo "-> Formatting Go code"
 	@ $(GO_TOOL) golangci-lint fmt
+	@ $(GO_TOOL) golangci-lint run --enable-only=goheader --fix
 
 .PHONY: terrafmt
 terrafmt:

--- a/internal/provider/address_lot/resource_test.go
+++ b/internal/provider/address_lot/resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package addresslot_test
 
 import (

--- a/internal/provider/credentials/function.go
+++ b/internal/provider/credentials/function.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package credentials
 
 import (

--- a/internal/provider/credentials/function_test.go
+++ b/internal/provider/credentials/function_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package credentials_test
 
 import (

--- a/internal/provider/instance/resource_v1.go
+++ b/internal/provider/instance/resource_v1.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package instance
 
 import (

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package provider_test
 
 import (

--- a/internal/provider/shared/planmodifiers.go
+++ b/internal/provider/shared/planmodifiers.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package shared
 
 import (

--- a/internal/provider/vpc_firewall_rules/resource_test.go
+++ b/internal/provider/vpc_firewall_rules/resource_test.go
@@ -445,7 +445,7 @@ func TestAccCloudResourceFirewallRules_full(t *testing.T) {
 			},
 			{
 				Config: configUpdate2,
-				Check:  checkResourceUpdate2(resourceName, vpcName),
+				Check:  checkResourceUpdate2(resourceName),
 			},
 			{
 				Config: configUpdate3,
@@ -650,7 +650,7 @@ func checkResourceUpdate(resourceName string) resource.TestCheckFunc {
 	}...)
 }
 
-func checkResourceUpdate2(resourceName, vpcName string) resource.TestCheckFunc {
+func checkResourceUpdate2(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
 		resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),


### PR DESCRIPTION
Updated `golangci-lint` rules to enforce the license header and error on unused parameters.