### PR TITLE
Add `attached_external_ips` to the instance resource.

### DIFF
--- a/.changelog/0.22.0.toml
+++ b/.changelog/0.22.0.toml
@@ -15,6 +15,10 @@ title = "New data source"
 description = "`oxide_current_user`"
 
 [[enhancements]]
+title = "`oxide_instance`"
+description = "The oxide_instance resource now exposes a read-only `attached_external_ips` attribute, which lists attached floating, ephemeral, and SNAT external IP addresses. For Terraform-managed instances, this attribute can replace the `oxide_instance_external_ips` data source. [#841](https://github.com/oxidecomputer/terraform-provider-oxide/pull/841)"
+
+[[enhancements]]
 title = "`oxide_silo_saml_identity_provider`"
 description = "The `idp_metadata_source` and `signing_keypair.private_key` attributes are now write-only. [#819](https://github.com/oxidecomputer/terraform-provider-oxide/pull/819)"
 

--- a/.changelog/0.22.0.toml
+++ b/.changelog/0.22.0.toml
@@ -15,6 +15,10 @@ title = "New data source"
 description = "`oxide_current_user`"
 
 [[enhancements]]
+title = "`oxide_instance`"
+description = "The `oxide_instance` resource now includes a read-only `attached_external_ips` that lists attached IP addresses by kind (floating, ephemeral, SNAT). This can replace the use of the `oxide_instance_external_ips` data source for terraform-managed instances. [#841](https://github.com/oxidecomputer/terraform-provider-oxide/pull/841)"
+
+[[enhancements]]
 title = "`oxide_silo_saml_identity_provider`"
 description = "The `idp_metadata_source` and `signing_keypair.private_key` attributes are now write-only. [#819](https://github.com/oxidecomputer/terraform-provider-oxide/pull/819)"
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -166,6 +166,7 @@ Maximum 32 KiB unencoded data.
 
 ### Read-Only
 
+- `attached_external_ips` (Attributes) External IP addresses attached to the instance, grouped by kind. (see [below for nested schema](#nestedatt--attached_external_ips))
 - `attached_network_interfaces` (Attributes Map) Network interfaces attached to the instance. (see [below for nested schema](#nestedatt--attached_network_interfaces))
 - `id` (String) Unique, immutable, system-controlled identifier of the instance.
 - `time_created` (String) Timestamp of when this instance was created.
@@ -243,6 +244,48 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+
+<a id="nestedatt--attached_external_ips"></a>
+### Nested Schema for `attached_external_ips`
+
+Read-Only:
+
+- `ephemeral` (Attributes List) Ephemeral external IPs attached to the instance. (see [below for nested schema](#nestedatt--attached_external_ips--ephemeral))
+- `floating` (Attributes List) Floating external IPs attached to the instance. (see [below for nested schema](#nestedatt--attached_external_ips--floating))
+- `snat` (Attributes List) Shared source NAT addresses used for outbound connectivity only. (see [below for nested schema](#nestedatt--attached_external_ips--snat))
+
+<a id="nestedatt--attached_external_ips--ephemeral"></a>
+### Nested Schema for `attached_external_ips.ephemeral`
+
+Read-Only:
+
+- `ip` (String) Ephemeral external IP address.
+- `ip_pool_id` (String) ID of the IP pool the address was allocated from.
+- `ip_version` (String) IP version of the address. One of `v4` or `v6`.
+
+
+<a id="nestedatt--attached_external_ips--floating"></a>
+### Nested Schema for `attached_external_ips.floating`
+
+Read-Only:
+
+- `id` (String) ID of the floating IP.
+- `ip` (String) Floating external IP address.
+- `ip_pool_id` (String) ID of the IP pool the address was allocated from.
+- `name` (String) Name of the floating IP.
+
+
+<a id="nestedatt--attached_external_ips--snat"></a>
+### Nested Schema for `attached_external_ips.snat`
+
+Read-Only:
+
+- `first_port` (Number) First port in the range assigned to this instance.
+- `ip` (String) Source NAT IP address.
+- `ip_pool_id` (String) ID of the IP pool the address was allocated from.
+- `last_port` (Number) Last port in the range assigned to this instance.
+
 
 
 <a id="nestedatt--attached_network_interfaces"></a>

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -64,6 +64,7 @@ type ResourceModel struct {
 	DiskAttachments           types.Set                `tfsdk:"disk_attachments"`
 	EnableJumboFrames         types.Bool               `tfsdk:"enable_jumbo_frames"`
 	ExternalIPs               *ExternalIPResourceModel `tfsdk:"external_ips"`
+	AttachedExternalIPs       types.Object             `tfsdk:"attached_external_ips"`
 	Hostname                  types.String             `tfsdk:"hostname"`
 	ID                        types.String             `tfsdk:"id"`
 	Memory                    types.Int64              `tfsdk:"memory"`
@@ -164,6 +165,32 @@ type FloatingIPResourceModel struct {
 	ID types.String `tfsdk:"id"`
 }
 
+type AttachedExternalIPsModel struct {
+	Ephemeral []AttachedEphemeralIPModel `tfsdk:"ephemeral"`
+	Floating  []AttachedFloatingIPModel  `tfsdk:"floating"`
+	SNAT      []AttachedSNATIPModel      `tfsdk:"snat"`
+}
+
+type AttachedEphemeralIPModel struct {
+	IP        types.String `tfsdk:"ip"`
+	IPPoolID  types.String `tfsdk:"ip_pool_id"`
+	IPVersion types.String `tfsdk:"ip_version"`
+}
+
+type AttachedFloatingIPModel struct {
+	IP       types.String `tfsdk:"ip"`
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	IPPoolID types.String `tfsdk:"ip_pool_id"`
+}
+
+type AttachedSNATIPModel struct {
+	IP        types.String `tfsdk:"ip"`
+	IPPoolID  types.String `tfsdk:"ip_pool_id"`
+	FirstPort types.Int64  `tfsdk:"first_port"`
+	LastPort  types.Int64  `tfsdk:"last_port"`
+}
+
 var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
 	map[string]attr.Type{
 		"id":          types.StringType,
@@ -190,6 +217,40 @@ var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
 		},
 		"time_created":  types.StringType,
 		"time_modified": types.StringType,
+	},
+)
+
+var AttachedEphemeralIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"ip_pool_id": types.StringType,
+		"ip_version": types.StringType,
+	},
+)
+
+var AttachedFloatingIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"id":         types.StringType,
+		"name":       types.StringType,
+		"ip_pool_id": types.StringType,
+	},
+)
+
+var AttachedSNATIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"ip_pool_id": types.StringType,
+		"first_port": types.Int64Type,
+		"last_port":  types.Int64Type,
+	},
+)
+
+var AttachedExternalIPsType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ephemeral": types.ListType{ElemType: AttachedEphemeralIPType},
+		"floating":  types.ListType{ElemType: AttachedFloatingIPType},
+		"snat":      types.ListType{ElemType: AttachedSNATIPType},
 	},
 )
 
@@ -578,6 +639,80 @@ This resource manages instances.
 					},
 				},
 			},
+			"attached_external_ips": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "External IP addresses attached to the instance, grouped by kind.",
+				Attributes: map[string]schema.Attribute{
+					"ephemeral": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Ephemeral external IPs attached to the instance.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Ephemeral external IP address.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+								"ip_version": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "IP version of the address. One of `v4` or `v6`.",
+								},
+							},
+						},
+					},
+					"floating": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Floating external IPs attached to the instance.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Floating external IP address.",
+								},
+								"id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the floating IP.",
+								},
+								"name": schema.StringAttribute{
+									Computed:    true,
+									Description: "Name of the floating IP.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+							},
+						},
+					},
+					"snat": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Shared source NAT addresses used for outbound connectivity only.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Source NAT IP address.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+								"first_port": schema.Int64Attribute{
+									Computed:    true,
+									Description: "First port in the range assigned to this instance.",
+								},
+								"last_port": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Last port in the range assigned to this instance.",
+								},
+							},
+						},
+					},
+				},
+			},
 			"user_data": schema.StringAttribute{
 				Optional: true,
 				MarkdownDescription: `
@@ -698,14 +833,17 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					Name:                      oldState.Name,
 					NetworkInterfaces:         newNICs,
 					AttachedNetworkInterfaces: oldState.AttachedNetworkInterfaces,
-					NCPUs:                     oldState.NCPUs,
-					ProjectID:                 oldState.ProjectID,
-					SSHPublicKeys:             oldState.SSHPublicKeys,
-					StartOnCreate:             oldState.StartOnCreate,
-					TimeCreated:               oldState.TimeCreated,
-					TimeModified:              oldState.TimeModified,
-					Timeouts:                  oldState.Timeouts,
-					UserData:                  oldState.UserData,
+					AttachedExternalIPs: types.ObjectNull(
+						AttachedExternalIPsType.AttributeTypes(),
+					),
+					NCPUs:         oldState.NCPUs,
+					ProjectID:     oldState.ProjectID,
+					SSHPublicKeys: oldState.SSHPublicKeys,
+					StartOnCreate: oldState.StartOnCreate,
+					TimeCreated:   oldState.TimeCreated,
+					TimeModified:  oldState.TimeModified,
+					Timeouts:      oldState.Timeouts,
+					UserData:      oldState.UserData,
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -798,6 +936,9 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					// that is going to be populated when the state is
 					// refreshed.
 					AttachedNetworkInterfaces: types.MapNull(AttachedNICType),
+					AttachedExternalIPs: types.ObjectNull(
+						AttachedExternalIPsType.AttributeTypes(),
+					),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -956,7 +1097,11 @@ func (r *Resource) Create(
 	plan.TimeModified = types.StringValue(instance.TimeModified.String())
 
 	// Populate Computed attribute values about external IPs.
-	instExternalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
+	instExternalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		plan,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -965,6 +1110,16 @@ func (r *Resource) Create(
 	for i, ip := range instExternalIPs.Ephemeral {
 		plan.ExternalIPs.Ephemeral[i].PoolID = ip.PoolID
 		plan.ExternalIPs.Ephemeral[i].IPVersion = ip.IPVersion
+	}
+
+	plan.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Populate Computed attribute values about network interfaces.
@@ -1054,7 +1209,11 @@ func (r *Resource) Read(
 	state.TimeCreated = types.StringValue(instance.TimeCreated.String())
 	state.TimeModified = types.StringValue(instance.TimeModified.String())
 
-	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, state)
+	externalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		state,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1065,6 +1224,15 @@ func (r *Resource) Read(
 		externalIPs = nil
 	}
 	state.ExternalIPs = externalIPs
+	state.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	keySet, diags := newAssociatedSSHKeysOnCreateSet(ctx, r.client, state.ID.ValueString())
 	resp.Diagnostics.Append(diags...)
@@ -1397,13 +1565,26 @@ func (r *Resource) Update(
 
 	// We use the plan here instead of the state to capture the desired IP pool ID
 	// value for the ephemeral external IP rather than the previous value.
-	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
+	externalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		plan,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	if !externalIPs.Empty() {
 		plan.ExternalIPs = externalIPs
+	}
+	plan.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// TODO: should I do this or read from the newly created ones?
@@ -1828,7 +2009,7 @@ func newAttachedExternalIPResourceModel(
 	client *oxide.Client,
 	model ResourceModel,
 ) (
-	*ExternalIPResourceModel, diag.Diagnostics) {
+	*ExternalIPResourceModel, *AttachedExternalIPsModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	externalIPResponse, err := client.InstanceExternalIpList(
@@ -1842,10 +2023,15 @@ func newAttachedExternalIPResourceModel(
 			"Unable to list instance external ips:",
 			"API error: "+err.Error(),
 		)
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	externalIPs := &ExternalIPResourceModel{}
+	attachedExternalIPs := &AttachedExternalIPsModel{
+		Ephemeral: []AttachedEphemeralIPModel{},
+		Floating:  []AttachedFloatingIPModel{},
+		SNAT:      []AttachedSNATIPModel{},
+	}
 	for _, ip := range externalIPResponse.Items {
 		switch v := ip.Value.(type) {
 		case *oxide.ExternalIpEphemeral:
@@ -1864,14 +2050,40 @@ func newAttachedExternalIPResourceModel(
 				PoolID:    types.StringValue(v.IpPoolId),
 				IPVersion: types.StringValue(ipVersion),
 			})
+			attachedExternalIPs.Ephemeral = append(
+				attachedExternalIPs.Ephemeral,
+				AttachedEphemeralIPModel{
+					IP:        types.StringValue(v.Ip),
+					IPPoolID:  types.StringValue(v.IpPoolId),
+					IPVersion: types.StringValue(ipVersion),
+				},
+			)
 
 		case *oxide.ExternalIpFloating:
 			externalIPs.Floating = append(externalIPs.Floating, FloatingIPResourceModel{
 				ID: types.StringValue(v.Id),
 			})
-		// Skipped until the schema is updated to support SNAT external IPs.
+			attachedExternalIPs.Floating = append(
+				attachedExternalIPs.Floating,
+				AttachedFloatingIPModel{
+					IP:       types.StringValue(v.Ip),
+					ID:       types.StringValue(v.Id),
+					Name:     types.StringValue(string(v.Name)),
+					IPPoolID: types.StringValue(v.IpPoolId),
+				},
+			)
+
 		case *oxide.ExternalIpSnat:
-			continue
+			attachedExternalIPs.SNAT = append(
+				attachedExternalIPs.SNAT,
+				AttachedSNATIPModel{
+					IP:        types.StringValue(v.Ip),
+					IPPoolID:  types.StringValue(v.IpPoolId),
+					FirstPort: types.Int64Value(int64(*v.FirstPort)),
+					LastPort:  types.Int64Value(int64(*v.LastPort)),
+				},
+			)
+
 		default:
 			diags.AddError(
 				"Invalid external IP kind:",
@@ -1880,7 +2092,7 @@ func newAttachedExternalIPResourceModel(
 		}
 	}
 
-	return externalIPs, nil
+	return externalIPs, attachedExternalIPs, diags
 }
 
 type vpcAndSubnetNames struct {

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -64,6 +64,7 @@ type ResourceModel struct {
 	DiskAttachments           types.Set                `tfsdk:"disk_attachments"`
 	EnableJumboFrames         types.Bool               `tfsdk:"enable_jumbo_frames"`
 	ExternalIPs               *ExternalIPResourceModel `tfsdk:"external_ips"`
+	AttachedExternalIPs       types.Object             `tfsdk:"attached_external_ips"`
 	Hostname                  types.String             `tfsdk:"hostname"`
 	ID                        types.String             `tfsdk:"id"`
 	Memory                    types.Int64              `tfsdk:"memory"`
@@ -164,6 +165,32 @@ type FloatingIPResourceModel struct {
 	ID types.String `tfsdk:"id"`
 }
 
+type AttachedExternalIPsModel struct {
+	Ephemeral []AttachedEphemeralIPModel `tfsdk:"ephemeral"`
+	Floating  []AttachedFloatingIPModel  `tfsdk:"floating"`
+	SNAT      []AttachedSNATIPModel      `tfsdk:"snat"`
+}
+
+type AttachedEphemeralIPModel struct {
+	IP        types.String `tfsdk:"ip"`
+	IPPoolID  types.String `tfsdk:"ip_pool_id"`
+	IPVersion types.String `tfsdk:"ip_version"`
+}
+
+type AttachedFloatingIPModel struct {
+	IP       types.String `tfsdk:"ip"`
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	IPPoolID types.String `tfsdk:"ip_pool_id"`
+}
+
+type AttachedSNATIPModel struct {
+	IP        types.String `tfsdk:"ip"`
+	IPPoolID  types.String `tfsdk:"ip_pool_id"`
+	FirstPort types.Int64  `tfsdk:"first_port"`
+	LastPort  types.Int64  `tfsdk:"last_port"`
+}
+
 var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
 	map[string]attr.Type{
 		"id":          types.StringType,
@@ -190,6 +217,40 @@ var AttachedNICType = types.ObjectType{}.WithAttributeTypes(
 		},
 		"time_created":  types.StringType,
 		"time_modified": types.StringType,
+	},
+)
+
+var AttachedEphemeralIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"ip_pool_id": types.StringType,
+		"ip_version": types.StringType,
+	},
+)
+
+var AttachedFloatingIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"id":         types.StringType,
+		"name":       types.StringType,
+		"ip_pool_id": types.StringType,
+	},
+)
+
+var AttachedSNATIPType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ip":         types.StringType,
+		"ip_pool_id": types.StringType,
+		"first_port": types.Int64Type,
+		"last_port":  types.Int64Type,
+	},
+)
+
+var AttachedExternalIPsType = types.ObjectType{}.WithAttributeTypes(
+	map[string]attr.Type{
+		"ephemeral": types.ListType{ElemType: AttachedEphemeralIPType},
+		"floating":  types.ListType{ElemType: AttachedFloatingIPType},
+		"snat":      types.ListType{ElemType: AttachedSNATIPType},
 	},
 )
 
@@ -578,6 +639,80 @@ This resource manages instances.
 					},
 				},
 			},
+			"attached_external_ips": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "External IP addresses attached to the instance, grouped by kind.",
+				Attributes: map[string]schema.Attribute{
+					"ephemeral": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Ephemeral external IPs attached to the instance.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Ephemeral external IP address.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+								"ip_version": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "IP version of the address. One of `v4` or `v6`.",
+								},
+							},
+						},
+					},
+					"floating": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Floating external IPs attached to the instance.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Floating external IP address.",
+								},
+								"id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the floating IP.",
+								},
+								"name": schema.StringAttribute{
+									Computed:    true,
+									Description: "Name of the floating IP.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+							},
+						},
+					},
+					"snat": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Shared source NAT addresses used for outbound connectivity only.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"ip": schema.StringAttribute{
+									Computed:    true,
+									Description: "Source NAT IP address.",
+								},
+								"ip_pool_id": schema.StringAttribute{
+									Computed:    true,
+									Description: "ID of the IP pool the address was allocated from.",
+								},
+								"first_port": schema.Int64Attribute{
+									Computed:    true,
+									Description: "First port in the range assigned to this instance.",
+								},
+								"last_port": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Last port in the range assigned to this instance.",
+								},
+							},
+						},
+					},
+				},
+			},
 			"user_data": schema.StringAttribute{
 				Optional: true,
 				MarkdownDescription: `
@@ -698,14 +833,17 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					Name:                      oldState.Name,
 					NetworkInterfaces:         newNICs,
 					AttachedNetworkInterfaces: oldState.AttachedNetworkInterfaces,
-					NCPUs:                     oldState.NCPUs,
-					ProjectID:                 oldState.ProjectID,
-					SSHPublicKeys:             oldState.SSHPublicKeys,
-					StartOnCreate:             oldState.StartOnCreate,
-					TimeCreated:               oldState.TimeCreated,
-					TimeModified:              oldState.TimeModified,
-					Timeouts:                  oldState.Timeouts,
-					UserData:                  oldState.UserData,
+					AttachedExternalIPs: types.ObjectNull(
+						AttachedExternalIPsType.AttributeTypes(),
+					),
+					NCPUs:         oldState.NCPUs,
+					ProjectID:     oldState.ProjectID,
+					SSHPublicKeys: oldState.SSHPublicKeys,
+					StartOnCreate: oldState.StartOnCreate,
+					TimeCreated:   oldState.TimeCreated,
+					TimeModified:  oldState.TimeModified,
+					Timeouts:      oldState.Timeouts,
+					UserData:      oldState.UserData,
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -798,6 +936,9 @@ func (r *Resource) UpgradeState(ctx context.Context) map[int64]resource.StateUpg
 					// that is going to be populated when the state is
 					// refreshed.
 					AttachedNetworkInterfaces: types.MapNull(AttachedNICType),
+					AttachedExternalIPs: types.ObjectNull(
+						AttachedExternalIPsType.AttributeTypes(),
+					),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -956,7 +1097,11 @@ func (r *Resource) Create(
 	plan.TimeModified = types.StringValue(instance.TimeModified.String())
 
 	// Populate Computed attribute values about external IPs.
-	instExternalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
+	instExternalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		plan,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -965,6 +1110,16 @@ func (r *Resource) Create(
 	for i, ip := range instExternalIPs.Ephemeral {
 		plan.ExternalIPs.Ephemeral[i].PoolID = ip.PoolID
 		plan.ExternalIPs.Ephemeral[i].IPVersion = ip.IPVersion
+	}
+
+	plan.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Populate Computed attribute values about network interfaces.
@@ -1054,7 +1209,11 @@ func (r *Resource) Read(
 	state.TimeCreated = types.StringValue(instance.TimeCreated.String())
 	state.TimeModified = types.StringValue(instance.TimeModified.String())
 
-	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, state)
+	externalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		state,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1062,6 +1221,15 @@ func (r *Resource) Read(
 	// Only set the external IPs if there are any to avoid drift.
 	if !externalIPs.Empty() {
 		state.ExternalIPs = externalIPs
+	}
+	state.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	keySet, diags := newAssociatedSSHKeysOnCreateSet(ctx, r.client, state.ID.ValueString())
@@ -1395,13 +1563,26 @@ func (r *Resource) Update(
 
 	// We use the plan here instead of the state to capture the desired IP pool ID
 	// value for the ephemeral external IP rather than the previous value.
-	externalIPs, diags := newAttachedExternalIPResourceModel(ctx, r.client, plan)
+	externalIPs, attachedExternalIPs, diags := newAttachedExternalIPResourceModel(
+		ctx,
+		r.client,
+		plan,
+	)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	if !externalIPs.Empty() {
 		plan.ExternalIPs = externalIPs
+	}
+	plan.AttachedExternalIPs, diags = types.ObjectValueFrom(
+		ctx,
+		AttachedExternalIPsType.AttributeTypes(),
+		attachedExternalIPs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// TODO: should I do this or read from the newly created ones?
@@ -1826,7 +2007,7 @@ func newAttachedExternalIPResourceModel(
 	client *oxide.Client,
 	model ResourceModel,
 ) (
-	*ExternalIPResourceModel, diag.Diagnostics) {
+	*ExternalIPResourceModel, *AttachedExternalIPsModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	externalIPResponse, err := client.InstanceExternalIpList(
@@ -1840,10 +2021,15 @@ func newAttachedExternalIPResourceModel(
 			"Unable to list instance external ips:",
 			"API error: "+err.Error(),
 		)
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	externalIPs := &ExternalIPResourceModel{}
+	attachedExternalIPs := &AttachedExternalIPsModel{
+		Ephemeral: []AttachedEphemeralIPModel{},
+		Floating:  []AttachedFloatingIPModel{},
+		SNAT:      []AttachedSNATIPModel{},
+	}
 	for _, ip := range externalIPResponse.Items {
 		switch v := ip.Value.(type) {
 		case *oxide.ExternalIpEphemeral:
@@ -1862,14 +2048,40 @@ func newAttachedExternalIPResourceModel(
 				PoolID:    types.StringValue(v.IpPoolId),
 				IPVersion: types.StringValue(ipVersion),
 			})
+			attachedExternalIPs.Ephemeral = append(
+				attachedExternalIPs.Ephemeral,
+				AttachedEphemeralIPModel{
+					IP:        types.StringValue(v.Ip),
+					IPPoolID:  types.StringValue(v.IpPoolId),
+					IPVersion: types.StringValue(ipVersion),
+				},
+			)
 
 		case *oxide.ExternalIpFloating:
 			externalIPs.Floating = append(externalIPs.Floating, FloatingIPResourceModel{
 				ID: types.StringValue(v.Id),
 			})
-		// Skipped until the schema is updated to support SNAT external IPs.
+			attachedExternalIPs.Floating = append(
+				attachedExternalIPs.Floating,
+				AttachedFloatingIPModel{
+					IP:       types.StringValue(v.Ip),
+					ID:       types.StringValue(v.Id),
+					Name:     types.StringValue(string(v.Name)),
+					IPPoolID: types.StringValue(v.IpPoolId),
+				},
+			)
+
 		case *oxide.ExternalIpSnat:
-			continue
+			attachedExternalIPs.SNAT = append(
+				attachedExternalIPs.SNAT,
+				AttachedSNATIPModel{
+					IP:        types.StringValue(v.Ip),
+					IPPoolID:  types.StringValue(v.IpPoolId),
+					FirstPort: types.Int64Value(int64(*v.FirstPort)),
+					LastPort:  types.Int64Value(int64(*v.LastPort)),
+				},
+			)
+
 		default:
 			diags.AddError(
 				"Invalid external IP kind:",
@@ -1878,7 +2090,7 @@ func newAttachedExternalIPResourceModel(
 		}
 	}
 
-	return externalIPs, nil
+	return externalIPs, attachedExternalIPs, diags
 }
 
 type vpcAndSubnetNames struct {

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -1532,6 +1532,22 @@ func checkResourceFull(resourceName, instanceName, nicName string) resource.Test
 		resource.TestCheckResourceAttrSet(resourceName, "external_ips.ephemeral.1.pool_id"),
 		resource.TestCheckResourceAttr(resourceName, "external_ips.ephemeral.1.ip_version", "v6"),
 		resource.TestCheckResourceAttrSet(resourceName, "external_ips.floating.0.id"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.ephemeral.#", "2"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.ephemeral.0.ip"),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.ephemeral.0.ip_pool_id",
+		),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.ephemeral.0.ip_version",
+		),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.floating.#", "2"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.ip"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.id"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.name"),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.floating.0.ip_pool_id",
+		),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.snat.#"),
 		testResourceNetworkInterface(resourceName, nicName, "a sample nic", 0, "dual"),
 		resource.TestCheckResourceAttrSet(resourceName, "ssh_public_keys.0"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1630,6 +1646,8 @@ func checkResourceIPUpdate2(resourceName, instanceName string) resource.TestChec
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
 		resource.TestCheckNoResourceAttr(resourceName, "external_ips"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.ephemeral.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.floating.#", "0"),
 	}...)
 }
 

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -1698,6 +1698,22 @@ func checkResourceFull(resourceName, instanceName, nicName string) resource.Test
 		resource.TestCheckResourceAttrSet(resourceName, "external_ips.ephemeral.1.pool_id"),
 		resource.TestCheckResourceAttr(resourceName, "external_ips.ephemeral.1.ip_version", "v6"),
 		resource.TestCheckResourceAttrSet(resourceName, "external_ips.floating.0.id"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.ephemeral.#", "2"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.ephemeral.0.ip"),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.ephemeral.0.ip_pool_id",
+		),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.ephemeral.0.ip_version",
+		),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.floating.#", "2"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.ip"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.id"),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.floating.0.name"),
+		resource.TestCheckResourceAttrSet(
+			resourceName, "attached_external_ips.floating.0.ip_pool_id",
+		),
+		resource.TestCheckResourceAttrSet(resourceName, "attached_external_ips.snat.#"),
 		testResourceNetworkInterface(resourceName, nicName, "a sample nic", 0, "dual"),
 		resource.TestCheckResourceAttrSet(resourceName, "ssh_public_keys.0"),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1796,6 +1812,8 @@ func checkResourceIPUpdate2(resourceName, instanceName string) resource.TestChec
 		resource.TestCheckResourceAttrSet(resourceName, "time_created"),
 		resource.TestCheckResourceAttrSet(resourceName, "time_modified"),
 		resource.TestCheckNoResourceAttr(resourceName, "external_ips"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.ephemeral.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, "attached_external_ips.floating.#", "0"),
 	}...)
 }
 


### PR DESCRIPTION
In order to look up the external ips attached to an instance, we currently use the `oxide_instance_external_ips` data source, then loop over its `external_ips` to find addresses of interest:

```
one([for eip in data.oxide_instance_external_ips.instance.external_ips : eip.ip if eip.kind == "ephemeral"])
```

This is cumbersome, both because we have to use a data source for a resource that's already managed in terraform, and because the user has to know to filter addresses by kind.

This patch adds an `attached_external_ips` computed attribute to the instance resource, which provides ip addresses for all external ips, grouped by kind. Using this computed attribute, users don't need to add a data source, and don't need to remember to filter:

```
one(oxide_instance.instance.attached_external_ips.ephemeral)
```



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
