### PR TITLE
oxide_switch_port_settings: mark the md5_auth_key attribute as sensitive

### DIFF
--- a/.changelog/0.21.0.toml
+++ b/.changelog/0.21.0.toml
@@ -8,6 +8,10 @@ description = "The `id` attribute for the `oxide_ip_pool_silo_link` resource now
 title = "Validate UUID Attributes"
 description = "Attributes that expect UUIDs now validate whether their values are, in fact, valid UUIDs. This catches cases where names passed to attributes expecting UUIDs accidentally worked. [#795](https://github.com/oxidecomputer/terraform-provider-oxide/pull/795)."
 
+[[enhancements]]
+title = "`oxide_switch_port_settings`"
+description = "The `md5_auth_key` attribute is now configured to be sensitive. [#808](https://github.com/oxidecomputer/terraform-provider-oxide/pull/808)."
+
 [[bugs]]
 title = "`oxide_ip_pool_silo_link`"
 description = "The `silo_id` attribute now resolves to the silo's UUID, even if the attribute was previously configured by name. [#795](https://github.com/oxidecomputer/terraform-provider-oxide/pull/795)."

--- a/internal/provider/switch_port_settings/resource.go
+++ b/internal/provider/switch_port_settings/resource.go
@@ -381,6 +381,7 @@ This resource manages switch port settings.
 										Description: "BGP local preference value for routes received from this peer.",
 									},
 									"md5_auth_key": schema.StringAttribute{
+										Sensitive:   true,
 										Optional:    true,
 										Description: "MD5 authentication key for this BGP session.",
 									},


### PR DESCRIPTION
The `oxide_switch_port_settings.md5_auth_key` attribute is now configured to be sensitive.
