### PR TITLE
fix: update ci check on generated docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,12 @@ docs:
 .PHONY: check-docs
 check-docs:
 	@ $(GO_TOOL) tfplugindocs generate
-	@ if ! git diff --exit-code docs; then echo 'Generated docs have changed. Re-generate with `make docs`.'; fi
+	@ if [ -n "$$(git status --porcelain -- docs)" ]; then \
+	    git status --short -- docs; \
+	    git diff -- docs; \
+	    echo 'Generated docs have changed. Re-generate with `make docs`.'; \
+	    exit 1; \
+	  fi
 
 ## Lints all of the source files
 .PHONY: lint


### PR DESCRIPTION
Currently, we log a warning but don't fail ci if regenerating the docs creates a diff in git. This patch fails the build as expected on docs diff, and additionally checks for untracked files in the generated docs.



-----

### Pull request checklist

- [ ] Add changelog entry for this change.
