### PR TITLE
misc: use oxide.go error type for 404

### DIFF
--- a/internal/provider/address_lot/resource.go
+++ b/internal/provider/address_lot/resource.go
@@ -6,6 +6,7 @@ package addresslot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -349,7 +350,7 @@ func (r *Resource) Delete(
 		oxide.NetworkingAddressLotDeleteParams{
 			AddressLot: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting Address Lot:",
 				"API error: "+err.Error(),

--- a/internal/provider/anti_affinity_group/resource.go
+++ b/internal/provider/anti_affinity_group/resource.go
@@ -6,6 +6,7 @@ package antiaffinitygroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -243,7 +244,7 @@ func (r *Resource) Read(
 	}
 	antiAffinityGroup, err := r.client.AntiAffinityGroupView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -366,7 +367,7 @@ func (r *Resource) Delete(
 		AntiAffinityGroup: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.AntiAffinityGroupDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting AntiAffinityGroup:",
 				"API error: "+err.Error(),

--- a/internal/provider/anti_affinity_group/resource_test.go
+++ b/internal/provider/anti_affinity_group/resource_test.go
@@ -6,6 +6,7 @@ package antiaffinitygroup_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -160,7 +159,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.AntiAffinityGroupView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/disk/resource.go
+++ b/internal/provider/disk/resource.go
@@ -6,6 +6,7 @@ package disk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -371,7 +372,7 @@ func (r *Resource) Read(
 	}
 	disk, err := r.client.DiskView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -448,7 +449,7 @@ func (r *Resource) Delete(
 		Disk: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.DiskDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete disk:",
 				"API error: "+err.Error(),

--- a/internal/provider/disk/resource_test.go
+++ b/internal/provider/disk/resource_test.go
@@ -6,6 +6,7 @@ package disk_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -17,8 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -266,7 +265,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		}
 		res, err := client.DiskView(ctx, params)
 
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/external_subnet/resource.go
+++ b/internal/provider/external_subnet/resource.go
@@ -6,6 +6,7 @@ package externalsubnet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
@@ -350,7 +351,7 @@ func (r *Resource) Read(
 
 	externalSubnet, err := r.client.ExternalSubnetView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -479,7 +480,7 @@ func (r *Resource) Delete(
 	}
 
 	if err := r.client.ExternalSubnetDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting external subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/external_subnet/resource_test.go
+++ b/internal/provider/external_subnet/resource_test.go
@@ -6,6 +6,7 @@ package externalsubnet_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 // resourceConfig holds parameters for generating test configurations.
@@ -393,7 +392,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.ExternalSubnetViewParams{ExternalSubnet: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		if err == nil {

--- a/internal/provider/external_subnet_attachment/resource.go
+++ b/internal/provider/external_subnet_attachment/resource.go
@@ -6,6 +6,7 @@ package externalsubnetattachment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -210,7 +211,7 @@ func (r *Resource) Read(
 
 	externalSubnet, err := r.client.ExternalSubnetView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -294,7 +295,7 @@ func (r *Resource) Delete(
 		ctx, viewParams,
 	)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -314,7 +315,7 @@ func (r *Resource) Delete(
 	if _, err := r.client.ExternalSubnetDetach(
 		ctx, detachParams,
 	); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error detaching external subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/external_subnet_attachment/resource_test.go
+++ b/internal/provider/external_subnet_attachment/resource_test.go
@@ -6,6 +6,7 @@ package externalsubnetattachment_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -299,7 +298,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.ExternalSubnetViewParams{ExternalSubnet: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		if err == nil && res.InstanceId != "" {

--- a/internal/provider/floating_ip/datasource.go
+++ b/internal/provider/floating_ip/datasource.go
@@ -6,6 +6,7 @@ package floatingip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -164,7 +165,7 @@ func (f *DataSource) Read(
 
 	floatingIP, err := f.client.FloatingIpView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/floating_ip/resource.go
+++ b/internal/provider/floating_ip/resource.go
@@ -6,6 +6,7 @@ package floatingip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/iptypes"
@@ -311,7 +312,7 @@ func (f *Resource) Read(
 
 	floatingIP, err := f.client.FloatingIpView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -440,7 +441,7 @@ func (f *Resource) Delete(
 	}
 
 	if err := f.client.FloatingIpDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete floating IP:",
 				"API error: "+err.Error(),

--- a/internal/provider/floating_ip/resource_test.go
+++ b/internal/provider/floating_ip/resource_test.go
@@ -6,6 +6,7 @@ package floatingip_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -245,7 +246,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.FloatingIpView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/image/resource.go
+++ b/internal/provider/image/resource.go
@@ -6,6 +6,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -322,7 +323,7 @@ func (r *Resource) Read(
 	}
 	image, err := r.client.ImageView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -430,7 +431,7 @@ func (r *Resource) Delete(
 	if err := r.client.ImageDelete(ctx, oxide.ImageDeleteParams{
 		Image: oxide.NameOrId(state.ID.ValueString()),
 	}); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to read image:",
 				"API error: "+err.Error(),

--- a/internal/provider/image/resource_test.go
+++ b/internal/provider/image/resource_test.go
@@ -6,6 +6,7 @@ package image_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -147,7 +146,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		}
 		res, err := client.ImageView(ctx, params)
 
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/instance/resource.go
+++ b/internal/provider/instance/resource.go
@@ -7,6 +7,7 @@ package instance
 import (
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -1171,7 +1172,7 @@ func (r *Resource) Read(
 	}
 	instance, err := r.client.InstanceView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -1330,7 +1331,7 @@ func (r *Resource) Update(
 	}
 	_, err := r.client.InstanceStop(ctx, stopParams)
 	if err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to stop instance:",
 				"API error: "+err.Error(),
@@ -1527,7 +1528,7 @@ func (r *Resource) Update(
 	startParams := oxide.InstanceStartParams{Instance: oxide.NameOrId(state.ID.ValueString())}
 	_, err = r.client.InstanceStart(ctx, startParams)
 	if err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to start instance:",
 				"API error: "+err.Error(),
@@ -1652,7 +1653,7 @@ func (r *Resource) Delete(
 	}
 	_, err := r.client.InstanceStop(ctx, params)
 	if err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to stop instance:",
 				"API error: "+err.Error(),
@@ -1676,7 +1677,7 @@ func (r *Resource) Delete(
 		Instance: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.InstanceDelete(ctx, params2); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete instance:",
 				"API error: "+err.Error(),
@@ -1720,7 +1721,7 @@ func waitForInstanceStop(
 			}
 			instance, err := client.InstanceView(ctx, params)
 			if err != nil {
-				if !shared.Is404(err) {
+				if !errors.Is(err, oxide.ErrHTTP404) {
 					return nil, "nil", fmt.Errorf(
 						"while polling for the status of instance %v: %v",
 						instanceID,
@@ -1738,7 +1739,7 @@ func waitForInstanceStop(
 		},
 	}
 	if _, err := stateConfig.WaitForStateContext(ctx); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			diags.AddError(
 				"Error stopping instance",
 				"API error: "+err.Error(),
@@ -2382,7 +2383,7 @@ func deleteNICs(
 			Interface: oxide.NameOrId(model.ID.ValueString()),
 		}
 		if err := client.InstanceNetworkInterfaceDelete(ctx, params); err != nil {
-			if !shared.Is404(err) {
+			if !errors.Is(err, oxide.ErrHTTP404) {
 				diags.AddError(
 					"Error deleting instance network interface:",
 					"API error: "+err.Error(),
@@ -2810,7 +2811,7 @@ func removeAntiAffinityGroups(
 		if err != nil {
 			// If the anti-affinity group doesn't exist anymore, it means
 			// the instance isn't part of it. We can just return.
-			if shared.Is404(err) {
+			if errors.Is(err, oxide.ErrHTTP404) {
 				return nil
 			}
 			diags.AddError(

--- a/internal/provider/instance/resource_test.go
+++ b/internal/provider/instance/resource_test.go
@@ -6,6 +6,7 @@ package instance_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"os"
@@ -19,7 +20,6 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/instance"
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
@@ -2152,7 +2152,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			Instance: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.InstanceView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/ip_pool/resource.go
+++ b/internal/provider/ip_pool/resource.go
@@ -6,6 +6,7 @@ package ippool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -415,7 +416,7 @@ func (r *Resource) Delete(
 		},
 	)
 	if err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error retrieving IP Pool ranges:",
 				"API error: "+err.Error(),
@@ -436,7 +437,7 @@ func (r *Resource) Delete(
 			Body: &item.Range,
 		}
 		if err := r.client.SystemIpPoolRangeRemove(ctx, params); err != nil {
-			if !shared.Is404(err) {
+			if !errors.Is(err, oxide.ErrHTTP404) {
 				resp.Diagnostics.AddError(
 					"Error deleting IP Pool range:",
 					"API error: "+err.Error(),
@@ -456,7 +457,7 @@ func (r *Resource) Delete(
 		oxide.SystemIpPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting IP Pool:",
 				"API error: "+err.Error(),

--- a/internal/provider/ip_pool/resource_test.go
+++ b/internal/provider/ip_pool/resource_test.go
@@ -6,6 +6,7 @@ package ippool_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccSiloResourceIpPool_full(t *testing.T) {
@@ -195,7 +194,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool"},
 		)
-		if err == nil || !shared.Is404(err) {
+		if err == nil || !errors.Is(err, oxide.ErrHTTP404) {
 			return fmt.Errorf("ip_pool (%v) still exists", &res.Name)
 		}
 
@@ -203,7 +202,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemIpPoolViewParams{Pool: "terraform-acc-myippool2"},
 		)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		return fmt.Errorf("ip_pool (%v) still exists", &res2.Name)

--- a/internal/provider/ip_pool_silo_link/resource.go
+++ b/internal/provider/ip_pool_silo_link/resource.go
@@ -6,6 +6,7 @@ package ippoolsilolink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -223,7 +224,7 @@ func (r *Resource) Read(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	})
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -260,7 +261,7 @@ func (r *Resource) Read(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	})
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -375,7 +376,7 @@ func (r *Resource) Delete(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
 	if err := r.client.SystemIpPoolSiloUnlink(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting link:",
 				"API error: "+err.Error(),

--- a/internal/provider/project/resource.go
+++ b/internal/provider/project/resource.go
@@ -6,6 +6,7 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -202,7 +203,7 @@ func (r *Resource) Read(
 	}
 	project, err := r.client.ProjectView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -324,7 +325,7 @@ func (r *Resource) Delete(
 		Subnet:  oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, paramsSubnet); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting default subnet:",
 				"API error: "+err.Error(),
@@ -343,7 +344,7 @@ func (r *Resource) Delete(
 		Vpc:     oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcDelete(ctx, paramsVPC); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting default VPC:",
 				"API error: "+err.Error(),
@@ -361,7 +362,7 @@ func (r *Resource) Delete(
 		Project: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.ProjectDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting project:",
 				"API error: "+err.Error(),

--- a/internal/provider/project/resource_test.go
+++ b/internal/provider/project/resource_test.go
@@ -6,6 +6,7 @@ package project_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -134,7 +133,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			Project: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.ProjectView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		return fmt.Errorf("project (%v) still exists", &res.Name)

--- a/internal/provider/shared/utils.go
+++ b/internal/provider/shared/utils.go
@@ -23,10 +23,6 @@ func ReplaceBackticks(s string) string {
 	return strings.ReplaceAll(s, "''", "`")
 }
 
-func Is404(err error) bool {
-	return strings.Contains(err.Error(), "Status: 404")
-}
-
 // IsIPv4 checks if the string is an IP version 4.
 // Original function from https://pkg.go.dev/github.com/asaskevich/govalidator#IsIPv4
 // Shamelessly copied here to avoid importing the entire package

--- a/internal/provider/silo/resource.go
+++ b/internal/provider/silo/resource.go
@@ -6,6 +6,7 @@ package silo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -400,7 +401,7 @@ func (r *Resource) Read(
 
 	silo, err := r.client.SiloView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -552,7 +553,7 @@ func (r *Resource) Delete(
 	}
 
 	if err := r.client.SiloDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting silo:",
 				"API error: "+err.Error(),

--- a/internal/provider/silo/resource_test.go
+++ b/internal/provider/silo/resource_test.go
@@ -6,6 +6,7 @@ package silo_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -251,7 +250,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		}
 
 		res, err := client.SiloView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/silo_saml_identity_provider/resource.go
+++ b/internal/provider/silo_saml_identity_provider/resource.go
@@ -402,7 +402,7 @@ func (r *Resource) Read(
 
 	idpConfig, err := r.client.SamlIdentityProviderView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/silo_saml_identity_provider/resource_test.go
+++ b/internal/provider/silo_saml_identity_provider/resource_test.go
@@ -6,6 +6,7 @@ package silosamlidp_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
 
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
@@ -465,7 +465,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		}
 
 		res, err := client.SamlIdentityProviderView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/snapshot/resource.go
+++ b/internal/provider/snapshot/resource.go
@@ -6,6 +6,7 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -255,7 +256,7 @@ func (r *Resource) Read(
 	}
 	snapshot, err := r.client.SnapshotView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -325,7 +326,7 @@ func (r *Resource) Delete(
 		Snapshot: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.SnapshotDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting snapshot:",
 				"API error: "+err.Error(),

--- a/internal/provider/snapshot/resource_test.go
+++ b/internal/provider/snapshot/resource_test.go
@@ -6,6 +6,7 @@ package snapshot_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -16,8 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -131,7 +130,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 
 		res, err := client.SnapshotView(ctx, params)
 
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/ssh_key/resource.go
+++ b/internal/provider/ssh_key/resource.go
@@ -6,6 +6,7 @@ package sshkey
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -226,7 +227,7 @@ func (r *Resource) Read(
 	}
 	sshKey, err := r.client.CurrentUserSshKeyView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -300,7 +301,7 @@ func (r *Resource) Delete(
 		SshKey: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.CurrentUserSshKeyDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting SSH key:",
 				"API error: "+err.Error(),

--- a/internal/provider/ssh_key/resource_test.go
+++ b/internal/provider/ssh_key/resource_test.go
@@ -6,6 +6,7 @@ package sshkey_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -110,7 +109,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.CurrentUserSshKeyView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/subnet_pool/resource.go
+++ b/internal/provider/subnet_pool/resource.go
@@ -6,6 +6,7 @@ package subnetpool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -213,7 +214,7 @@ func (r *Resource) Read(
 		Pool: oxide.NameOrId(state.ID.ValueString()),
 	})
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -335,7 +336,7 @@ func (r *Resource) Delete(
 		oxide.SystemSubnetPoolDeleteParams{
 			Pool: oxide.NameOrId(state.ID.ValueString()),
 		}); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool:",
 				"API error: "+err.Error(),

--- a/internal/provider/subnet_pool/resource_test.go
+++ b/internal/provider/subnet_pool/resource_test.go
@@ -6,6 +6,7 @@ package subnetpool_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccResourceSubnetPool_full(t *testing.T) {
@@ -163,7 +162,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SubnetPoolViewParams{Pool: oxide.NameOrId(rs.Primary.ID)},
 		)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		if err == nil {

--- a/internal/provider/subnet_pool_member/resource.go
+++ b/internal/provider/subnet_pool_member/resource.go
@@ -6,6 +6,7 @@ package subnetpoolmember
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -262,7 +263,7 @@ func (r *Resource) Read(
 		},
 	)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Pool doesn't exist, remove resource from state
 			resp.State.RemoveResource(ctx)
 			return
@@ -366,7 +367,7 @@ func (r *Resource) Delete(
 		// rather than 404. Handle both cases for idempotent deletes.
 		//
 		// TODO: Switch to a 404 in omicron.
-		if !shared.Is404(err) && !strings.Contains(err.Error(), "does not exist") {
+		if !errors.Is(err, oxide.ErrHTTP404) && !strings.Contains(err.Error(), "does not exist") {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool member:",
 				"API error: "+err.Error(),

--- a/internal/provider/subnet_pool_member/resource_test.go
+++ b/internal/provider/subnet_pool_member/resource_test.go
@@ -6,6 +6,7 @@ package subnetpoolmember_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 func TestAccResourceSubnetPoolMember_full(t *testing.T) {
@@ -284,7 +283,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			ctx,
 			oxide.SystemSubnetPoolMemberListParams{Pool: oxide.NameOrId(poolID)},
 		)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			// Pool doesn't exist, so member is definitely gone
 			continue
 		}

--- a/internal/provider/subnet_pool_silo_link/resource.go
+++ b/internal/provider/subnet_pool_silo_link/resource.go
@@ -6,6 +6,7 @@ package subnetpoolsilolink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -219,7 +220,7 @@ func (r *Resource) Read(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	})
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -256,7 +257,7 @@ func (r *Resource) Read(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	})
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -367,7 +368,7 @@ func (r *Resource) Delete(
 		Silo: oxide.NameOrId(state.SiloID.ValueString()),
 	}
 	if err := r.client.SystemSubnetPoolSiloUnlink(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting subnet pool silo link:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc/resource.go
+++ b/internal/provider/vpc/resource.go
@@ -6,6 +6,7 @@ package vpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -240,7 +241,7 @@ func (r *Resource) Read(
 	}
 	vpc, err := r.client.VpcView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -364,7 +365,7 @@ func (r *Resource) Delete(
 		Subnet: oxide.NameOrId("default"),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, paramsSubnet); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting default subnet:",
 				"API error: "+err.Error(),
@@ -382,7 +383,7 @@ func (r *Resource) Delete(
 		Vpc: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting VPC:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc/resource_test.go
+++ b/internal/provider/vpc/resource_test.go
@@ -6,6 +6,7 @@ package vpc_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -204,7 +203,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/vpc_firewall_rules/resource.go
+++ b/internal/provider/vpc_firewall_rules/resource.go
@@ -6,6 +6,7 @@ package vpcfirewallrules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -520,7 +521,7 @@ func (r *Resource) Read(
 	}
 	firewallRules, err := r.client.VpcFirewallRulesView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/vpc_firewall_rules/resource_test.go
+++ b/internal/provider/vpc_firewall_rules/resource_test.go
@@ -7,6 +7,7 @@ package vpcfirewallrules_test
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,6 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/stretchr/testify/require"
 
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/sharedtest"
 )
 
@@ -812,7 +812,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcFirewallRulesView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 

--- a/internal/provider/vpc_internet_gateway/resource.go
+++ b/internal/provider/vpc_internet_gateway/resource.go
@@ -6,6 +6,7 @@ package vpcinternetgateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -229,7 +230,7 @@ func (r *Resource) Read(
 	}
 	vpcInternetGateway, err := r.client.InternetGatewayView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -301,7 +302,7 @@ func (r *Resource) Update(
 	}
 	vpcInternetGateway, err := r.client.InternetGatewayView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -356,7 +357,7 @@ func (r *Resource) Delete(
 		Cascade: state.CascadeDelete.ValueBoolPointer(),
 	}
 	if err := r.client.InternetGatewayDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC internet gateway:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc_internet_gateway/resource_test.go
+++ b/internal/provider/vpc_internet_gateway/resource_test.go
@@ -6,6 +6,7 @@ package vpcinternetgateway_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -177,7 +176,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			Gateway: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.InternetGatewayView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		return fmt.Errorf("internet gateway (%v) still exists", &res.Name)

--- a/internal/provider/vpc_router/resource.go
+++ b/internal/provider/vpc_router/resource.go
@@ -6,6 +6,7 @@ package vpcrouter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -222,7 +223,7 @@ func (r *Resource) Read(
 	}
 	vpcRouter, err := r.client.VpcRouterView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -344,7 +345,7 @@ func (r *Resource) Delete(
 		Router: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcRouterDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC router:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc_router/resource_test.go
+++ b/internal/provider/vpc_router/resource_test.go
@@ -6,6 +6,7 @@ package vpcrouter_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -170,7 +169,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			Router: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.VpcRouterView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		return fmt.Errorf("router (%v) still exists", &res.Name)

--- a/internal/provider/vpc_router_route/resource.go
+++ b/internal/provider/vpc_router_route/resource.go
@@ -6,6 +6,7 @@ package vpcrouterroute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -321,7 +322,7 @@ func (r *Resource) Read(
 	}
 	vpcRouterRoute, err := r.client.VpcRouterRouteView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -486,7 +487,7 @@ func (r *Resource) Delete(
 		Route: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcRouterRouteDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Unable to delete VPC router route:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc_router_route/resource_test.go
+++ b/internal/provider/vpc_router_route/resource_test.go
@@ -6,6 +6,7 @@ package vpcrouterroute_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -323,7 +322,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 			Router: oxide.NameOrId(rs.Primary.Attributes["id"]),
 		}
 		res, err := client.VpcRouterView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 		return fmt.Errorf("router (%v) still exists", &res.Name)

--- a/internal/provider/vpc_subnet/resource.go
+++ b/internal/provider/vpc_subnet/resource.go
@@ -6,6 +6,7 @@ package vpcsubnet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
@@ -246,7 +247,7 @@ func (r *Resource) Read(
 	}
 	subnet, err := r.client.VpcSubnetView(ctx, params)
 	if err != nil {
-		if shared.Is404(err) {
+		if errors.Is(err, oxide.ErrHTTP404) {
 			// Remove resource from state during a refresh
 			resp.State.RemoveResource(ctx)
 			return
@@ -369,7 +370,7 @@ func (r *Resource) Delete(
 		Subnet: oxide.NameOrId(state.ID.ValueString()),
 	}
 	if err := r.client.VpcSubnetDelete(ctx, params); err != nil {
-		if !shared.Is404(err) {
+		if !errors.Is(err, oxide.ErrHTTP404) {
 			resp.Diagnostics.AddError(
 				"Error deleting VPC subnet:",
 				"API error: "+err.Error(),

--- a/internal/provider/vpc_subnet/resource_test.go
+++ b/internal/provider/vpc_subnet/resource_test.go
@@ -6,6 +6,7 @@ package vpcsubnet_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/oxidecomputer/oxide.go/oxide"
-
-	"github.com/oxidecomputer/terraform-provider-oxide/internal/provider/shared"
 )
 
 type resourceConfig struct {
@@ -178,7 +177,7 @@ func testAccResourceDestroy(s *terraform.State) error {
 		defer cancel()
 
 		res, err := client.VpcSubnetView(ctx, params)
-		if err != nil && shared.Is404(err) {
+		if err != nil && errors.Is(err, oxide.ErrHTTP404) {
 			continue
 		}
 


### PR DESCRIPTION
Removed `shared.Is404` and replaced it with `errors.Is(err, oxide.ErrHTTP404)`.