### PR TITLE
fix(oxide_system_ip_pools): use system_ip_pool_list api

### DIFF
--- a/.changelog/0.21.0.toml
+++ b/.changelog/0.21.0.toml
@@ -15,3 +15,7 @@ description = "The `silo_id` attribute now resolves to the silo's UUID, even if 
 [[bugs]]
 title = "`oxide_subnet_pool_silo_link`"
 description = "The `silo_id` attribute now resolves to the silo's UUID, even if the attribute was previously configured by name. [#795](https://github.com/oxidecomputer/terraform-provider-oxide/pull/795)."
+
+[[bugs]]
+title = "`oxide_system_ip_pools`"
+description = "The `oxide_system_ip_pools` data source now uses the `system_ip_pool_list` API, allowing it to read all the IP pools for the system.. [#807](https://github.com/oxidecomputer/terraform-provider-oxide/pull/807)."

--- a/internal/provider/system_ip_pools/datasource.go
+++ b/internal/provider/system_ip_pools/datasource.go
@@ -131,10 +131,10 @@ func (d *DataSource) Read(
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	params := oxide.IpPoolListParams{
+	params := oxide.SystemIpPoolListParams{
 		SortBy: oxide.NameOrIdSortModeIdAscending,
 	}
-	ipPools, err := d.client.IpPoolListAllPages(ctx, params)
+	ipPools, err := d.client.SystemIpPoolListAllPages(ctx, params)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read system IP pools list:",


### PR DESCRIPTION
Updated the `oxide_system_ip_pools` data source to use the `system_ip_pool_list` API, allowing it to read all the IP pools for the system. This was missed when https://github.com/oxidecomputer/omicron/issues/9838 landed but now resolved.

Resolves SSE-418.

