### PR TITLE
fix: handle 404 on fip datasource and fix example test.

### DIFF
--- a/.changelog/0.22.0.toml
+++ b/.changelog/0.22.0.toml
@@ -41,3 +41,7 @@ description = "Added the read-only attributes `ip_version` and `pool_type`."
 [[bugs]]
 title = "`oxide_instance`"
 description = "Previously, the provider would fail to detect a diff on the `external_ips` attribute of the `oxide_instance` resource when external IPs were detached from the instance out of band. These diffs are now detected correctly. [#842](https://github.com/oxidecomputer/terraform-provider-oxide/pull/842)"
+
+[[bugs]]
+title = "`oxide_floating_ip`"
+description = "Previously, the `oxide_floating_ip` data source would return a null object and throw an uninformative error if the relevant floating IP didn't exist. These errors are now surfaced correctly, without manifesting as provider bugs. [#850](https://github.com/oxidecomputer/terraform-provider-oxide/pull/850)"

--- a/docs/data-sources/floating_ip.md
+++ b/docs/data-sources/floating_ip.md
@@ -15,7 +15,7 @@ Retrieve information about a specified floating IP.
 ```terraform
 data "oxide_floating_ip" "example" {
   project_name = "my-project"
-  name         = "app-ingress"
+  name         = "my-floating-ip"
 }
 ```
 

--- a/examples/data-sources/oxide_floating_ip/data-source.tf
+++ b/examples/data-sources/oxide_floating_ip/data-source.tf
@@ -1,4 +1,4 @@
 data "oxide_floating_ip" "example" {
   project_name = "my-project"
-  name         = "app-ingress"
+  name         = "my-floating-ip"
 }

--- a/internal/provider/examples_test.go
+++ b/internal/provider/examples_test.go
@@ -24,7 +24,6 @@ const examplesRoot = "../../examples"
 //
 // TODO: Fix failing examples and deprecate this escape hatch.
 var knownFailingExample = map[string]bool{
-	"data-sources/oxide_floating_ip/data-source.tf":           true,
 	"data-sources/oxide_image/data-source.tf":                 true,
 	"data-sources/oxide_instance_external_ips/data-source.tf": true,
 	"data-sources/oxide_silo/data-source.tf":                  true,

--- a/internal/provider/floating_ip/datasource.go
+++ b/internal/provider/floating_ip/datasource.go
@@ -6,7 +6,6 @@ package floatingip
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -165,10 +164,6 @@ func (f *DataSource) Read(
 
 	floatingIP, err := f.client.FloatingIpView(ctx, params)
 	if err != nil {
-		if errors.Is(err, oxide.ErrHTTP404) {
-			resp.State.RemoveResource(ctx)
-			return
-		}
 		resp.Diagnostics.AddError(
 			"Unable to read floating IP:",
 			"API error: "+err.Error(),

--- a/scripts/example-test-setup.sh
+++ b/scripts/example-test-setup.sh
@@ -32,6 +32,19 @@ if ! oxide disk view --project my-project --disk my-disk > /dev/null 2>&1; then
 EOF
 fi
 
+if ! oxide floating-ip view --project my-project --floating-ip my-floating-ip > /dev/null 2>&1; then
+    oxide api "/v1/floating-ips?project=my-project" --method POST --input - > /dev/null <<'EOF'
+{
+  "name": "my-floating-ip",
+  "description": "my-floating-ip",
+  "address_allocator": {
+    "type": "auto",
+    "pool_selector": { "type": "auto", "ip_version": "v4" }
+  }
+}
+EOF
+fi
+
 if ! oxide system networking ip-pool view --pool my-pool > /dev/null 2>&1; then
     oxide system networking ip-pool create --name my-pool --description my-pool > /dev/null
 fi


### PR DESCRIPTION
The `oxide_floating_ip` datasource currently causes a provider error on read when the ip doesn't exist, e.g.:

```
Error: Provider produced null object

Provider "provider[\"registry.terraform.io/hashicorp/oxide\"]" produced a
null value for
data.oxide_floating_ip.acc-datasource-floating-ip-not-found-627b323c-487b-49ba-a5ec-f60fac65b0d7.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

This happens because the datasource attempts to remove itself from state on
404. This is the correct behavior for a resource, but not for a datasource, and is probably a copy and paste error from porting the floating ip resource to a datasource. To fix, we drop the state removal.

We also fix the example test for the floating ip datasource, which had been skipped due to this error, and due to references to example uuids (also fixed here).



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
