### PR TITLE
fix: record empty set of external ips.

### DIFF
--- a/.changelog/0.22.0.toml
+++ b/.changelog/0.22.0.toml
@@ -23,5 +23,5 @@ title = "`oxide_silo_saml_identity_provider`"
 description = "The `oxide_silo_saml_identity_provider` resource can now be imported. [#819](https://github.com/oxidecomputer/terraform-provider-oxide/pull/819)"
 
 [[bugs]]
-title = ""
-description = ""
+title = "`oxide_instance`"
+description = "Previously, the provider would fail to detect a diff on the `external_ips` attribute of the `oxide_instance` resource when external IPs were detached from the instance out of band. These diffs are now detected correctly. [#842](https://github.com/oxidecomputer/terraform-provider-oxide/pull/842)"

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -1059,10 +1059,12 @@ func (r *Resource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// Only set the external IPs if there are any to avoid drift.
-	if !externalIPs.Empty() {
-		state.ExternalIPs = externalIPs
+	// If the current attached external IPs list is empty (i.e. no non-snat IPs), write `nil` to the
+	// state. This represents an instance with an unspecified `external_ips` block.
+	if externalIPs.Empty() {
+		externalIPs = nil
 	}
+	state.ExternalIPs = externalIPs
 
 	keySet, diags := newAssociatedSSHKeysOnCreateSet(ctx, r.client, state.ID.ValueString())
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 
@@ -563,6 +564,171 @@ resource "oxide_instance" "{{.BlockName}}" {
 					"external_ips",
 					"network_interfaces.0.ip_config",
 				},
+			},
+		},
+	})
+}
+
+// TestAccCloudResourceInstance_extIPDetachedOutOfBand tests for correctness when an external IP is
+// detached from a tf-managed instance out of band. We provision an instance with an external IP,
+// detach the IP outside terraform, then re-apply. We assert that the plan is non-empty after
+// detaching an IP out of band.
+func TestAccCloudResourceInstance_extIPDetachedOutOfBand(t *testing.T) {
+	type resourceInstanceConfig struct {
+		BlockName        string
+		InstanceName     string
+		SupportBlockName string
+	}
+
+	resourceInstanceOutOfBandConfigTpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+data "oxide_vpc_subnet" "default" {
+  project_name = data.oxide_project.{{.SupportBlockName}}.name
+  vpc_name     = "default"
+  name         = "default"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  hostname        = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 1
+  start_on_create = false
+
+  external_ips = {
+    ephemeral = [
+      { ip_version = "v4" },
+    ]
+  }
+
+  network_interfaces = [
+    {
+      name        = "net0"
+      description = "net0"
+      subnet_id   = data.oxide_vpc_subnet.default.id
+      vpc_id      = data.oxide_vpc_subnet.default.vpc_id
+      ip_config = {
+        v4 = { ip = "auto" }
+      }
+    }
+  ]
+}
+`
+
+	instanceName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance")
+	supportBlockName := sharedtest.NewBlockName("support")
+	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
+	config := sharedtest.ParsedAccConfig(t,
+		resourceInstanceConfig{
+			BlockName:        blockName,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName,
+		},
+		resourceInstanceOutOfBandConfigTpl,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		CheckDestroy:             testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDetachEphemeralIPOutOfBand(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDetachEphemeralIPOutOfBand(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		client, err := sharedtest.NewTestClient()
+		if err != nil {
+			return err
+		}
+
+		return client.InstanceEphemeralIpDetach(
+			context.Background(),
+			oxide.InstanceEphemeralIpDetachParams{
+				Instance:  oxide.NameOrId(rs.Primary.ID),
+				IpVersion: oxide.IpVersionV4,
+			},
+		)
+	}
+}
+
+// TestAccCloudResourceInstance_extIPsOmitted is a regression test asserting that an instance that
+// omits `external_ips` has an empty plan after apply. This prevents a regression such that an
+// omitted `external_ips` registers as different from an empty `ExternalIPResourceModel` struct,
+// triggering a perpetual diff.
+func TestAccCloudResourceInstance_extIPsOmitted(t *testing.T) {
+	type resourceInstanceConfig struct {
+		BlockName        string
+		InstanceName     string
+		SupportBlockName string
+	}
+
+	resourceInstanceNoExternalIPConfigTpl := `
+data "oxide_project" "{{.SupportBlockName}}" {
+	name = "tf-acc-test"
+}
+
+resource "oxide_instance" "{{.BlockName}}" {
+  project_id      = data.oxide_project.{{.SupportBlockName}}.id
+  description     = "a test instance"
+  name            = "{{.InstanceName}}"
+  hostname        = "terraform-acc-myhost"
+  memory          = 1073741824
+  ncpus           = 1
+  start_on_create = false
+}
+`
+
+	instanceName := sharedtest.NewResourceName()
+	blockName := sharedtest.NewBlockName("instance")
+	supportBlockName := sharedtest.NewBlockName("support")
+	resourceName := fmt.Sprintf("oxide_instance.%s", blockName)
+	config := sharedtest.ParsedAccConfig(t,
+		resourceInstanceConfig{
+			BlockName:        blockName,
+			InstanceName:     instanceName,
+			SupportBlockName: supportBlockName,
+		},
+		resourceInstanceNoExternalIPConfigTpl,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { sharedtest.PreCheck(t) },
+		ProtoV6ProviderFactories: sharedtest.ProviderFactories(),
+		CheckDestroy:             testAccResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "external_ips"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Currently, if a user creates an instance with `external_ips` in terraform, and then detaches them outside terraform, `terraform plan` won't detect a diff. This is incorrect: the provider should restore the detached ip addresses on the next `plan` or `apply`. This patch adds a regression test that covers ip detachment out of band, and ensures the next plan has a diff. Then we fix the failing regression test by unconditionally setting the state to the observed ips on `Read()`.

Note: we write `nil` to state rather than an empty struct, so that terraform doesn't see a spurious diff between a user-configured omitted `external_ips` and an empty struct.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
