### PR TITLE
feat(oxide_silo_saml_identity_provider): support import and mark attributes write-only

### DIFF
--- a/.changelog/0.22.0.toml
+++ b/.changelog/0.22.0.toml
@@ -7,8 +7,12 @@ title = ""
 description = ""
 
 [[enhancements]]
-title = ""
-description = ""
+title = "`oxide_silo_saml_identity_provider`"
+description = "The `idp_metadata_source` and `signing_keypair.private_key` attributes are now write-only. [#819](https://github.com/oxidecomputer/terraform-provider-oxide/pull/819)"
+
+[[enhancements]]
+title = "`oxide_silo_saml_identity_provider`"
+description = "The `oxide_silo_saml_identity_provider` resource can now be imported. [#819](https://github.com/oxidecomputer/terraform-provider-oxide/pull/819)"
 
 [[bugs]]
 title = ""

--- a/docs/resources/silo_saml_identity_provider.md
+++ b/docs/resources/silo_saml_identity_provider.md
@@ -54,12 +54,12 @@ resource "oxide_silo_saml_identity_provider" "example" {
 
   idp_metadata_source = {
     type = "base64_encoded_xml"
-    data = base64encode(file("${path.module}/idp-metadata.xml"))
+    data = filebase64("${path.module}/idp-metadata.xml")
   }
 
   signing_keypair = {
-    private_key = base64encode(file("${path.module}/saml-key.pem"))
-    public_cert = base64encode(file("${path.module}/saml-cert.pem"))
+    private_key = filebase64("${path.module}/saml-key.der")
+    public_cert = filebase64("${path.module}/saml-cert.der")
   }
 }
 ```
@@ -69,10 +69,12 @@ resource "oxide_silo_saml_identity_provider" "example" {
 
 ### Required
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `acs_url` (String) URL where the identity provider should send the SAML response.
 - `description` (String) Free-form text describing the SAML identity provider.
 - `idp_entity_id` (String) Identity provider's entity ID.
-- `idp_metadata_source` (Attributes) Source of identity provider metadata (URL or base64-encoded XML). (see [below for nested schema](#nestedatt--idp_metadata_source))
+- `idp_metadata_source` (Attributes, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Source of identity provider metadata (URL or base64-encoded XML). (see [below for nested schema](#nestedatt--idp_metadata_source))
 - `name` (String) Unique, immutable, user-controlled identifier of the SAML identity provider.
 - `silo` (String) Name or ID of the silo.
 - `slo_url` (String) URL where the identity provider should send logout requests.
@@ -96,12 +98,12 @@ resource "oxide_silo_saml_identity_provider" "example" {
 
 Required:
 
-- `type` (String) The type of metadata source. Must be one of: `url`, `base64_encoded_xml`.
+- `type` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The type of metadata source. Must be one of: `url`, `base64_encoded_xml`.
 
 Optional:
 
-- `data` (String) Base64-encoded XML metadata (required when type is `base64_encoded_xml`). Conflicts with `url`.
-- `url` (String) URL to fetch metadata from (required when type is `url`). Conflicts with `data`.
+- `data` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Base64-encoded XML metadata (required when type is `base64_encoded_xml`). Conflicts with `url`.
+- `url` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) URL to fetch metadata from (required when type is `url`). Conflicts with `data`.
 
 
 <a id="nestedatt--signing_keypair"></a>
@@ -109,8 +111,8 @@ Optional:
 
 Required:
 
-- `private_key` (String, Sensitive) RSA private key (base64 encoded).
-- `public_cert` (String) Public certificate (base64 encoded).
+- `private_key` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Request signing RSA private key in PKCS#1 DER format (base64 encoded).
+- `public_cert` (String) Request signing public certificate in DER format (base64 encoded).
 
 
 <a id="nestedatt--timeouts"></a>
@@ -120,3 +122,13 @@ Optional:
 
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+terraform import oxide_silo_saml_identity_provider.example 508d32b8-3685-43b6-846f-f339f3100ed9
+```

--- a/examples/resources/oxide_silo_saml_identity_provider/import.sh
+++ b/examples/resources/oxide_silo_saml_identity_provider/import.sh
@@ -1,0 +1,1 @@
+terraform import oxide_silo_saml_identity_provider.example 508d32b8-3685-43b6-846f-f339f3100ed9

--- a/examples/resources/oxide_silo_saml_identity_provider/resource.tf
+++ b/examples/resources/oxide_silo_saml_identity_provider/resource.tf
@@ -29,11 +29,11 @@ resource "oxide_silo_saml_identity_provider" "example" {
 
   idp_metadata_source = {
     type = "base64_encoded_xml"
-    data = base64encode(file("${path.module}/idp-metadata.xml"))
+    data = filebase64("${path.module}/idp-metadata.xml")
   }
 
   signing_keypair = {
-    private_key = base64encode(file("${path.module}/saml-key.pem"))
-    public_cert = base64encode(file("${path.module}/saml-cert.pem"))
+    private_key = filebase64("${path.module}/saml-key.der")
+    public_cert = filebase64("${path.module}/saml-cert.der")
   }
 }

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -433,9 +433,7 @@ func (r *Resource) Read(
 	state.Description = types.StringValue(idpConfig.Description)
 	state.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
 	state.Name = types.StringValue(string(idpConfig.Name))
-	if idpConfig.PublicCert == "" {
-		state.SigningKeypair = nil
-	} else {
+	if idpConfig.PublicCert != "" {
 		state.SigningKeypair = &SigningKeypairResourceModel{
 			PrivateKey: types.StringNull(),
 			PublicCert: types.StringValue(idpConfig.PublicCert),
@@ -503,33 +501,9 @@ func (r *Resource) UpgradeState(
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema:   &priorSchema,
-			StateUpgrader: r.stateUpgraderV0ToCurrent,
+			StateUpgrader: r.stateUpgraderV0,
 		},
 	}
-}
-
-// stateUpgraderV0ToCurrent updates the v0 state to current.
-func (r *Resource) stateUpgraderV0ToCurrent(
-	ctx context.Context,
-	req resource.UpgradeStateRequest,
-	resp *resource.UpgradeStateResponse,
-) {
-	var state ResourceModel
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Explicitly remove write-only attributes from state. The Terraform plugin
-	// framework does this automatically but having this here makes it easier to
-	// understand the intentions of the state upgrade.
-	state.IdpMetadataSource = nil
-	if state.SigningKeypair != nil {
-		state.SigningKeypair.PrivateKey = types.StringNull()
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // diff returns diagnostics for any attributes that differ between the

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -24,8 +24,10 @@ import (
 )
 
 var (
-	_ resource.Resource              = (*Resource)(nil)
-	_ resource.ResourceWithConfigure = (*Resource)(nil)
+	_ resource.Resource                 = (*Resource)(nil)
+	_ resource.ResourceWithConfigure    = (*Resource)(nil)
+	_ resource.ResourceWithImportState  = (*Resource)(nil)
+	_ resource.ResourceWithUpgradeState = (*Resource)(nil)
 )
 
 // NewResource returns a new silo SAML identity provider resource.
@@ -92,6 +94,7 @@ func (r *Resource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		MarkdownDescription: `
 Manages a SAML identity provider (IdP) for an Oxide silo.
 
@@ -128,10 +131,12 @@ Terraform, it will be removed from state but will continue to exist in Oxide.
 			},
 			"idp_metadata_source": schema.SingleNestedAttribute{
 				Required:    true,
+				WriteOnly:   true,
 				Description: "Source of identity provider metadata (URL or base64-encoded XML).",
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
 						Required:            true,
+						WriteOnly:           true,
 						MarkdownDescription: "The type of metadata source. Must be one of: `url`, `base64_encoded_xml`.",
 						Validators: []validator.String{
 							stringvalidator.OneOf(
@@ -142,6 +147,7 @@ Terraform, it will be removed from state but will continue to exist in Oxide.
 					},
 					"url": schema.StringAttribute{
 						Optional:            true,
+						WriteOnly:           true,
 						MarkdownDescription: "URL to fetch metadata from (required when type is `url`). Conflicts with `data`.",
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(
@@ -151,6 +157,7 @@ Terraform, it will be removed from state but will continue to exist in Oxide.
 					},
 					"data": schema.StringAttribute{
 						Optional:            true,
+						WriteOnly:           true,
 						MarkdownDescription: "Base64-encoded XML metadata (required when type is `base64_encoded_xml`). Conflicts with `url`.",
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(
@@ -173,12 +180,13 @@ Terraform, it will be removed from state but will continue to exist in Oxide.
 				Attributes: map[string]schema.Attribute{
 					"private_key": schema.StringAttribute{
 						Required:    true,
+						WriteOnly:   true,
 						Sensitive:   true,
-						Description: "RSA private key (base64 encoded).",
+						Description: "Request signing RSA private key in PKCS#1 DER format (base64 encoded).",
 					},
 					"public_cert": schema.StringAttribute{
 						Required:    true,
-						Description: "Public certificate (base64 encoded).",
+						Description: "Request signing public certificate in DER format (base64 encoded).",
 					},
 				},
 			},
@@ -222,6 +230,24 @@ func (r *Resource) Create(
 		return
 	}
 
+	// Fetch write-only attributes from the configuration instead of the plan, as
+	// documented by the plugin framework.
+	var idpMetadataSourceConfig *MetadataSourceResourceModel
+	resp.Diagnostics.Append(req.Config.GetAttribute(
+		ctx,
+		path.Root("idp_metadata_source"),
+		&idpMetadataSourceConfig,
+	)...)
+	var signingKeypairConfig *SigningKeypairResourceModel
+	resp.Diagnostics.Append(req.Config.GetAttribute(
+		ctx,
+		path.Root("signing_keypair"),
+		&signingKeypairConfig,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createTimeout, diags := plan.Timeouts.Create(ctx, shared.DefaultTimeout())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -232,17 +258,17 @@ func (r *Resource) Create(
 	defer cancel()
 
 	var idpMetadataSource oxide.IdpMetadataSource
-	switch oxide.IdpMetadataSourceType(plan.IdpMetadataSource.Type.ValueString()) {
+	switch oxide.IdpMetadataSourceType(idpMetadataSourceConfig.Type.ValueString()) {
 	case oxide.IdpMetadataSourceTypeBase64EncodedXml:
 		idpMetadataSource = oxide.IdpMetadataSource{
 			Value: &oxide.IdpMetadataSourceBase64EncodedXml{
-				Data: plan.IdpMetadataSource.Data.ValueString(),
+				Data: idpMetadataSourceConfig.Data.ValueString(),
 			},
 		}
 	case oxide.IdpMetadataSourceTypeUrl:
 		idpMetadataSource = oxide.IdpMetadataSource{
 			Value: &oxide.IdpMetadataSourceUrl{
-				Url: plan.IdpMetadataSource.Url.ValueString(),
+				Url: idpMetadataSourceConfig.Url.ValueString(),
 			},
 		}
 	default:
@@ -250,7 +276,7 @@ func (r *Resource) Create(
 			"Invalid IDP metadata source type",
 			fmt.Sprintf(
 				"Unexpected IDP metadata source type: %s",
-				plan.IdpMetadataSource.Type.ValueString(),
+				idpMetadataSourceConfig.Type.ValueString(),
 			),
 		)
 		return
@@ -271,10 +297,10 @@ func (r *Resource) Create(
 		},
 	}
 
-	if plan.SigningKeypair != nil {
+	if signingKeypairConfig != nil {
 		params.Body.SigningKeypair = oxide.DerEncodedKeyPair{
-			PrivateKey: plan.SigningKeypair.PrivateKey.ValueString(),
-			PublicCert: plan.SigningKeypair.PublicCert.ValueString(),
+			PrivateKey: signingKeypairConfig.PrivateKey.ValueString(),
+			PublicCert: signingKeypairConfig.PublicCert.ValueString(),
 		}
 	}
 
@@ -283,9 +309,8 @@ func (r *Resource) Create(
 	if errors.Is(err, oxide.ErrObjectAlreadyExists) {
 		// Read the remote state from the Oxide Control Plane.
 		// The response does not include all parameters from the Create.
-		// The idp_metadata_source and the signing_keypair.private_key attributes are not returned
-		// from the API on a read. In those cases, the plan includes the user-provided values from
-		// the configuration.
+		// The idp_metadata_source and signing_keypair.private_key attributes are
+		// not returned from the API on a read.
 		idpConfig, err = r.client.SamlIdentityProviderView(
 			ctx,
 			oxide.SamlIdentityProviderViewParams{
@@ -304,7 +329,10 @@ func (r *Resource) Create(
 		// Diff the remote state with the configuration before adopting the resource
 		// If any parameters differ, diagnostics are returned and we should abort to display
 		// errors to the user.
-		if diagnostics := plan.Diff(idpConfig); diagnostics.HasError() {
+		if diagnostics := plan.diff(
+			idpConfig,
+			signingKeypairConfig,
+		); diagnostics.HasError() {
 			resp.Diagnostics.Append(diagnostics...)
 			return
 		}
@@ -405,6 +433,14 @@ func (r *Resource) Read(
 	state.Description = types.StringValue(idpConfig.Description)
 	state.IdpEntityId = types.StringValue(idpConfig.IdpEntityId)
 	state.Name = types.StringValue(string(idpConfig.Name))
+	if idpConfig.PublicCert == "" {
+		state.SigningKeypair = nil
+	} else {
+		state.SigningKeypair = &SigningKeypairResourceModel{
+			PrivateKey: types.StringNull(),
+			PublicCert: types.StringValue(idpConfig.PublicCert),
+		}
+	}
 	state.SloUrl = types.StringValue(idpConfig.SloUrl)
 	state.SpClientId = types.StringValue(idpConfig.SpClientId)
 	state.TechnicalContactEmail = types.StringValue(idpConfig.TechnicalContactEmail)
@@ -449,17 +485,67 @@ func (r *Resource) Delete(
 	)
 }
 
-// Diff returns diagnostics for any attributes that differ between the
+// ImportState implements [resource.ResourceWithImportState].
+func (r *Resource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// UpgradeState implements [resource.ResourceWithUpgradeState].
+func (r *Resource) UpgradeState(
+	ctx context.Context,
+) map[int64]resource.StateUpgrader {
+	priorSchema := r.schemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &priorSchema,
+			StateUpgrader: r.stateUpgraderV0ToCurrent,
+		},
+	}
+}
+
+// stateUpgraderV0ToCurrent updates the v0 state to current.
+func (r *Resource) stateUpgraderV0ToCurrent(
+	ctx context.Context,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+) {
+	var state ResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Explicitly remove write-only attributes from state. The Terraform plugin
+	// framework does this automatically but having this here makes it easier to
+	// understand the intentions of the state upgrade.
+	state.IdpMetadataSource = nil
+	if state.SigningKeypair != nil {
+		state.SigningKeypair.PrivateKey = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// diff returns diagnostics for any attributes that differ between the
 // configuration (m) and the remote IdP state. It only compares
 // attributes the Oxide API returns on read; idp_metadata_source and
 // signing_keypair.private_key are not returned and therefore cannot be diffed.
-func (m ResourceModel) Diff(remote *oxide.SamlIdentityProvider) diag.Diagnostics {
+func (m ResourceModel) diff(
+	remote *oxide.SamlIdentityProvider,
+	signingKeypairConfig *SigningKeypairResourceModel,
+) diag.Diagnostics {
 	// signing_keypair is optional; when the block is absent, treat the
 	// public_cert as the empty string so the comparison flags a mismatch
 	// when the remote IdP has a cert configured.
 	var signingPublicCert string
-	if m.SigningKeypair != nil {
-		signingPublicCert = m.SigningKeypair.PublicCert.ValueString()
+	if signingKeypairConfig != nil {
+		signingPublicCert = signingKeypairConfig.PublicCert.ValueString()
 	}
 
 	checks := []struct {

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -11,13 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
+	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
 type resourceConfig struct {
@@ -35,6 +34,7 @@ type resourceConfig struct {
 	SiloSamlIdentityProviderTechnicalContactEmail  string
 	SkipSiloSamlIdentityProviderGroupAttributeName bool
 	SkipSiloSamlIdentityProvider                   bool
+	IncludeSigningKeypair                          bool
 }
 
 var resourceConfigTpl = `
@@ -107,6 +107,14 @@ resource "oxide_silo_saml_identity_provider" "{{.SiloSamlIdentityProviderBlockNa
     type = "base64_encoded_xml"
     data = "PG1kOkVudGl0eURlc2NyaXB0b3IKCXhtbG5zPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6bWV0YWRhdGEiCgl4bWxuczptZD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm1ldGFkYXRhIgoJeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIKCXhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIiBlbnRpdHlJRD0iaHR0cHM6Ly9leGFtcGxlLmNvbSI+Cgk8bWQ6SURQU1NPRGVzY3JpcHRvciBXYW50QXV0aG5SZXF1ZXN0c1NpZ25lZD0idHJ1ZSIgcHJvdG9jb2xTdXBwb3J0RW51bWVyYXRpb249InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCI+CgkJPG1kOktleURlc2NyaXB0b3IgdXNlPSJzaWduaW5nIj4KCQkJPGRzOktleUluZm8+CgkJCQk8ZHM6S2V5TmFtZT5xWlc3N3I2Vy1NQVhCQURPWkdfb0lVeGlWSmhzWHJGa2tEUlFlQWREYzhjPC9kczpLZXlOYW1lPgoJCQkJPGRzOlg1MDlEYXRhPgoJCQkJCTxkczpYNTA5Q2VydGlmaWNhdGU+TUlJQ3VUQ0NBYUVDQmdHVUdOYUluekFOQmdrcWhraUc5dzBCQVFzRkFEQWdNUjR3SEFZRFZRUUREQlZrWlcxdkxUQXdaakF6WWpoaFpEUmpaVFExT0RJd0hoY05NalF4TWpNd01UZ3pNREF3V2hjTk16UXhNak13TVRnek1UUXdXakFnTVI0d0hBWURWUVFEREJWa1pXMXZMVEF3WmpBellqaGhaRFJqWlRRMU9ESXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDc04yR2Y4Z040b0hHSVI3NXZTaDBZakc0ejFyNytLSGx2cG84QnZmRm9hVk5QR255NHNOMVJGdlI5V25pOVMvM0lXRHNjaDV3NTZnMnk3MFNYcmloUWVKZUptUHhucVd1cUFuSDVLeUgxcjFZeVNqK3pHRGJpRHJyM3pBNlYvdFErUHlJZ0R1cUEvaGg1cmxoRndwOEdQRndnZFBCNTEyK2x5MmR5bTkzQ1BrdDdTdk1KQXhlOHFWYWZPTU9nVEIzcUdiT25jSDdYd1BMMnlhTUhKYUlsTFMwSHh5Ti81S1RrUk5aZERwb25JTFYvajlZT2hZSDdJRDl3c3Y2dlR2NnM3Y3BST0dPMmdFOUVPM1pzTTlwUWlxMjN0RGlTUjloY3BvT2piOElyc0VzMXYxZDlkUGRTV2xybSt4L0U1THlZb1VVT1RUdnlpWDdrU0dPVVFMbS9BZ01CQUFFd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFHTGhBSXlITURVSk9QNkttNzRIYjhUSncxdVh4bVJXRjBRcDBza1BtcUxFSEdRYVpic0R4YVBNYzR0ZDI2TUY0R2dMZ2FNZXVnQlkwZk12d0ErMGJDR0EwY2hLVWpJQUwybEg0UGpzVG15cGliVWMySDFlU1BsOTNoYlBzaTFPSm85bTRvblVHcmg3Z3hHWWJ5Tm85R0tBemgvMmZyZVNRbE82K1pmZkdmSlhabEtTT3pnangzcUVYOTc1N2t1Q3VYWVdtQ3hGbmROd0h2ZjdOTVJENUlQOHRYeEN4a09sbUFBZjRKbUlBbnNsNVp1KzR6K0NuZE1vNkYxMjFsT0t4Tkt2Y0ZYaHFQaHJyd1krZlFreEpXdWprVGp2dTRTN1FsM0dOMzVDWURZdDg5a2drL212VmVCaHVRd1pBR3dWRzE3RnlsN3BNRlFyTGtUQ2ErQmJyY1U9PC9kczpYNTA5Q2VydGlmaWNhdGU+CgkJCQk8L2RzOlg1MDlEYXRhPgoJCQk8L2RzOktleUluZm8+CgkJPC9tZDpLZXlEZXNjcmlwdG9yPgoJCTxtZDpBcnRpZmFjdFJlc29sdXRpb25TZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpTT0FQIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIgaW5kZXg9IjAiLz4KCQk8bWQ6U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLVJlZGlyZWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLUFydGlmYWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpTaW5nbGVMb2dvdXRTZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpTT0FQIiBMb2NhdGlvbj0iaHR0cHM6Ly9leGFtcGxlLmNvbSIvPgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvbWQ6TmFtZUlERm9ybWF0PgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50PC9tZDpOYW1lSURGb3JtYXQ+CgkJPG1kOk5hbWVJREZvcm1hdD51cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoxLjE6bmFtZWlkLWZvcm1hdDp1bnNwZWNpZmllZDwvbWQ6TmFtZUlERm9ybWF0PgoJCTxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9tZDpOYW1lSURGb3JtYXQ+CgkJPG1kOlNpbmdsZVNpZ25PblNlcnZpY2UgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1SZWRpcmVjdCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6U09BUCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCQk8bWQ6U2luZ2xlU2lnbk9uU2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1BcnRpZmFjdCIgTG9jYXRpb249Imh0dHBzOi8vZXhhbXBsZS5jb20iLz4KCTwvbWQ6SURQU1NPRGVzY3JpcHRvcj4KPC9tZDpFbnRpdHlEZXNjcmlwdG9yPgo="
   }
+
+  {{ if .IncludeSigningKeypair }}
+  signing_keypair = {
+    # PEM bodies are already base64-encoded DER; remove the PEM encapsulation.
+    private_key = replace(tls_private_key.self-signed.private_key_pem, "/-----[^-]+-----|[[:space:]]/", "")
+    public_cert = replace(tls_self_signed_cert.self-signed.cert_pem, "/-----[^-]+-----|[[:space:]]/", "")
+  }
+  {{ end }}
 }
 {{ end }}
 `
@@ -131,6 +139,7 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 			SiloName:                          siloName,
 			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
 			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+			IncludeSigningKeypair:             true,
 		},
 		resourceConfigTpl,
 	)
@@ -150,8 +159,69 @@ func TestAccSiloResourceSiloSamlIdentityProvider_full(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: checkResource(
+				Check: checkResourceWithSigningKeypair(
 					siloSamlIdentityProviderResourceID,
+					siloSamlIdentityProviderName,
+				),
+			},
+			{
+				ResourceName:            siloSamlIdentityProviderResourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"silo"},
+			},
+		},
+	})
+}
+
+func TestAccSiloResourceSiloSamlIdentityProvider_v0Upgrade(t *testing.T) {
+	siloBlockName := sharedtest.NewBlockName("silo")
+	siloName := sharedtest.NewResourceName()
+	siloSamlIdentityProviderBlockName := sharedtest.NewBlockName("silo-idp")
+	siloSamlIdentityProviderName := sharedtest.NewResourceName()
+	resourceName := fmt.Sprintf(
+		"oxide_silo_saml_identity_provider.%s",
+		siloSamlIdentityProviderBlockName,
+	)
+
+	config := sharedtest.ParsedAccConfig(t,
+		resourceConfig{
+			SiloBlockName:                     siloBlockName,
+			SiloDNSName:                       sharedtest.SiloDNSName(),
+			SiloName:                          siloName,
+			SiloSamlIdentityProviderBlockName: siloSamlIdentityProviderBlockName,
+			SiloSamlIdentityProviderName:      siloSamlIdentityProviderName,
+			IncludeSigningKeypair:             true,
+		},
+		resourceConfigTpl,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { sharedtest.PreCheck(t) },
+		CheckDestroy: testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"oxide": {
+						Source:            "registry.terraform.io/oxidecomputer/oxide",
+						VersionConstraint: "0.21.0",
+					},
+					"tls": {
+						Source: "hashicorp/tls",
+					},
+				},
+				Config: config,
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"tls": {
+						Source: "hashicorp/tls",
+					},
+				},
+				ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+				Config:                   config,
+				Check: checkResourceWithSigningKeypair(
+					resourceName,
 					siloSamlIdentityProviderName,
 				),
 			},
@@ -336,11 +406,24 @@ func TestAccSiloResourceSiloSamlIdentityProvider_adoptMismatch(t *testing.T) {
 	}
 }
 
+func checkResourceWithSigningKeypair(
+	resourceID string,
+	nameAttr string,
+) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkResource(resourceID, nameAttr),
+		resource.TestCheckResourceAttrSet(
+			resourceID,
+			"signing_keypair.public_cert",
+		),
+	)
+}
+
 func checkResource(
 	resourceID string,
 	nameAttr string,
 ) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttrSet(resourceID, "id"),
 		resource.TestCheckResourceAttr(resourceID, "name", nameAttr),
 		resource.TestCheckResourceAttr(resourceID, "description", "Managed by Terraform."),
@@ -355,13 +438,11 @@ func checkResource(
 			"technical_contact_email",
 			"example@example.com",
 		),
-		resource.TestCheckResourceAttr(
-			resourceID,
-			"idp_metadata_source.type",
-			"base64_encoded_xml",
-		),
-		resource.TestCheckResourceAttrSet(resourceID, "idp_metadata_source.data"),
-	}...)
+		resource.TestCheckNoResourceAttr(resourceID, "idp_metadata_source.type"),
+		resource.TestCheckNoResourceAttr(resourceID, "idp_metadata_source.url"),
+		resource.TestCheckNoResourceAttr(resourceID, "idp_metadata_source.data"),
+		resource.TestCheckNoResourceAttr(resourceID, "signing_keypair.private_key"),
+	)
 }
 
 func testAccResourceDestroy(s *terraform.State) error {

--- a/internal/provider/silo_saml_identity_provider/resource_v0.go
+++ b/internal/provider/silo_saml_identity_provider/resource_v0.go
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package silosamlidp
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// schemaV0 is the resource schema before idp_metadata_source and
+// signing_keypair became write-only.
+func (r *Resource) schemaV0(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		MarkdownDescription: `
+Manages a SAML identity provider (IdP) for an Oxide silo.
+
+-> This resource does not support updates. All attributes are immutable once
+created.
+
+-> This resource does not support deletion from the Oxide API. When destroyed in
+Terraform, it will be removed from state but will continue to exist in Oxide.
+`,
+		Attributes: map[string]schema.Attribute{
+			"silo": schema.StringAttribute{
+				Required:    true,
+				Description: "Name or ID of the silo.",
+			},
+			"acs_url": schema.StringAttribute{
+				Required:    true,
+				Description: "URL where the identity provider should send the SAML response.",
+			},
+			"description": schema.StringAttribute{
+				Required:    true,
+				Description: "Free-form text describing the SAML identity provider.",
+			},
+			"group_attribute_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "SAML attribute that holds a user's group membership.",
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique, immutable, system-controlled identifier of the SAML identity provider.",
+			},
+			"idp_entity_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Identity provider's entity ID.",
+			},
+			"idp_metadata_source": schema.SingleNestedAttribute{
+				Required:    true,
+				Description: "Source of identity provider metadata (URL or base64-encoded XML).",
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "The type of metadata source. Must be one of: `url`, `base64_encoded_xml`.",
+						Validators: []validator.String{
+							stringvalidator.OneOf(
+								"url",
+								"base64_encoded_xml",
+							),
+						},
+					},
+					"url": schema.StringAttribute{
+						Optional:            true,
+						MarkdownDescription: "URL to fetch metadata from (required when type is `url`). Conflicts with `data`.",
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(
+								path.MatchRelative().AtParent().AtName("data"),
+							),
+						},
+					},
+					"data": schema.StringAttribute{
+						Optional:            true,
+						MarkdownDescription: "Base64-encoded XML metadata (required when type is `base64_encoded_xml`). Conflicts with `url`.",
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(
+								path.MatchRelative().AtParent().AtName("url"),
+							),
+						},
+					},
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Unique, immutable, user-controlled identifier of the SAML identity provider.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(63),
+				},
+			},
+			"signing_keypair": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "RSA private key and public certificate for signing SAML requests.",
+				Attributes: map[string]schema.Attribute{
+					"private_key": schema.StringAttribute{
+						Required:    true,
+						Sensitive:   true,
+						Description: "RSA private key (base64 encoded).",
+					},
+					"public_cert": schema.StringAttribute{
+						Required:    true,
+						Description: "Public certificate (base64 encoded).",
+					},
+				},
+			},
+			"slo_url": schema.StringAttribute{
+				Required:    true,
+				Description: "URL where the identity provider should send logout requests.",
+			},
+			"sp_client_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Service provider's client ID.",
+			},
+			"technical_contact_email": schema.StringAttribute{
+				Required:    true,
+				Description: "Technical contact email for SAML configuration.",
+			},
+			"time_created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SAML identity provider was created.",
+			},
+			"time_modified": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of when this SAML identity provider was last modified.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+			}),
+		},
+	}
+}

--- a/internal/provider/silo_saml_identity_provider/resource_v0.go
+++ b/internal/provider/silo_saml_identity_provider/resource_v0.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // schemaV0 is the resource schema before idp_metadata_source and
@@ -135,4 +137,28 @@ Terraform, it will be removed from state but will continue to exist in Oxide.
 			}),
 		},
 	}
+}
+
+// stateUpgraderV0 updates the v0 state to current.
+func (r *Resource) stateUpgraderV0(
+	ctx context.Context,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+) {
+	var state ResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Explicitly remove write-only attributes from state. The Terraform plugin
+	// framework does this automatically but having this here makes it easier to
+	// understand the intentions of the state upgrade.
+	state.IdpMetadataSource = nil
+	if state.SigningKeypair != nil {
+		state.SigningKeypair.PrivateKey = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
…ibutes write-only

The `idp_metadata_source` and `signing_keypair` attributes are now write-only and the `oxide_silo_saml_identity_provider` resource can now be imported.

Resolves SSE-314.