### PR TITLE
fix(oxide_silo): mark tls_certificates[].key attribute sensitive

### DIFF
--- a/.changelog/0.21.0.toml
+++ b/.changelog/0.21.0.toml
@@ -23,3 +23,7 @@ description = "The `silo_id` attribute now resolves to the silo's UUID, even if 
 [[bugs]]
 title = "`oxide_system_ip_pools`"
 description = "The `oxide_system_ip_pools` data source now uses the `system_ip_pool_list` API, allowing it to read all the IP pools for the system.. [#807](https://github.com/oxidecomputer/terraform-provider-oxide/pull/807)."
+
+[[bugs]]
+title = "`oxide_silo`"
+description = "The `tls_certificates[].key` attribute is now marked sensitive and its cleartext value no longer logged in debug mode, resolving [Oxide Security Advisory 20260804-1](https://docs.oxide.computer/security/advisories/20260804-1). [#810](https://github.com/oxidecomputer/terraform-provider-oxide/pull/810)"

--- a/internal/provider/silo/resource.go
+++ b/internal/provider/silo/resource.go
@@ -214,6 +214,7 @@ attributes will result in the silo being destroyed and created anew.
 						"key": schema.StringAttribute{
 							Required:    true,
 							WriteOnly:   true,
+							Sensitive:   true,
 							Description: "PEM-formatted string containing private key.",
 						},
 						"service": schema.StringAttribute{
@@ -345,8 +346,6 @@ func (r *Resource) Create(
 			TlsCertificates: tlsCertsModelToCertificateCreateSlice(plan.TlsCertificates),
 		},
 	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Silo creation parameters: %+v", params.Body.TlsCertificates), nil)
 
 	silo, err := r.client.SiloCreate(ctx, params)
 	if err != nil {


### PR DESCRIPTION
The `oxide_silo`'s `tls_certificates[].key` attribute is now marked sensitive and its cleartext value no longer logged in debug mode, resolving Oxide Security Advisory 20260804-1.

The attribute was already write-only to keep it out of Terraform state but nothing prevented it from being printed in CLI output or logs.

Resolves SSE-421.
